### PR TITLE
fix: E2E install Hugo in workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,12 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
+      - name: 🔧 Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.164.0'
+          extended: false
+
       - name: 📦 Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund
 


### PR DESCRIPTION
e2e.yml ran hugo server but never installed Hugo -> 'hugo: not found'. Added peaceiris/actions-hugo@v3 (0.164.0, extended:false) matching the deploy workflow.