### PR TITLE
fix: restore .gitmodules (un-break fresh clones / Vercel & CI)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "themes/blowfish"]
+	path = themes/blowfish
+	url = https://github.com/nunocoracao/blowfish.git


### PR DESCRIPTION
Commit a1018136b deleted .gitmodules but left the themes/blowfish gitlink, so fresh clones (Vercel/CI) cannot fetch the theme -> build fails. Restore the 3-line submodule decl. Verified: git submodule update --init now resolves v2.105.0 (1d761fc5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Blowfish theme to the project, enabling its use for the site’s appearance and layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->