### PR TITLE
security: tighten vr-export.yml permissions to least-privilege

### DIFF
--- a/.github/workflows/vr-export.yml
+++ b/.github/workflows/vr-export.yml
@@ -20,11 +20,10 @@ jobs:
   generate-vr-scene:
     runs-on: ubuntu-latest
     permissions:
+      # VR export builds a GLB/GLTF artifact and (on tags) a GitHub release.
+      # It does NOT deploy to Pages — hugo.yml is the sole Pages publisher.
+      # Least-privilege: only contents:write is needed (release + commit comment).
       contents: write
-      pages: write
-      id-token: write
-      statuses: write
-      actions: read
     
     steps:
       - name: Checkout repository


### PR DESCRIPTION
vr-export.yml had pages:write/id-token:write/statuses:write/actions:read but never deploys to Pages (deploy step commented out). It only builds artifacts + creates releases (needs contents:write). Tighten to contents:write only, reinforcing the single-publisher (hugo.yml) architecture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the VR export workflow permissions to follow least-privilege access.
  * Removed permissions unrelated to building and releasing VR artifacts.
  * Clarified that the workflow does not deploy to GitHub Pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->