### PR TITLE
feat: enable full Blowfish feature set

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -1,6 +1,8 @@
 # Hugo + Blowfish configuration — dominicusin.github.io
 # Publishing Plane (see docs/SSG_MIGRATION_PLAN.md, variant A).
 # Jekyll/src/DAO are preserved untouched; this is an additive parallel scaffold.
+#
+# All Blowfish [params.*] live in config/_default/params.toml (single source).
 
 baseURL = "https://dominicusin.github.io/"
 title = "Dominicus In"
@@ -15,9 +17,6 @@ summaryLength = 25
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true
-
-# Use the Blowfish theme (git submodule at themes/blowfish) — declared in
-# config/_default/config.toml so Hugo picks it up reliably.
 
 # Disable Hugo's default taxonomy pluralization surprises; keep standard.
 pluralizeListTitles = false
@@ -36,58 +35,6 @@ canonifyURLs = false
   section = ["HTML", "RSS"]
   taxonomy = ["HTML", "RSS"]
   term = ["HTML", "RSS"]
-
-[params]
-  colorScheme = "dark"
-  defaultTheme = "auto"
-  # Built-in client-side search (Blowfish loads index.json + Fuse.js)
-  enableSearch = true
-  description = "Engineering blog & decentralized web notes by Dominicus In."
-  showDarkModeToggle = true
-  showLanguageSelector = true
-  # Replace with a real external form provider endpoint (Buttondown) at cutover.
-  # See layouts/partials/custom/subscription.html
-  externalSubscriptionURL = "https://buttondown.email/api/emails/embed-subscribe/dominicusin" 
-  giscus = { repo = "dominicusin/dominicusin.github.io", repoId = "MDEwOlJlcG9zaXRvcnk0NjQ1OTg0OQ==", category = "Announcements", categoryId = "DIC_kwDOAsTryc4CRUZ_", mapping = "pathname", reactionsEnabled = true, commentCount = true, inputPosition = "bottom", lang = "ru", loading = "lazy" }
-  # Default social share image (OpenGraph + Twitter) — posts have no per-page
-  # images, so this guarantees a preview card on share. Uses the existing
-  # assets/images/og-default.svg (Blowfish resolves defaultSocialImage via
-  # resources.Get, which needs a RELATIVE path with no leading slash).
-  defaultSocialImage = "images/og-default.svg"
-
-[params.footer]
-  showCopyright = true
-  showThemeSwitcher = true
-  showAppearanceSwitcher = true
-
-[params.article]
-  showDate = true
-  showDateUpdated = false
-  showWordCount = true
-  showReadingTime = true
-  showPagination = true
-  showRelatedContent = true
-  showTaxonomies = true
-  showComments = true
-  relatedContentLimit = 3
-
-[params.list]
-  showBreadcrumbs = true
-  showDate = true
-  showReadingTime = true
-
-[params.sitemap]
-  changeFreq = "monthly"
-  priority = 0.5
-
-[params.opengraph]
-  showImages = true
-  imagesMaxCount = 3
-
-[params.twitter]
-  # Enable Twitter/X summary cards (Blowfish renders them when set).
-  card = "summary_large_image"
-  site = "@dominicusin"
 
 [taxonomies]
   tag = "tags"

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -1,0 +1,103 @@
+# Blowfish theme parameters — full feature enablement (variant A publishing plane).
+# Consolidated here from the previous [params] block in hugo.toml so all
+# theme capabilities are configured in one place. See https://blowfish.page/docs/configuration/
+
+# --- Core appearance ---
+colorScheme = "dark"
+defaultAppearance = "auto"
+description = "Engineering blog & decentralized web notes by Dominicus In."
+showDarkModeToggle = true
+showLanguageSelector = true
+mainSections = ["blog"]
+
+# --- Feature flags ---
+enableSearch = true          # client-side Fuse.js search (index.json)
+enableA11y = true            # improved accessibility (skip-links, a11y nav)
+enableCodeCopy = true        # copy-to-clipboard on code blocks
+enableStructuredBreadcrumbs = true  # structured-data breadcrumbs (SEO)
+highlightCurrentMenuArea = true     # highlight active menu item
+smartTOC = true              # scroll-spy table of contents
+
+# --- Images ---
+defaultSocialImage = "images/og-default.svg"   # OG/Twitter fallback
+defaultFeaturedImage = "images/og-default.svg" # card/hero fallback when a post has no image
+
+# --- Subscription (Buttondown) ---
+externalSubscriptionURL = "https://buttondown.email/api/emails/embed-subscribe/dominicusin"
+
+# --- Comments (giscus) ---
+[giscus]
+  repo = "dominicusin/dominicusin.github.io"
+  repoId = "MDEwOlJlcG9zaXRvcnk0NjQ1OTg0OQ=="
+  category = "Announcements"
+  categoryId = "DIC_kwDOAsTryc4CRUZ_"
+  mapping = "pathname"
+  reactionsEnabled = true
+  commentCount = true
+  inputPosition = "bottom"
+  lang = "ru"
+  loading = "lazy"
+
+# --- Header ---
+[header]
+  layout = "fixed"   # sticky header
+
+# --- Footer ---
+[footer]
+  showMenu = true
+  showCopyright = true
+  showThemeAttribution = true
+  showAppearanceSwitcher = true
+  showScrollToTop = true
+
+# --- Homepage ---
+[homepage]
+  layout = "profile"          # personal-site landing: author card + recent posts
+  showRecent = true
+  showRecentItems = 8
+  showMoreLink = true
+  showMoreLinkDest = "blog"
+
+# --- Articles / posts ---
+[article]
+  showDate = true
+  showDateUpdated = false
+  showWordCount = true
+  showReadingTime = true
+  showAuthor = true
+  showHeadingAnchors = true   # anchor links on headings
+  showZenMode = true          # focus/reading mode toggle
+  showTableOfContents = true  # TOC (works with smartTOC scroll-spy)
+  showPagination = true
+  showRelatedContent = true
+  relatedContentLimit = 3
+  showTaxonomies = true
+  showComments = true
+  showBreadcrumbs = true
+  showEdit = true             # "Edit this page" GitHub link
+  editURL = "https://github.com/dominicusin/dominicusin.github.io/edit/main/content"
+  editAppendPath = true
+  sharingLinks = ["linkedin", "twitter", "bluesky", "reddit", "telegram", "email"]
+
+# --- List / section pages ---
+[list]
+  showBreadcrumbs = true
+  showDate = true
+  showReadingTime = true
+  showCards = true
+  cardView = true
+
+# --- Sitemap ---
+[sitemap]
+  changeFreq = "monthly"
+  priority = 0.5
+
+# --- OpenGraph ---
+[opengraph]
+  showImages = true
+  imagesMaxCount = 3
+
+# --- Twitter / X cards ---
+[twitter]
+  card = "summary_large_image"
+  site = "@dominicusin"

--- a/data/authors/dominicusin.yml
+++ b/data/authors/dominicusin.yml
@@ -1,0 +1,7 @@
+name: Dominicus In
+image: images/avatar.jpg
+social:
+  github: "https://github.com/dominicusin"
+  telegram: "https://t.me/dominicusin"
+  linkedin: "https://www.linkedin.com/in/dominicusin"
+  rss: "/index.xml"


### PR DESCRIPTION
Enable previously-off theme capabilities (a11y, code-copy, smartTOC, heading anchors, zen mode, author card, edit link, social sharing, scroll-to-top, fixed header, profile homepage with recent posts). Consolidate params into params.toml. Add data/authors/dominicusin.yml. Build verified 167 HTML, 0 errors.