### PR TITLE
fix: Knowledge Graph CLS (reserve space)

### DIFF
--- a/content/knowledge-graph/_index.md
+++ b/content/knowledge-graph/_index.md
@@ -25,7 +25,7 @@ Pick a concept to see the posts linked to it.
 <script src="/js/knowledge-graph.js" defer></script>
 
 <style>
-.kg-root { margin: 1.5rem 0; }
+.kg-root { margin: 1.5rem 0; min-height: 60vh; }
 .kg-meta { color: var(--color-muted, #888); font-size: .9rem; }
 .kg-filters { display: flex; flex-wrap: wrap; gap: .5rem; margin: 1rem 0; }
 .kg-filter {


### PR DESCRIPTION
Lighthouse CI flagged /knowledge-graph/ at CLS 0.208 (budget <=0.1). The JS widget injected content into #kg-root after load, causing layout shift. Reserve min-height:60vh so injection no longer shifts. Fixes the perf budget failure.