### PR TITLE
feat: axe-core accessibility E2E gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
+        "@axe-core/playwright": "^4.13.0",
         "acorn": "^8.18.0",
         "acorn-jsx": "^5.3.2",
         "agent-base": "^6.0.2",
@@ -413,6 +414,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.13.0.tgz",
+      "integrity": "sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.13.0"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5778,7 +5791,6 @@
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
       "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
-      "dev": true,
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@nomicfoundation/hardhat-network-helpers": "^1.1.0",
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
     "@openzeppelin/contracts": "^5.4.0",
+    "@playwright/test": "^1.55.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "ajv": "^8.20.0",
@@ -75,8 +76,7 @@
     "jsdoc": "^4.0.2",
     "lighthouse": "^12.8.2",
     "tailwindcss": "^3.4.19",
-    "terser": "^5.19.0",
-    "@playwright/test": "^1.55.0"
+    "terser": "^5.19.0"
   },
   "engines": {
     "node": ">=22.0.0"
@@ -129,6 +129,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "@axe-core/playwright": "^4.13.0",
     "acorn": "^8.18.0",
     "acorn-jsx": "^5.3.2",
     "agent-base": "^6.0.2",

--- a/tests/e2e/accessibility.spec.cjs
+++ b/tests/e2e/accessibility.spec.cjs
@@ -1,0 +1,55 @@
+// Phase 0/1 accessibility gate — axe-core via Playwright.
+// Catches critical a11y violations on the real rendered DOM (jsdom can't).
+// Plan refs: STRATEGIC_PLAN_2026-2027.md Goal 1 (axe-core, 0 critical),
+// STRATEGIC_PLAN_2026-2028_UPDATED.md P2 (accessibility checks).
+const { test, expect } = require('@playwright/test');
+const AxeBuilder = require('@axe-core/playwright').default;
+
+// SVG/link-only decorative elements and the Blowfish theme toggle are out of
+// scope for a content blog; we fail only on critical/serious rule violations.
+const IGNORE = [
+  'color-contrast', // visual-only, reviewed separately via Lighthouse
+  'html-has-lang', // Hugo sets lang on <html>; axe sometimes misses inherited
+];
+
+test.describe('Accessibility (axe-core)', () => {
+  const pages = [
+    { name: 'home', url: '/' },
+    { name: 'blog', url: '/blog/' },
+    { name: 'about', url: '/about/' },
+  ];
+
+  for (const p of pages) {
+    test(`no critical/serious violations on ${p.name}`, async ({ page }) => {
+      await page.goto(p.url);
+      const results = await new AxeBuilder({ page })
+        .disableRules(IGNORE)
+        .analyze();
+      const serious = results.violations.filter(
+        (v) => v.impact === 'critical' || v.impact === 'serious'
+      );
+      if (serious.length > 0) {
+        // Surface the violations for the CI log before failing.
+        console.log(`\n[a11y ${p.name}] serious/critical violations:`);
+        for (const v of serious) {
+          console.log(`  - ${v.id}: ${v.help} (${v.nodes.length} node(s))`);
+        }
+      }
+      expect(serious, `${serious.length} serious/critical a11y violation(s)`).toHaveLength(0);
+    });
+  }
+
+  test('post page is accessible (giscus iframe context)', async ({ page }) => {
+    await page.goto('/blog/');
+    const first = page.locator('a[href*="/20"]').first();
+    const href = await first.getAttribute('href');
+    await page.goto(href);
+    const results = await new AxeBuilder({ page })
+      .disableRules(IGNORE)
+      .analyze();
+    const serious = results.violations.filter(
+      (v) => v.impact === 'critical' || v.impact === 'serious'
+    );
+    expect(serious, `${serious.length} serious/critical a11y violation(s)`).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Adds automated a11y checks (axe-core via Playwright) on home/blog/about/post. Fails on critical/serious violations. Extends the E2E suite; runs in e2e.yml (separate from Pages deploy).