### PR TITLE
fix: a11y alt-text (correct checker false-positive + fix ai2.md logos)

### DIFF
--- a/content/blog/2018-11-09-awesome-machine-learning-for-cyber-security.md
+++ b/content/blog/2018-11-09-awesome-machine-learning-for-cyber-security.md
@@ -9,7 +9,7 @@ author: DominicusIn
 
 # Awesome Machine Learning for Cyber Security [![Awesom](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
-[<img src="https://github.com/jivoi/awesome-ml-for-cybersecurity/raw/master/cyber-ml-logo.png" align="right" width="100">](https://github.com/jivoi/awesome-ml-for-cybersecurity)
+[<img src="https://github.com/jivoi/awesome-ml-for-cybersecurity/raw/master/cyber-ml-logo.png" alt="" align="right" width="100">](https://github.com/jivoi/awesome-ml-for-cybersecurity)
 
 A curated list of amazingly awesome tools and resources related to the use of machine learning for cyber security.
 

--- a/content/blog/2025-08-29-ai2.md
+++ b/content/blog/2025-08-29-ai2.md
@@ -9,39 +9,39 @@ author: DominicusIn
 
 ## 🦜 LLMs
 
-* |<img src="/assets/openai.png" width="30">|[OpenAI](https://chatgpt.com) | GPT-5 is an iPhone in LLM space |
+* |<img alt="" src="/assets/openai.png" width="30">|[OpenAI](https://chatgpt.com) | GPT-5 is an iPhone in LLM space |
 
-* |<img src="/assets/antropic.png" width="30">| [Anthropic](https://claude.ai) | Claude Sonnet 4 and Claude Opus 4.1 |
+* |<img alt="" src="/assets/antropic.png" width="30">| [Anthropic](https://claude.ai) | Claude Sonnet 4 and Claude Opus 4.1 |
 
-* |<img src="/assets/gemine.png" width="30">|[Google](https://gemini.google.com) | Gemini 2.5 PRO |
+* |<img alt="" src="/assets/gemine.png" width="30">|[Google](https://gemini.google.com) | Gemini 2.5 PRO |
 
-* |<img src="/assets/grok4.png" width="30">|[xAI](https://grok.com) | Grok 4 |
+* |<img alt="" src="/assets/grok4.png" width="30">|[xAI](https://grok.com) | Grok 4 |
 
-* |<img src="/assets/deepseek.png" width="30">|[DeepSeek](https://chat.deepseek.com/) | DeepSeek & DeepSeek R1 |
+* |<img alt="" src="/assets/deepseek.png" width="30">|[DeepSeek](https://chat.deepseek.com/) | DeepSeek & DeepSeek R1 |
 
-* |<img src="/assets/mistral.png" width="30">| [Mistral](https://chat.mistral.ai/chat) | Mistral AI. French company|
+* |<img alt="" src="/assets/mistral.png" width="30">| [Mistral](https://chat.mistral.ai/chat) | Mistral AI. French company|
 
-* |<img src="/assets/qwen3.jpeg" width="30">|[Qwen3](https://chat.qwen.ai/) | Qwen3 |
+* |<img alt="" src="/assets/qwen3.jpeg" width="30">|[Qwen3](https://chat.qwen.ai/) | Qwen3 |
 
 ## 🧭 LLMs Aggregators
 
-* |<img src="/assets/perplexity.png" width="30">|[Perplexity](https://www.perplexity.ai/) | main Perplexity AI platform, a smart chat-based search engine that combines AI (like Claude, GPT-5, Gemini) and real-time internet data|
+* |<img alt="" src="/assets/perplexity.png" width="30">|[Perplexity](https://www.perplexity.ai/) | main Perplexity AI platform, a smart chat-based search engine that combines AI (like Claude, GPT-5, Gemini) and real-time internet data|
 
-* |<img src="/assets/perplexity.png" width="30">|[Perplexity Playground](https://playground.perplexity.ai/) | r1-1776, sonar-resoning-pro & other models |
+* |<img alt="" src="/assets/perplexity.png" width="30">|[Perplexity Playground](https://playground.perplexity.ai/) | r1-1776, sonar-resoning-pro & other models |
 
-* |<img src="/assets/llmarena.png" width="30">|[LmArena](https://lmarena.ai/) | Pretty nice collections of LLM models |
+* |<img alt="" src="/assets/llmarena.png" width="30">|[LmArena](https://lmarena.ai/) | Pretty nice collections of LLM models |
 
 ## 🌀 AI-IDEs
 
-* | <img src="/assets/cursor.png" width="30">|[Cursor](https://www.cursor.com) | AI-first code editor built for pair-programming with models |
+* | <img alt="" src="/assets/cursor.png" width="30">|[Cursor](https://www.cursor.com) | AI-first code editor built for pair-programming with models |
 
-* | <img src="/assets/windsurf.png" width="30">|[Windsurf](https://windsurf.ai) | AI-powered IDE with advanced code completion and workflow utomation |
+* | <img alt="" src="/assets/windsurf.png" width="30">|[Windsurf](https://windsurf.ai) | AI-powered IDE with advanced code completion and workflow utomation |
 
-* | <img src="/assets/zed.jpg" width="30">|[Zed](https://zed.dev) | High-performance, collaborative code editor with AI features |
+* | <img alt="" src="/assets/zed.jpg" width="30">|[Zed](https://zed.dev) | High-performance, collaborative code editor with AI features |
 
-* | <img src="/assets/fleet.png" width="30">| [JetBrains Fleet](https://www.jetbrains.com/fleet/) | Next-gen IDE with AI Assistant (JetBrains) |
+* | <img alt="" src="/assets/fleet.png" width="30">| [JetBrains Fleet](https://www.jetbrains.com/fleet/) | Next-gen IDE with AI Assistant (JetBrains) |
 
-* | <img src="/assets/kiro.png" width="30">| [Kiro](https://kiro.dev) | The AI IDE for prototype to production Kiro helps you do your best work by bringing structure to AI coding with spec-driven development.|
+* | <img alt="" src="/assets/kiro.png" width="30">| [Kiro](https://kiro.dev) | The AI IDE for prototype to production Kiro helps you do your best work by bringing structure to AI coding with spec-driven development.|
 
 ## ⛏️ Prompt Technics
 

--- a/scripts/check-html.cjs
+++ b/scripts/check-html.cjs
@@ -38,7 +38,10 @@ for (const f of files) {
   // <img> without alt
   const imgs = html.match(/<img\b[^>]*>/g) || [];
   for (const tag of imgs) {
-    if (!/\salt=/.test(tag)) {
+    // Valid if an `alt` attribute token is present — including empty alt
+    // (Hugo renders markdown ![]() as <img alt src=...>, which is intentional
+    // for decorative images). Only flag imgs that have NO alt attribute at all.
+    if (!/\balt\b/.test(tag)) {
       console.warn(`⚠ ${rel}: <img> missing alt attribute`);
       warnings++;
     }


### PR DESCRIPTION
check-html.cjs now only flags imgs with NO alt attribute (was false-flagging valid empty-alt from markdown ![]()). Fixed 15 genuinely-missing-alt logo imgs in ai2.md + cyber-security post. Verified: 0 HTML warnings, 0 broken links, 160 HTML build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved image accessibility across blog content by adding appropriate empty alternative-text attributes where images are decorative.
  * Updated HTML validation to accept explicitly empty `alt` attributes while warning only when the attribute is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->