### PR TITLE
fix: render About bio as HTML (not in <code>)

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -185,3 +185,112 @@ html { scroll-behavior: smooth; }
 * { scrollbar-width: thin; scrollbar-color: rgb(var(--color-neutral-700)) transparent; }
 *::-webkit-scrollbar { width: 10px; height: 10px; }
 *::-webkit-scrollbar-thumb { background: rgb(var(--color-neutral-700)); border-radius: 999px; }
+
+/* ============================================================
+   About page (content/about.md custom HTML)
+   ============================================================ */
+.about-container { max-width: var(--content-width); margin: 0 auto; }
+
+.about-hero {
+  display: flex; gap: 1.5rem; align-items: center; flex-wrap: wrap;
+  padding: 1.75rem; margin-bottom: 2rem;
+  background: linear-gradient(135deg, rgb(var(--ring) / .12), rgb(34, 211, 238, .08));
+  border: 1px solid rgb(var(--color-neutral-700) / .5);
+  border-radius: var(--radius);
+}
+.about-avatar { position: relative; width: 112px; height: 112px; flex: 0 0 auto; }
+.about-avatar .avatar-image { width: 100%; height: 100%; object-fit: cover; border-radius: 50%;
+  border: 2px solid rgb(var(--ring) / .6); box-shadow: 0 0 0 4px rgb(var(--ring) / .12); }
+.about-avatar .avatar-placeholder { display: none; }
+.about-header-content { flex: 1 1 16rem; min-width: 0; }
+.about-title { margin: 0; font-size: 1.9rem; font-weight: 800; letter-spacing: -.02em; }
+.about-subtitle { margin: .25rem 0 .6rem; color: rgb(var(--color-primary-300)); font-weight: 600; }
+.about-description { margin: 0 0 1rem; color: rgb(var(--color-neutral-300)); }
+.about-social { display: flex; flex-wrap: wrap; gap: .6rem; }
+.social-link { display: inline-flex; align-items: center; gap: .4rem; padding: .4rem .8rem;
+  border-radius: 999px; font-size: .9rem; text-decoration: none; color: rgb(var(--color-neutral-200));
+  background: rgb(var(--bg-elevated) / .7); border: 1px solid rgb(var(--color-neutral-700) / .5);
+  transition: transform .15s ease, background .15s ease, border-color .15s ease; }
+.social-link:hover { transform: translateY(-2px); background: rgb(var(--ring) / .18);
+  border-color: rgb(var(--ring) / .6); color: #fff; }
+
+.about-section { margin: 2.5rem 0; }
+.section-title { font-size: 1.35rem; font-weight: 700; margin: 0 0 1rem;
+  padding-bottom: .5rem; border-bottom: 1px solid rgb(var(--color-neutral-700) / .5); }
+
+/* Timeline */
+.experience-timeline { display: grid; gap: 1rem; }
+.timeline-item { display: grid; grid-template-columns: 9rem 1fr; gap: 1rem; padding: 1rem;
+  background: rgb(var(--bg-elevated) / .5); border: 1px solid rgb(var(--color-neutral-700) / .4);
+  border-radius: var(--radius); }
+.timeline-date { font-weight: 700; color: rgb(var(--color-primary-300)); font-size: .9rem; }
+.timeline-content h3 { margin: 0 0 .3rem; font-size: 1.05rem; }
+.timeline-content p { margin: 0; color: rgb(var(--color-neutral-300)); font-size: .95rem; }
+
+/* Skills */
+.skills-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr)); gap: 1rem; }
+.skill-category { padding: 1rem; background: rgb(var(--bg-elevated) / .5);
+  border: 1px solid rgb(var(--color-neutral-700) / .4); border-radius: var(--radius); }
+.skill-title { margin: 0 0 .6rem; font-size: 1rem; color: rgb(var(--color-primary-200)); }
+.skill-list { list-style: none; margin: 0; padding: 0; display: grid; gap: .4rem; }
+.skill-item { padding: .35rem .6rem; background: rgb(var(--ring) / .1); border-radius: .5rem;
+  font-size: .9rem; color: rgb(var(--color-neutral-200)); }
+
+/* Projects */
+.projects-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr)); gap: 1rem; }
+.project-card { padding: 1.1rem; background: rgb(var(--bg-elevated) / .5);
+  border: 1px solid rgb(var(--color-neutral-700) / .4); border-radius: var(--radius);
+  transition: transform .15s ease, border-color .15s ease; }
+.project-card:hover { transform: translateY(-3px); border-color: rgb(var(--ring) / .55); }
+.project-header { display: flex; justify-content: space-between; align-items: baseline; gap: .5rem; }
+.project-title { margin: 0; font-size: 1.05rem; }
+.project-status { font-size: .72rem; padding: .2rem .55rem; border-radius: 999px; font-weight: 600;
+  background: rgb(34, 211, 238, .15); color: rgb(34, 211, 238); }
+.project-description { margin: .6rem 0; font-size: .9rem; color: rgb(var(--color-neutral-300)); }
+.project-tags { display: flex; flex-wrap: wrap; gap: .35rem; }
+.project-tag { font-size: .72rem; padding: .15rem .5rem; border-radius: 999px;
+  background: rgb(var(--ring) / .14); color: rgb(var(--color-neutral-200)); }
+
+/* Education */
+.education-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr)); gap: 1rem; }
+.education-item { padding: 1rem; background: rgb(var(--bg-elevated) / .5);
+  border: 1px solid rgb(var(--color-neutral-700) / .4); border-radius: var(--radius); }
+.education-title { margin: 0 0 .3rem; font-size: 1.05rem; }
+.education-institution { margin: 0; color: rgb(var(--color-primary-300)); font-weight: 600; font-size: .9rem; }
+.education-period { margin: .15rem 0; color: rgb(var(--color-neutral-400)); font-size: .85rem; }
+.education-details { margin: .15rem 0 0; color: rgb(var(--color-neutral-300)); font-size: .9rem; }
+.certifications { margin-top: 1.25rem; }
+.certifications-title { margin: 0 0 .6rem; font-size: 1.05rem; color: rgb(var(--color-primary-200)); }
+.certification-list { list-style: none; margin: 0; padding: 0; display: grid; gap: .4rem; }
+.certification-item { padding: .4rem .7rem; background: rgb(var(--ring) / .1);
+  border-left: 3px solid rgb(var(--ring) / .6); border-radius: .4rem; font-size: .9rem; }
+
+/* Blog areas */
+.blog-areas { display: grid; grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr)); gap: 1rem; }
+.area-card { padding: 1.1rem; background: rgb(var(--bg-elevated) / .5);
+  border: 1px solid rgb(var(--color-neutral-700) / .4); border-radius: var(--radius);
+  transition: transform .15s ease, border-color .15s ease; }
+.area-card:hover { transform: translateY(-3px); border-color: rgb(34, 211, 238, .5); }
+.area-icon { font-size: 1.6rem; margin-bottom: .4rem; }
+.area-title { margin: 0 0 .35rem; font-size: 1rem; }
+.area-description { margin: 0; font-size: .9rem; color: rgb(var(--color-neutral-300)); }
+
+/* Contact */
+.contact-section { padding: 1.5rem; background: rgb(var(--ring) / .08);
+  border: 1px solid rgb(var(--color-neutral-700) / .5); border-radius: var(--radius); }
+.contact-text { margin: 0 0 1rem; color: rgb(var(--color-neutral-200)); }
+.contact-methods { display: grid; grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr)); gap: .8rem; }
+.contact-method { display: flex; align-items: center; gap: .7rem; padding: .8rem; text-decoration: none;
+  color: rgb(var(--color-neutral-200)); background: rgb(var(--bg-elevated) / .6);
+  border: 1px solid rgb(var(--color-neutral-700) / .45); border-radius: var(--radius);
+  transition: transform .15s ease, border-color .15s ease; }
+.contact-method:hover { transform: translateY(-2px); border-color: rgb(var(--ring) / .6); color: #fff; }
+.contact-icon { font-size: 1.3rem; }
+.contact-info h4 { margin: 0; font-size: .9rem; }
+.contact-info p { margin: 0; font-size: .82rem; color: rgb(var(--color-neutral-400)); }
+
+@media (max-width: 640px) {
+  .timeline-item { grid-template-columns: 1fr; gap: .35rem; }
+  .about-hero { justify-content: center; text-align: center; }
+  .about-social { justify-content: center; }
+}

--- a/content/about.md
+++ b/content/about.md
@@ -2,282 +2,87 @@
 title: About
 slug: "about"
 draft: false
+description: "Dominicus In — industrial & systems engineer; this site is an engineering notebook on optimization, automation, and decentralized systems."
 ---
 
 <div class="about-container">
-  <div class="about-hero">
-    <div class="about-avatar">
-      <img src="/assets/images/avatar.jpg" alt="Dominicus In" class="avatar-image" />
-      <div class="avatar-placeholder">
-        <span class="avatar-initials">DI</span>
-      </div>
-    </div>
-    
-    <div class="about-header-content">
-      <h1 class="about-title">Dominicus In</h1>
-      <p class="about-subtitle">Industrial & Systems Engineer</p>
-      <p class="about-description">
-        Passionate about optimizing complex systems, data-driven decision making, and building scalable engineering solutions. 
-        Specializing in industrial automation, process optimization, and systems integration.
-      </p>
-      
-      <div class="about-social">
-        <a href="https://github.com/dominicusin" class="social-link" target="_blank" rel="noopener">
-          <span class="social-icon">📦</span>
-          <span class="social-text">GitHub</span>
-        </a>
-        <a href="https://linkedin.com/in/dominicusin" class="social-link" target="_blank" rel="noopener">
-          <span class="social-icon">💼</span>
-          <span class="social-text">LinkedIn</span>
-        </a>
-        <a href="https://twitter.com/dominicusin" class="social-link" target="_blank" rel="noopener">
-          <span class="social-icon">🐦</span>
-          <span class="social-text">Twitter</span>
-        </a>
-        <a href="mailto:contact@dominicu_sin.io" class="social-link">
-          <span class="social-icon">📧</span>
-          <span class="social-text">Email</span>
-        </a>
-      </div>
-    </div>
-  </div>
-  
-  <div class="about-content">
-    <section class="about-section">
-      <h2 class="section-title">Professional Background</h2>
-      <div class="experience-timeline">
-        <div class="timeline-item">
-          <div class="timeline-date">2022 - Present</div>
-          <div class="timeline-content">
-            <h3>Senior Systems Engineer</h3>
-            <p>Leading complex industrial automation projects and implementing cutting-edge optimization strategies for manufacturing processes.</p>
-          </div>
-        </div>
-        
-        <div class="timeline-item">
-          <div class="timeline-date">2019 - 2022</div>
-          <div class="timeline-content">
-            <h3>Industrial Engineer</h3>
-            <p>Designed and implemented process improvements resulting in 25% efficiency gains and 30% cost reduction.</p>
-          </div>
-        </div>
-        
-        <div class="timeline-item">
-          <div class="timeline-date">2017 - 2019</div>
-          <div class="timeline-content">
-            <h3>Systems Analyst</h3>
-            <p>Analyzed complex manufacturing systems and developed data-driven solutions for operational challenges.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-    
-    <section class="about-section">
-      <h2 class="section-title">Core Competencies</h2>
-      <div class="skills-grid">
-        <div class="skill-category">
-          <h3 class="skill-title">Industrial Engineering</h3>
-          <ul class="skill-list">
-            <li class="skill-item">Process Optimization</li>
-            <li class="skill-item">Quality Management</li>
-            <li class="skill-item">Lean Manufacturing</li>
-            <li class="skill-item">Six Sigma</li>
-          </ul>
-        </div>
-        
-        <div class="skill-category">
-          <h3 class="skill-title">Systems Engineering</h3>
-          <ul class="skill-list">
-            <li class="skill-item">System Integration</li>
-            <li class="skill-item">Automation Design</li>
-            <li class="skill-item">Control Systems</li>
-            <li class="skill-item">IoT Implementation</li>
-          </ul>
-        </div>
-        
-        <div class="skill-category">
-          <h3 class="skill-title">Data Science</h3>
-          <ul class="skill-list">
-            <li class="skill-item">Statistical Analysis</li>
-            <li class="skill-item">Machine Learning</li>
-            <li class="skill-item">Data Visualization</li>
-            <li class="skill-item">Predictive Modeling</li>
-          </ul>
-        </div>
-        
-        <div class="skill-category">
-          <h3 class="skill-title">Technical Tools</h3>
-          <ul class="skill-list">
-            <li class="skill-item">Python / R</li>
-            <li class="skill-item">MATLAB / Simulink</li>
-            <li class="skill-item">SQL / NoSQL</li>
-            <li class="skill-item">Cloud Platforms</li>
-          </ul>
-        </div>
-      </div>
-    </section>
-    
-    <section class="about-section">
-      <h2 class="section-title">Featured Projects</h2>
-      <div class="projects-grid">
-        <div class="project-card">
-          <div class="project-header">
-            <h3 class="project-title">Smart Manufacturing System</h3>
-            <span class="project-status">Completed</span>
-          </div>
-          <p class="project-description">
-            Implemented IoT-based monitoring and optimization system for large-scale manufacturing facility, 
-            resulting in 40% efficiency improvement and real-time predictive maintenance capabilities.
-          </p>
-          <div class="project-tags">
-            <span class="project-tag">IoT</span>
-            <span class="project-tag">Automation</span>
-            <span class="project-tag">Machine Learning</span>
-          </div>
-        </div>
-        
-        <div class="project-card">
-          <div class="project-header">
-            <h3 class="project-title">Supply Chain Optimization</h3>
-            <span class="project-status">In Progress</span>
-          </div>
-          <p class="project-description">
-            Developing AI-powered supply chain optimization platform using advanced algorithms and real-time data 
-            analysis to minimize costs and maximize efficiency.
-          </p>
-          <div class="project-tags">
-            <span class="project-tag">AI/ML</span>
-            <span class="project-tag">Optimization</span>
-            <span class="project-tag">Data Science</span>
-          </div>
-        </div>
-        
-        <div class="project-card">
-          <div class="project-header">
-            <h3 class="project-title">Quality Management System</h3>
-            <span class="project-status">Completed</span>
-          </div>
-          <p class="project-description">
-            Designed comprehensive quality management system with automated inspection, statistical process control, 
-            and continuous improvement methodologies.
-          </p>
-          <div class="project-tags">
-            <span class="project-tag">Quality</span>
-            <span class="project-tag">Statistics</span>
-            <span class="project-tag">Process Control</span>
-          </div>
-        </div>
-      </div>
-    </section>
-    
-    <section class="about-section">
-      <h2 class="section-title">Education & Certifications</h2>
-      <div class="education-grid">
-        <div class="education-item">
-          <h3 class="education-title">M.S. Industrial Engineering</h3>
-          <p class="education-institution">Technical University</p>
-          <p class="education-period">2015 - 2017</p>
-          <p class="education-details">Focus on Systems Optimization and Data Analytics</p>
-        </div>
-        
-        <div class="education-item">
-          <h3 class="education-title">B.S. Industrial Engineering</h3>
-          <p class="education-institution">Engineering Institute</p>
-          <p class="education-period">2011 - 2015</p>
-          <p class="education-details">Graduated Magna Cum Laude</p>
-        </div>
-      </div>
-      
-      <div class="certifications">
-        <h3 class="certifications-title">Professional Certifications</h3>
-        <ul class="certification-list">
-          <li class="certification-item">Certified Six Sigma Black Belt</li>
-          <li class="certification-item">AWS Solutions Architect</li>
-          <li class="certification-item">PMP Project Management</li>
-          <li class="certification-item">Lean Manufacturing Expert</li>
-        </ul>
-      </div>
-    </section>
-    
-    <section class="about-section">
-      <h2 class="section-title">Blog Focus Areas</h2>
-      <div class="blog-areas">
-        <div class="area-card">
-          <div class="area-icon">⚙️</div>
-          <h3 class="area-title">Industrial Engineering</h3>
-          <p class="area-description">
-            Process optimization, quality management, lean principles, and manufacturing excellence.
-          </p>
-        </div>
-        
-        <div class="area-card">
-          <div class="area-icon">🔗</div>
-          <h3 class="area-title">Systems Integration</h3>
-          <p class="area-description">
-            Complex system design, automation, IoT implementation, and cross-platform integration.
-          </p>
-        </div>
-        
-        <div class="area-card">
-          <div class="area-icon">📊</div>
-          <h3 class="area-title">Data Science</h3>
-          <p class="area-description">
-            Statistical analysis, machine learning, data visualization, and predictive modeling.
-          </p>
-        </div>
-        
-        <div class="area-card">
-          <div class="area-icon">🚀</div>
-          <h3 class="area-title">Technology Trends</h3>
-          <p class="area-description">
-            Emerging technologies, industry 4.0, digital transformation, and innovation.
-          </p>
-        </div>
-      </div>
-    </section>
-    
-    <section class="about-section">
-      <h2 class="section-title">Get In Touch</h2>
-      <div class="contact-section">
-        <p class="contact-text">
-          I'm always interested in collaborating on challenging projects, sharing knowledge, 
-          or discussing the latest developments in engineering and technology. Feel free to reach out!
-        </p>
-        
-        <div class="contact-methods">
-          <a href="mailto:contact@dominicu_sin.io" class="contact-method">
-            <span class="contact-icon">📧</span>
-            <div class="contact-info">
-              <h4>Email</h4>
-              <p>contact@dominicu_sin.io</p>
-            </div>
-          </a>
-          
-          <a href="https://linkedin.com/in/dominicusin" class="contact-method" target="_blank" rel="noopener">
-            <span class="contact-icon">💼</span>
-            <div class="contact-info">
-              <h4>LinkedIn</h4>
-              <p>/in/dominicusin</p>
-            </div>
-          </a>
-          
-          <a href="https://github.com/dominicusin" class="contact-method" target="_blank" rel="noopener">
-            <span class="contact-icon">📦</span>
-            <div class="contact-info">
-              <h4>GitHub</h4>
-              <p>/dominicusin</p>
-            </div>
-          </a>
-          
-          <a href="https://twitter.com/dominicusin" class="contact-method" target="_blank" rel="noopener">
-            <span class="contact-icon">🐦</span>
-            <div class="contact-info">
-              <h4>Twitter</h4>
-              <p>@dominicusin</p>
-            </div>
-          </a>
-        </div>
-      </div>
-    </section>
-  </div>
+<div class="about-hero">
+<div class="about-avatar">
+<img src="/images/avatar.svg" alt="Dominicus In" class="avatar-image" />
+<div class="avatar-placeholder"><span class="avatar-initials">DI</span></div>
+</div>
+<div class="about-header-content">
+<h1 class="about-title">Dominicus In</h1>
+<p class="about-subtitle">Industrial &amp; Systems Engineer</p>
+<p class="about-description">Passionate about optimizing complex systems, data-driven decision making, and building scalable engineering solutions. Specializing in industrial automation, process optimization, and systems integration.</p>
+<div class="about-social">
+<a href="https://github.com/dominicusin" class="social-link" target="_blank" rel="noopener"><span class="social-icon">📦</span><span class="social-text">GitHub</span></a>
+<a href="https://linkedin.com/in/dominicusin" class="social-link" target="_blank" rel="noopener"><span class="social-icon">💼</span><span class="social-text">LinkedIn</span></a>
+<a href="https://twitter.com/dominicusin" class="social-link" target="_blank" rel="noopener"><span class="social-icon">🐦</span><span class="social-text">Twitter</span></a>
+<a href="mailto:contact@dominicu_sin.io" class="social-link"><span class="social-icon">📧</span><span class="social-text">Email</span></a>
+</div>
+</div>
+</div>
+
+<div class="about-content">
+<section class="about-section">
+<h2 class="section-title">Professional Background</h2>
+<div class="experience-timeline">
+<div class="timeline-item"><div class="timeline-date">2022 - Present</div><div class="timeline-content"><h3>Senior Systems Engineer</h3><p>Leading complex industrial automation projects and implementing cutting-edge optimization strategies for manufacturing processes.</p></div></div>
+<div class="timeline-item"><div class="timeline-date">2019 - 2022</div><div class="timeline-content"><h3>Industrial Engineer</h3><p>Designed and implemented process improvements resulting in 25% efficiency gains and 30% cost reduction.</p></div></div>
+<div class="timeline-item"><div class="timeline-date">2017 - 2019</div><div class="timeline-content"><h3>Systems Analyst</h3><p>Analyzed complex manufacturing systems and developed data-driven solutions for operational challenges.</p></div></div>
+</div>
+</section>
+
+<section class="about-section">
+<h2 class="section-title">Core Competencies</h2>
+<div class="skills-grid">
+<div class="skill-category"><h3 class="skill-title">Industrial Engineering</h3><ul class="skill-list"><li class="skill-item">Process Optimization</li><li class="skill-item">Quality Management</li><li class="skill-item">Lean Manufacturing</li><li class="skill-item">Six Sigma</li></ul></div>
+<div class="skill-category"><h3 class="skill-title">Systems Engineering</h3><ul class="skill-list"><li class="skill-item">System Integration</li><li class="skill-item">Automation Design</li><li class="skill-item">Control Systems</li><li class="skill-item">IoT Implementation</li></ul></div>
+<div class="skill-category"><h3 class="skill-title">Data Science</h3><ul class="skill-list"><li class="skill-item">Statistical Analysis</li><li class="skill-item">Machine Learning</li><li class="skill-item">Data Visualization</li><li class="skill-item">Predictive Modeling</li></ul></div>
+<div class="skill-category"><h3 class="skill-title">Technical Tools</h3><ul class="skill-list"><li class="skill-item">Python / R</li><li class="skill-item">MATLAB / Simulink</li><li class="skill-item">SQL / NoSQL</li><li class="skill-item">Cloud Platforms</li></ul></div>
+</div>
+</section>
+
+<section class="about-section">
+<h2 class="section-title">Featured Projects</h2>
+<div class="projects-grid">
+<div class="project-card"><div class="project-header"><h3 class="project-title">Smart Manufacturing System</h3><span class="project-status">Completed</span></div><p class="project-description">Implemented IoT-based monitoring and optimization system for large-scale manufacturing facility, resulting in 40% efficiency improvement and real-time predictive maintenance capabilities.</p><div class="project-tags"><span class="project-tag">IoT</span><span class="project-tag">Automation</span><span class="project-tag">Machine Learning</span></div></div>
+<div class="project-card"><div class="project-header"><h3 class="project-title">Supply Chain Optimization</h3><span class="project-status">In Progress</span></div><p class="project-description">Developing AI-powered supply chain optimization platform using advanced algorithms and real-time data analysis to minimize costs and maximize efficiency.</p><div class="project-tags"><span class="project-tag">AI/ML</span><span class="project-tag">Optimization</span><span class="project-tag">Data Science</span></div></div>
+<div class="project-card"><div class="project-header"><h3 class="project-title">Quality Management System</h3><span class="project-status">Completed</span></div><p class="project-description">Designed comprehensive quality management system with automated inspection, statistical process control, and continuous improvement methodologies.</p><div class="project-tags"><span class="project-tag">Quality</span><span class="project-tag">Statistics</span><span class="project-tag">Process Control</span></div></div>
+</div>
+</section>
+
+<section class="about-section">
+<h2 class="section-title">Education &amp; Certifications</h2>
+<div class="education-grid">
+<div class="education-item"><h3 class="education-title">M.S. Industrial Engineering</h3><p class="education-institution">Technical University</p><p class="education-period">2015 - 2017</p><p class="education-details">Focus on Systems Optimization and Data Analytics</p></div>
+<div class="education-item"><h3 class="education-title">B.S. Industrial Engineering</h3><p class="education-institution">Engineering Institute</p><p class="education-period">2011 - 2015</p><p class="education-details">Graduated Magna Cum Laude</p></div>
+</div>
+<div class="certifications"><h3 class="certifications-title">Professional Certifications</h3><ul class="certification-list"><li class="certification-item">Certified Six Sigma Black Belt</li><li class="certification-item">AWS Solutions Architect</li><li class="certification-item">PMP Project Management</li><li class="certification-item">Lean Manufacturing Expert</li></ul></div>
+</section>
+
+<section class="about-section">
+<h2 class="section-title">Blog Focus Areas</h2>
+<div class="blog-areas">
+<div class="area-card"><div class="area-icon">⚙️</div><h3 class="area-title">Industrial Engineering</h3><p class="area-description">Process optimization, quality management, lean principles, and manufacturing excellence.</p></div>
+<div class="area-card"><div class="area-icon">🔗</div><h3 class="area-title">Systems Integration</h3><p class="area-description">Complex system design, automation, IoT implementation, and cross-platform integration.</p></div>
+<div class="area-card"><div class="area-icon">📊</div><h3 class="area-title">Data Science</h3><p class="area-description">Statistical analysis, machine learning, data visualization, and predictive modeling.</p></div>
+<div class="area-card"><div class="area-icon">🚀</div><h3 class="area-title">Technology Trends</h3><p class="area-description">Emerging technologies, industry 4.0, digital transformation, and innovation.</p></div>
+</div>
+</section>
+
+<section class="about-section">
+<h2 class="section-title">Get In Touch</h2>
+<div class="contact-section">
+<p class="contact-text">I'm always interested in collaborating on challenging projects, sharing knowledge, or discussing the latest developments in engineering and technology. Feel free to reach out!</p>
+<div class="contact-methods">
+<a href="mailto:contact@dominicu_sin.io" class="contact-method"><span class="contact-icon">📧</span><div class="contact-info"><h4>Email</h4><p>contact@dominicu_sin.io</p></div></a>
+<a href="https://linkedin.com/in/dominicusin" class="contact-method" target="_blank" rel="noopener"><span class="contact-icon">💼</span><div class="contact-info"><h4>LinkedIn</h4><p>/in/dominicusin</p></div></a>
+<a href="https://github.com/dominicusin" class="contact-method" target="_blank" rel="noopener"><span class="contact-icon">📦</span><div class="contact-info"><h4>GitHub</h4><p>/dominicusin</p></div></a>
+<a href="https://twitter.com/dominicusin" class="contact-method" target="_blank" rel="noopener"><span class="contact-icon">🐦</span><div class="contact-info"><h4>Twitter</h4><p>@dominicusin</p></div></a>
+</div>
+</div>
+</section>
+</div>
 </div>

--- a/data/authors/dominicusin.yml
+++ b/data/authors/dominicusin.yml
@@ -1,5 +1,5 @@
 name: Dominicus In
-image: images/avatar.jpg
+image: images/avatar.svg
 social:
   github: "https://github.com/dominicusin"
   telegram: "https://t.me/dominicusin"

--- a/static/images/avatar.svg
+++ b/static/images/avatar.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="224" height="224" viewBox="0 0 224 224" role="img" aria-label="Dominicus In">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7c6cf0"/>
+      <stop offset="1" stop-color="#22d3ee"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.5" cy="0.35" r="0.7">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.25"/>
+      <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <circle cx="112" cy="112" r="112" fill="url(#bg)"/>
+  <circle cx="112" cy="112" r="112" fill="url(#glow)"/>
+  <text x="112" y="112" text-anchor="middle" dominant-baseline="central"
+        font-family="Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif"
+        font-size="96" font-weight="800" fill="#ffffff" letter-spacing="-4">DI</text>
+</svg>


### PR DESCRIPTION
Rewrote about.md with flush-left raw HTML so Goldmark no longer escapes it into <pre><code>. Added cohesive About-page styling to custom.css and an SVG monogram avatar (old avatar.jpg was missing). Verified: 0 <pre><code> on /about/, real headings/cards render, avatar 200, links clean.