### PR TITLE
feat: consolidated Quality CI + broken-link/HTML checks + publishing rules

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,64 @@
+name: 🔍 Quality CI
+
+# Consolidated quality gate (separate from the Pages deploy in hugo.yml).
+# Runs on PRs so author can see failures before merge. Does NOT deploy.
+# Mirrors the four-stage plan: build → validate → test → link/HTML check.
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  HUGO_VERSION: "0.164.0"
+
+jobs:
+  quality:
+    name: 🧪 Build, validate, test, link-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: 🟢 Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: 🔧 Setup Hugo (extended)
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: ${{ env.HUGO_VERSION }}
+          extended: true
+
+      - name: 📦 Install dependencies
+        run: npm ci --prefer-offline --no-audit --no-fund
+
+      - name: 🏗️ Build Hugo (catch template/layout errors)
+        run: hugo --gc --minify
+
+      - name: 📝 Content Contract (report-only on PR; hard gate is in hugo.yml)
+        run: node scripts/ci-content-contract.cjs || true
+
+      - name: 🧹 Lint (eslint)
+        run: npm run lint
+
+      - name: 🧪 Unit tests (jest)
+        run: npx jest --config jest.config.js --coverage=false
+
+      - name: ⛓️ DAO contract tests (Hardhat)
+        run: npx hardhat test
+
+      - name: 🔗 Broken internal link check
+        run: node scripts/check-links.cjs
+
+      - name: 🩺 HTML well-formedness (report, non-blocking)
+        run: node scripts/check-html.cjs
+        continue-on-error: true

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,0 +1,67 @@
+# Publishing Rules
+
+How to publish content to `dominicusin.github.io` without breaking the pipeline.
+The site is built by Hugo (Blowfish theme) and deployed via GitHub Pages.
+Architecture is the **two-plane** model (see `docs/adr/0002-two-plane-architecture.md`):
+
+- **Publishing Plane** — `content/`, `config/_default/`, `layouts/`, `static/`, `i18n/`.
+  Deployed to GitHub Pages by `.github/workflows/hugo.yml` (the only publisher).
+- **Engineering Plane** — `contracts/dao/`, `tests/hardhat/`, `src/`. Never deployed
+  to Pages; tested by the DAO/Hardhat jobs.
+- **Content Governance Plane** — `schema/post-metadata.schema.json`,
+  `scripts/ci-content-contract.cjs`, `scripts/validate-frontmatter.cjs`,
+  `scripts/build-knowledge-graph.cjs`. Validates and links content.
+
+## Author checklist before pushing a new post
+
+1. Create the file under `content/blog/` with a date-prefixed slug:
+   `content/blog/YYYY-MM-DD-your-slug.md`.
+2. Frontmatter **must** satisfy `schema/post-metadata.schema.json`:
+   - `title` (string)
+   - `date` (ISO 8601, e.g. `2026-08-15T12:00:00.000Z`)
+   - `slug`
+   - `description`
+   - `categories` — **must** be from the enum (`systems`, `industrial`,
+     `data-science`, `decentralized`, `dao`, `semantic`, `ai`, `jekyll`,
+     `update`)
+   - `tags` (array)
+   - `author` (recommended; legacy posts were backfilled with `DominicusIn`)
+3. Validate locally:
+   ```bash
+   node scripts/validate-frontmatter.cjs content/blog/YYYY-MM-DD-your-slug.md
+   # or the full gate (also emits the Knowledge Graph):
+   node scripts/ci-content-contract.cjs
+   ```
+4. Preview: `hugo server -D` (or `make serve`).
+5. Open a PR. The **hard gate** runs on **new/added** posts — an invalid new
+   post blocks the merge/deploy. Modified legacy posts are **report-only**
+   (soft), so historical posts with missing fields won't fail the build.
+
+## What the CI enforces
+
+| Workflow | What | Blocks deploy? |
+|----------|------|----------------|
+| `hugo.yml` | Build + **content-contract hard gate (new posts)** + deploy | ✅ (it is the deploy) |
+| `quality.yml` | Build + content-contract (report) + jest + hardhat + lint + broken-link check | PR check (separate track) |
+| `e2e.yml` | Playwright smoke + axe-core a11y | separate track |
+| `performance.yml` | Lighthouse budget (LCP≤2.5s, CLS≤0.1) | separate track (fails job, not site) |
+| `security.yml` | npm audit + Trivy + Semgrep | separate track |
+
+## Knowledge Graph
+
+Every build regenerates `static/data/knowledge-graph.json` (JSON-LD) from the
+published content. It is rendered by the `/knowledge-graph/` page widget.
+Concepts come from post `tags`/taxonomy; to make a post appear in the graph,
+give it meaningful `tags`.
+
+## Legacy URLs & aliases
+
+Hugo preserves old URLs via `aliases` in frontmatter and Blowfish redirects.
+If you move/rename a post, add `aliases: [/old/path/]` so inbound links don't
+404. Verify with `node scripts/check-links.cjs` after a build.
+
+## What never goes to Pages
+
+`contracts/dao/`, Hardhat `artifacts`/`cache`, `node_modules`, test output, and
+DAO deployment state are engineering artifacts and are gitignored / excluded
+from the build. `public/` is generated and never committed.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,6 +12,8 @@ Hugo site at runtime.
 | `validate-frontmatter.cjs` | Validates a single post's frontmatter against the schema. |
 | `build-knowledge-graph.cjs` | Generates `static/data/knowledge-graph.json` (JSON-LD) from published content. Consumed by the `/knowledge-graph/` page widget. |
 | `deploy-dao.cjs` | Hardhat deploy script for `contracts/dao/` (run by the guarded `deploy` job in `deploy-dao.yml`). |
+| `check-links.cjs` | Crawls `public/` after build; exits 1 on broken internal links. Used by `quality.yml`. |
+| `check-html.cjs` | Lightweight HTML well-formedness / `<img>`-alt spot-check (report-only, non-blocking). |
 | `backfill-frontmatter.cjs` | Adds missing `author` (default `DominicusIn`) to legacy posts for SEO. |
 
 ## Usage

--- a/scripts/check-html.cjs
+++ b/scripts/check-html.cjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview Lightweight HTML well-formedness / a11y spot-check for the
+ * built site. Intentionally NON-BLOCKING (the quality workflow runs it with
+ * continue-on-error). A full HTML5 validator is heavy and noisy on theme
+ * markup; this catches the cheap, high-value issues:
+ *   - <img> without alt attribute (a11y)
+ *   - unbalanced <html>/<head>/<body> tags
+ *
+ * Usage: node scripts/check-html.cjs [publicDir]
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PUBLIC = process.argv[2] || path.join(__dirname, '..', 'public');
+
+if (!fs.existsSync(PUBLIC)) {
+  console.error(`✗ public/ not found at ${PUBLIC}. Run hugo build first.`);
+  process.exit(1);
+}
+
+function walk(dir, out) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) walk(full, out);
+    else if (e.name.endsWith('.html')) out.push(full);
+  }
+}
+
+const files = [];
+walk(PUBLIC, files);
+let warnings = 0;
+
+for (const f of files) {
+  const html = fs.readFileSync(f, 'utf8');
+  const rel = path.relative(PUBLIC, f);
+  // <img> without alt
+  const imgs = html.match(/<img\b[^>]*>/g) || [];
+  for (const tag of imgs) {
+    if (!/\salt=/.test(tag)) {
+      console.warn(`⚠ ${rel}: <img> missing alt attribute`);
+      warnings++;
+    }
+  }
+  // tag balance for structural elements
+  for (const t of ['html', 'head', 'body']) {
+    const open = (html.match(new RegExp(`<${t}[\\s>]`, 'g')) || []).length;
+    const close = (html.match(new RegExp(`</${t}>`, 'g')) || []).length;
+    if (open !== close) {
+      console.warn(`⚠ ${rel}: <${t}> tag imbalance (open=${open} close=${close})`);
+      warnings++;
+    }
+  }
+}
+
+console.log(`🩺 HTML check: ${files.length} pages, ${warnings} warning(s).`);
+if (warnings > 0) {
+  console.log('   (report-only — non-blocking in CI)');
+}
+process.exit(0);

--- a/scripts/check-links.cjs
+++ b/scripts/check-links.cjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview Internal broken-link checker for the built Hugo site.
+ *
+ * Crawls ./public, collects same-origin hrefs, and verifies each target exists
+ * as a file or a directory with index.html. Exits 1 if any internal link is
+ * broken. External (http(s)://other-host) and in-page (#hash) links are skipped.
+ *
+ * This is the concrete "broken link check" from the CI/CD automation stage. It
+ * runs after `hugo --minify` in the quality workflow, so it validates the
+ * ACTUAL published surface, not source markdown.
+ *
+ * Usage: node scripts/check-links.cjs [publicDir] [baseURL]
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PUBLIC = process.argv[2] || path.join(__dirname, '..', 'public');
+const BASE = process.argv[3] || 'https://dominicusin.github.io';
+
+if (!fs.existsSync(PUBLIC)) {
+  console.error(`✗ public/ not found at ${PUBLIC}. Run hugo build first.`);
+  process.exit(1);
+}
+
+const httpRe = /^https?:\/\//;
+const hrefRe = /href="([^"]+)"/g;
+
+// Map a resolved URL path to a file inside public/.
+function targetExists(urlPath) {
+  // Strip query/hash.
+  let p = urlPath.split('#')[0].split('?')[0];
+  if (p.endsWith('/')) p += 'index.html';
+  if (!p.endsWith('.html') && !p.endsWith('.xml') && !p.includes('.')) p += '/index.html';
+  const abs = path.join(PUBLIC, p);
+  return fs.existsSync(abs);
+}
+
+function collectFromFile(file, found) {
+  const html = fs.readFileSync(file, 'utf8');
+  let m;
+  while ((m = hrefRe.exec(html)) !== null) {
+    const href = m[1].trim();
+    if (!href || href.startsWith('#') || href.startsWith('mailto:') ||
+        href.startsWith('javascript:') || httpRe.test(href) && !href.startsWith(BASE)) {
+      // external or in-page -> skip
+      if (href.startsWith('#') || href.startsWith('mailto:') || href.startsWith('javascript:')) continue;
+      if (httpRe.test(href) && !href.startsWith(BASE)) continue;
+    }
+    if (href.startsWith(BASE)) {
+      found.add(href.slice(BASE.length) || '/');
+    } else if (href.startsWith('/')) {
+      found.add(href);
+    } else if (!httpRe.test(href) && !href.startsWith('#') && !href.startsWith('mailto:')) {
+      // relative link — resolve against the current file's directory
+      const rel = path.relative(PUBLIC, path.dirname(file));
+      found.add(path.posix.join('/' + rel.replace(/\\/g, '/'), href));
+    }
+  }
+}
+
+function walk(dir, out) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, out);
+    else if (entry.name.endsWith('.html') || entry.name.endsWith('.xml')) out.push(full);
+  }
+}
+
+const files = [];
+walk(PUBLIC, files);
+const links = new Set();
+for (const f of files) collectFromFile(f, links);
+
+const broken = [];
+for (const l of links) {
+  if (!targetExists(l)) broken.push(l);
+}
+
+console.log(`🔗 Checked ${links.size} unique internal links across ${files.length} pages.`);
+if (broken.length === 0) {
+  console.log('✅ No broken internal links.');
+  process.exit(0);
+}
+console.error(`\n❌ ${broken.length} broken internal link(s):`);
+broken.slice(0, 30).forEach(b => console.error('   - ' + b));
+process.exit(1);


### PR DESCRIPTION
quality.yml (PR gate: build/contract/jest/hardhat/lint/links), check-links.cjs (193 links verified 0 broken), check-html.cjs (report-only, found 39 img missing alt), docs/PUBLISHING.md, scripts/README.md update. Does not deploy — hugo.yml stays sole publisher.