### PR TITLE
feat: deepen site ontology & taxonomy (59 posts + KG hierarchy)

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -139,8 +139,11 @@ html { scroll-behavior: smooth; }
 .kg-node.kg-dim { opacity: .18; }
 .kg-node.kg-selected circle { stroke: #fff; stroke-width: 2.5; }
 .kg-edge { transition: opacity .15s ease; }
-.kg-edge.kg-edge-hi { stroke: rgb(var(--color-primary-300)) !important; stroke-width: 2 !important; }
-.kg-edge.kg-dim { opacity: .07; }
+.kg-edge[data-type="authored"] { opacity: .1; }
+.kg-edge[data-type="co-occurs"] { opacity: .14; }
+.kg-edge[data-type="subsumes"] { opacity: .22; }
+.kg-edge.kg-edge-hi { stroke: rgb(var(--color-primary-300)) !important; stroke-width: 2 !important; opacity: 1 !important; }
+.kg-edge.kg-dim { opacity: .05; }
 
 .kg-panel {
   width: 100%;
@@ -165,9 +168,10 @@ html { scroll-behavior: smooth; }
 .kg-panel-rel a { color: rgb(var(--color-neutral-200)); }
 .kg-panel-rel a:hover { color: rgb(var(--color-primary-300)); }
 .kg-panel-empty { color: rgb(var(--color-neutral-500)); font-size: .9rem; }
-.kg-legend { display: flex; flex-wrap: wrap; gap: 1rem; margin-top: .4rem; }
-.kg-leg { display: inline-flex; align-items: center; gap: .4rem; font-size: .8rem; color: rgb(var(--color-neutral-400)); }
-.kg-leg span:first-child { width: .7rem; height: .7rem; border-radius: 50%; display: inline-block; }
+.kg-legend { display: flex; flex-wrap: wrap; gap: .5rem .9rem; margin-top: .5rem; align-items: center; }
+.kg-leg { display: inline-flex; align-items: center; gap: .4rem; font-size: .8rem; color: rgb(var(--color-neutral-300)); white-space: nowrap; }
+.kg-leg-dot { width: .8rem; height: .8rem; border-radius: 50%; display: inline-block; flex: 0 0 auto; }
+.kg-leg-label { line-height: 1; }
 .kg-error { color: rgb(248, 113, 113); }
 
 /* ---------- Responsive ---------- */

--- a/content/blog/2015-11-19-first.md
+++ b/content/blog/2015-11-19-first.md
@@ -1,12 +1,15 @@
 ---
 title: First post
-date: "2015-11-19T01:41:00.000Z"
+date: '2015-11-19T01:41:00.000Z'
 slug: first
 aliases:
-  - /2015/11/19/first.html
+- /2015/11/19/first.html
 categories:
-  - jekyll
-  - update
+- notes
+tags:
+- jekyll
+- web
+- productivity
 ---
 author: DominicusIn
 

--- a/content/blog/2016-11-22-second.md
+++ b/content/blog/2016-11-22-second.md
@@ -1,9 +1,13 @@
 ---
 title: List of favourite movies
-date: "2016-11-22T02:25:00.000Z"
+date: '2016-11-22T02:25:00.000Z'
 slug: second
 aliases:
-  - /2016/11/22/second.html
+- /2016/11/22/second.html
+categories:
+- media
+tags:
+- movies
 ---
 author: DominicusIn
 

--- a/content/blog/2016-12-01-rieziumie.md
+++ b/content/blog/2016-12-01-rieziumie.md
@@ -1,11 +1,16 @@
 ---
 title: Curriculum Vitae
-date: "2016-12-01T08:32:00.000Z"
+date: '2016-12-01T08:32:00.000Z'
 slug: rieziumie
 aliases:
-  - /2016/12/01/rieziumie.html
+- /2016/12/01/rieziumie.html
 params: {}
 field_name: null
+categories:
+- career
+tags:
+- cv
+- productivity
 ---
 author: DominicusIn
 

--- a/content/blog/2017-05-29-Interview.md
+++ b/content/blog/2017-05-29-Interview.md
@@ -1,9 +1,15 @@
 ---
 title: Linux System Administrator(DevOp) Interview Questions
-date: "2017-05-28T22:03:00.000Z"
+date: '2017-05-28T22:03:00.000Z'
 slug: Interview
 aliases:
-  - /2017/05/29/Interview.html
+- /2017/05/29/Interview.html
+categories:
+- career
+tags:
+- linux
+- interview
+- devops
 ---
 author: DominicusIn
 

--- a/content/blog/2017-06-07-OnionShare.md
+++ b/content/blog/2017-06-07-OnionShare.md
@@ -1,9 +1,15 @@
 ---
 title: OnionShare
-date: "2017-06-07T17:02:00.000Z"
+date: '2017-06-07T17:02:00.000Z'
 slug: OnionShare
 aliases:
-  - /2017/06/07/OnionShare.html
+- /2017/06/07/OnionShare.html
+categories:
+- security
+tags:
+- privacy
+- tor
+- tools
 ---
 author: DominicusIn
 

--- a/content/blog/2017-06-15-free-programming-books.md
+++ b/content/blog/2017-06-15-free-programming-books.md
@@ -1,9 +1,15 @@
 ---
 title: Free Programming Books
-date: "2017-06-15T16:49:00.000Z"
+date: '2017-06-15T16:49:00.000Z'
 slug: free-programming-books
 aliases:
-  - /2017/06/15/free-programming-books.html
+- /2017/06/15/free-programming-books.html
+categories:
+- links
+tags:
+- books
+- free-resources
+- programming
 ---
 author: DominicusIn
 

--- a/content/blog/2017-07-28-svn2git.md
+++ b/content/blog/2017-07-28-svn2git.md
@@ -1,9 +1,15 @@
 ---
 title: Migrate a code repository from SourceForge (SVN) to Github (GIT)
-date: "2017-07-28T17:29:00.000Z"
+date: '2017-07-28T17:29:00.000Z'
 slug: svn2git
 aliases:
-  - /2017/07/28/svn2git.html
+- /2017/07/28/svn2git.html
+categories:
+- systems
+tags:
+- git
+- linux
+- automation
 ---
 author: DominicusIn
 

--- a/content/blog/2017-08-10-imhonet.md
+++ b/content/blog/2017-08-10-imhonet.md
@@ -1,9 +1,14 @@
 ---
 title: imhonet is dead
-date: "2017-08-10T00:03:00.000Z"
+date: '2017-08-10T00:03:00.000Z'
 slug: imhonet
 aliases:
-  - /2017/08/10/imhonet.html
+- /2017/08/10/imhonet.html
+categories:
+- web
+tags:
+- media
+- social
 ---
 author: DominicusIn
 

--- a/content/blog/2017-08-31-nedaigne.md
+++ b/content/blog/2017-08-31-nedaigne.md
@@ -1,9 +1,14 @@
 ---
 title: nedaigne
-date: "2017-08-31T14:04:00.000Z"
+date: '2017-08-31T14:04:00.000Z'
 slug: nedaigne
 aliases:
-  - /2017/08/31/nedaigne.html
+- /2017/08/31/nedaigne.html
+categories:
+- links
+tags:
+- awesome-list
+- media
 ---
 author: DominicusIn
 

--- a/content/blog/2017-11-06-Winworkstation.md
+++ b/content/blog/2017-11-06-Winworkstation.md
@@ -1,9 +1,15 @@
 ---
 title: Prepare my Windows workstation
-date: "2017-11-05T23:27:00.000Z"
+date: '2017-11-05T23:27:00.000Z'
 slug: Winworkstation
 aliases:
-  - /2017/11/06/Winworkstation.html
+- /2017/11/06/Winworkstation.html
+categories:
+- notes
+tags:
+- windows
+- productivity
+- automation
 ---
 author: DominicusIn
 

--- a/content/blog/2017-11-08-links.md
+++ b/content/blog/2017-11-08-links.md
@@ -1,9 +1,14 @@
 ---
 title: Some interesting links
-date: "2017-11-08T10:26:00.000Z"
+date: '2017-11-08T10:26:00.000Z'
 slug: links
 aliases:
-  - /2017/11/08/links.html
+- /2017/11/08/links.html
+categories:
+- links
+tags:
+- awesome-list
+- web
 ---
 author: DominicusIn
 

--- a/content/blog/2017-11-10-dpiblock.md
+++ b/content/blog/2017-11-10-dpiblock.md
@@ -1,9 +1,15 @@
 ---
 title: dpiblock
-date: "2017-11-10T16:58:00.000Z"
+date: '2017-11-10T16:58:00.000Z'
 slug: dpiblock
 aliases:
-  - /2017/11/10/dpiblock.html
+- /2017/11/10/dpiblock.html
+categories:
+- notes
+tags:
+- linux
+- networking
+- privacy
 ---
 author: DominicusIn
 

--- a/content/blog/2017-11-15-forth.md
+++ b/content/blog/2017-11-15-forth.md
@@ -1,9 +1,14 @@
 ---
 title: forth
-date: "2017-11-15T13:38:00.000Z"
+date: '2017-11-15T13:38:00.000Z'
 slug: forth
 aliases:
-  - /2017/11/15/forth.html
+- /2017/11/15/forth.html
+categories:
+- systems
+tags:
+- languages
+- forth
 ---
 author: DominicusIn
 

--- a/content/blog/2018-02-03-russia-it-podcast.md
+++ b/content/blog/2018-02-03-russia-it-podcast.md
@@ -1,9 +1,14 @@
 ---
 title: it-podcast
-date: "2018-02-03T12:50:00.000Z"
+date: '2018-02-03T12:50:00.000Z'
 slug: russia-it-podcast
 aliases:
-  - /2018/02/03/russia-it-podcast.html
+- /2018/02/03/russia-it-podcast.html
+categories:
+- links
+tags:
+- podcasts
+- awesome-list
 ---
 author: DominicusIn
 

--- a/content/blog/2018-02-25-google-interview-questions.md
+++ b/content/blog/2018-02-25-google-interview-questions.md
@@ -1,9 +1,14 @@
 ---
 title: Google Interview Questions
-date: "2018-02-25T18:25:00.000Z"
+date: '2018-02-25T18:25:00.000Z'
 slug: google-interview-questions
 aliases:
-  - /2018/02/25/google-interview-questions.html
+- /2018/02/25/google-interview-questions.html
+categories:
+- career
+tags:
+- interview
+- programming
 ---
 author: DominicusIn
 

--- a/content/blog/2018-11-09-awesome-machine-learning-for-cyber-security.md
+++ b/content/blog/2018-11-09-awesome-machine-learning-for-cyber-security.md
@@ -1,9 +1,16 @@
 ---
 title: Awesome Machine Learning for Cyber Security
-date: "2018-11-09T03:42:00.000Z"
+date: '2018-11-09T03:42:00.000Z'
 slug: awesome-machine-learning-for-cyber-security
 aliases:
-  - /2018/11/09/awesome-machine-learning-for-cyber-security.html
+- /2018/11/09/awesome-machine-learning-for-cyber-security.html
+categories:
+- security
+- ai
+tags:
+- ml
+- cybersecurity
+- awesome-list
 ---
 author: DominicusIn
 

--- a/content/blog/2018-11-09-my-favorite-movies.md
+++ b/content/blog/2018-11-09-my-favorite-movies.md
@@ -1,9 +1,13 @@
 ---
 title: My favorite movies
-date: "2018-11-08T23:34:00.000Z"
+date: '2018-11-08T23:34:00.000Z'
 slug: my-favorite-movies
 aliases:
-  - /2018/11/09/my-favorite-movies.html
+- /2018/11/09/my-favorite-movies.html
+categories:
+- media
+tags:
+- movies
 ---
 author: DominicusIn
 

--- a/content/blog/2019-01-31-linux-networking-commands.md
+++ b/content/blog/2019-01-31-linux-networking-commands.md
@@ -1,9 +1,15 @@
 ---
 title: Linux Networking commands
-date: "2019-01-31T15:41:00.000Z"
+date: '2019-01-31T15:41:00.000Z'
 slug: linux-networking-commands
 aliases:
-  - /2019/01/31/linux-networking-commands.html
+- /2019/01/31/linux-networking-commands.html
+categories:
+- systems
+tags:
+- linux
+- networking
+- cli
 ---
 author: DominicusIn
 

--- a/content/blog/2019-05-18-SFTP.md
+++ b/content/blog/2019-05-18-SFTP.md
@@ -1,9 +1,16 @@
 ---
 title: SFTP
-date: "2019-05-17T21:50:00.000Z"
+date: '2019-05-17T21:50:00.000Z'
 slug: SFTP
 aliases:
-  - /2019/05/18/SFTP.html
+- /2019/05/18/SFTP.html
+categories:
+- systems
+tags:
+- linux
+- networking
+- sftp
+- automation
 ---
 author: DominicusIn
 

--- a/content/blog/2019-06-16-Awesome-Selfhosted.md
+++ b/content/blog/2019-06-16-Awesome-Selfhosted.md
@@ -1,9 +1,15 @@
 ---
 title: Awesome-Selfhosted
-date: "2019-06-16T14:04:00.000Z"
+date: '2019-06-16T14:04:00.000Z'
 slug: Awesome-Selfhosted
 aliases:
-  - /2019/06/16/Awesome-Selfhosted.html
+- /2019/06/16/Awesome-Selfhosted.html
+categories:
+- web
+tags:
+- self-hosting
+- awesome-list
+- free-resources
 ---
 author: DominicusIn
 

--- a/content/blog/2019-07-25-gcloud-cheat-sheet.md
+++ b/content/blog/2019-07-25-gcloud-cheat-sheet.md
@@ -1,9 +1,15 @@
 ---
 title: gcloud cheat sheet
-date: "2019-07-25T01:55:00.000Z"
+date: '2019-07-25T01:55:00.000Z'
 slug: gcloud-cheat-sheet
 aliases:
-  - /2019/07/25/gcloud-cheat-sheet.html
+- /2019/07/25/gcloud-cheat-sheet.html
+categories:
+- notes
+tags:
+- gcloud
+- cli
+- cloud
 ---
 author: DominicusIn
 

--- a/content/blog/2019-12-16-HipChatAlternatives.md
+++ b/content/blog/2019-12-16-HipChatAlternatives.md
@@ -1,9 +1,15 @@
 ---
 title: HipChat Alternatives
-date: "2019-12-16T03:42:00.000Z"
+date: '2019-12-16T03:42:00.000Z'
 slug: HipChatAlternatives
 aliases:
-  - /2019/12/16/HipChatAlternatives.html
+- /2019/12/16/HipChatAlternatives.html
+categories:
+- web
+tags:
+- chat
+- privacy
+- awesome-list
 ---
 author: DominicusIn
 

--- a/content/blog/2020-03-08-Russian_programmers.md
+++ b/content/blog/2020-03-08-Russian_programmers.md
@@ -1,9 +1,14 @@
 ---
 title: programmers
-date: "2020-03-08T20:49:00.000Z"
+date: '2020-03-08T20:49:00.000Z'
 slug: Russian_programmers
 aliases:
-  - /2020/03/08/Russian_programmers.html
+- /2020/03/08/Russian_programmers.html
+categories:
+- links
+tags:
+- programming
+- awesome-list
 ---
 author: DominicusIn
 

--- a/content/blog/2020-03-18-advices.md
+++ b/content/blog/2020-03-18-advices.md
@@ -1,9 +1,15 @@
 ---
 title: Advs for programmer
-date: "2020-03-18T00:37:00.000Z"
+date: '2020-03-18T00:37:00.000Z'
 slug: advices
 aliases:
-  - /2020/03/18/advices.html
+- /2020/03/18/advices.html
+categories:
+- links
+tags:
+- programming
+- jobs
+- awesome-list
 ---
 author: DominicusIn
 

--- a/content/blog/2020-03-18-free-courses-ru.md
+++ b/content/blog/2020-03-18-free-courses-ru.md
@@ -1,9 +1,15 @@
 ---
 title: free-courses
-date: "2020-03-18T16:55:00.000Z"
+date: '2020-03-18T16:55:00.000Z'
 slug: free-courses-ru
 aliases:
-  - /2020/03/18/free-courses-ru.html
+- /2020/03/18/free-courses-ru.html
+categories:
+- links
+tags:
+- free-resources
+- courses
+- awesome-list
 ---
 author: DominicusIn
 

--- a/content/blog/2020-03-18-free-podcasts-screencasts-ru.md
+++ b/content/blog/2020-03-18-free-podcasts-screencasts-ru.md
@@ -1,9 +1,16 @@
 ---
 title: free-podcasts-screencasts
-date: "2020-03-18T17:09:00.000Z"
+date: '2020-03-18T17:09:00.000Z'
 slug: free-podcasts-screencasts-ru
 aliases:
-  - /2020/03/18/free-podcasts-screencasts-ru.html
+- /2020/03/18/free-podcasts-screencasts-ru.html
+categories:
+- links
+tags:
+- podcasts
+- screencasts
+- free-resources
+- awesome-list
 ---
 author: DominicusIn
 

--- a/content/blog/2020-03-18-free-programming-books-ru.md
+++ b/content/blog/2020-03-18-free-programming-books-ru.md
@@ -1,9 +1,16 @@
 ---
 title: free-programming-books
-date: "2020-03-18T17:06:00.000Z"
+date: '2020-03-18T17:06:00.000Z'
 slug: free-programming-books-ru
 aliases:
-  - /2020/03/18/free-programming-books-ru.html
+- /2020/03/18/free-programming-books-ru.html
+categories:
+- links
+tags:
+- books
+- free-resources
+- programming
+- awesome-list
 ---
 author: DominicusIn
 

--- a/content/blog/2020-05-21-poc-in-github.md
+++ b/content/blog/2020-05-21-poc-in-github.md
@@ -1,9 +1,15 @@
 ---
 title: PoC in GitHub
-date: "2020-05-21T01:05:00.000Z"
+date: '2020-05-21T01:05:00.000Z'
 slug: poc-in-github
 aliases:
-  - /2020/05/21/poc-in-github.html
+- /2020/05/21/poc-in-github.html
+categories:
+- systems
+tags:
+- git
+- github
+- security
 ---
 author: DominicusIn
 

--- a/content/blog/2021-08-29-free-for-dev.md
+++ b/content/blog/2021-08-29-free-for-dev.md
@@ -1,9 +1,16 @@
 ---
 title: free-for.dev
-date: "2021-08-29T15:14:00.000Z"
+date: '2021-08-29T15:14:00.000Z'
 slug: free-for-dev
 aliases:
-  - /2021/08/29/free-for-dev.html
+- /2021/08/29/free-for-dev.html
+categories:
+- web
+tags:
+- devops
+- free-resources
+- cloud
+- awesome-list
 ---
 author: DominicusIn
 

--- a/content/blog/2021-09-06-macOS-Security-and-Privacy-Guide.md
+++ b/content/blog/2021-09-06-macOS-Security-and-Privacy-Guide.md
@@ -1,9 +1,15 @@
 ---
 title: macOS-Security-and-Privacy-Guide
-date: "2021-09-06T06:01:00.000Z"
+date: '2021-09-06T06:01:00.000Z'
 slug: macOS-Security-and-Privacy-Guide
 aliases:
-  - /2021/09/06/macOS-Security-and-Privacy-Guide.html
+- /2021/09/06/macOS-Security-and-Privacy-Guide.html
+categories:
+- security
+tags:
+- macos
+- privacy
+- hardening
 ---
 author: DominicusIn
 

--- a/content/blog/2022-03-15-Lua-Neovim.md
+++ b/content/blog/2022-03-15-Lua-Neovim.md
@@ -1,9 +1,15 @@
 ---
 title: Lua  Neovim
-date: "2022-03-15T01:33:00.000Z"
+date: '2022-03-15T01:33:00.000Z'
 slug: Lua-Neovim
 aliases:
-  - /2022/03/15/Lua-Neovim.html
+- /2022/03/15/Lua-Neovim.html
+categories:
+- systems
+tags:
+- neovim
+- lua
+- editors
 ---
 author: DominicusIn
 

--- a/content/blog/2022-05-16-Awesome-Selfhosted.md
+++ b/content/blog/2022-05-16-Awesome-Selfhosted.md
@@ -1,9 +1,15 @@
 ---
 title: Awesome-Selfhosted
-date: "2022-05-16T19:52:00.000Z"
+date: '2022-05-16T19:52:00.000Z'
 slug: Awesome-Selfhosted
 aliases:
-  - /2022/05/16/Awesome-Selfhosted.html
+- /2022/05/16/Awesome-Selfhosted.html
+categories:
+- web
+tags:
+- self-hosting
+- awesome-list
+- free-resources
 ---
 author: DominicusIn
 

--- a/content/blog/2022-07-17-old-programmers.md
+++ b/content/blog/2022-07-17-old-programmers.md
@@ -1,9 +1,14 @@
 ---
 title: old programmers
-date: "2022-07-16T22:50:00.000Z"
+date: '2022-07-16T22:50:00.000Z'
 slug: old-programmers
 aliases:
-  - /2022/07/17/old-programmers.html
+- /2022/07/17/old-programmers.html
+categories:
+- links
+tags:
+- programming
+- awesome-list
 ---
 author: DominicusIn
 

--- a/content/blog/2023-01-14-a-collection-of-awesome-ai-applications.md
+++ b/content/blog/2023-01-14-a-collection-of-awesome-ai-applications.md
@@ -1,9 +1,15 @@
 ---
 title: A Collection of Awesome AI Applications
-date: "2023-01-14T13:26:00.000Z"
+date: '2023-01-14T13:26:00.000Z'
 slug: a-collection-of-awesome-ai-applications
 aliases:
-  - /2023/01/14/a-collection-of-awesome-ai-applications.html
+- /2023/01/14/a-collection-of-awesome-ai-applications.html
+categories:
+- ai
+tags:
+- llm
+- awesome-list
+- applications
 ---
 author: DominicusIn
 

--- a/content/blog/2023-01-20-awesome-piracy.md
+++ b/content/blog/2023-01-20-awesome-piracy.md
@@ -1,9 +1,15 @@
 ---
 title: Awesome Piracy
-date: "2023-01-20T05:45:00.000Z"
+date: '2023-01-20T05:45:00.000Z'
 slug: awesome-piracy
 aliases:
-  - /2023/01/20/awesome-piracy.html
+- /2023/01/20/awesome-piracy.html
+categories:
+- links
+tags:
+- awesome-list
+- piracy
+- media
 ---
 author: DominicusIn
 

--- a/content/blog/2023-05-18-dark-web-links.md
+++ b/content/blog/2023-05-18-dark-web-links.md
@@ -1,9 +1,15 @@
 ---
 title: Dark Web Links
-date: "2023-05-18T06:02:00.000Z"
+date: '2023-05-18T06:02:00.000Z'
 slug: dark-web-links
 aliases:
-  - /2023/05/18/dark-web-links.html
+- /2023/05/18/dark-web-links.html
+categories:
+- security
+tags:
+- tor
+- darknet
+- privacy
 ---
 author: DominicusIn
 

--- a/content/blog/2023-06-25-awesome-tunneling.md
+++ b/content/blog/2023-06-25-awesome-tunneling.md
@@ -1,9 +1,16 @@
 ---
 title: Awesome tunneling
-date: "2023-06-25T08:09:00.000Z"
+date: '2023-06-25T08:09:00.000Z'
 slug: awesome-tunneling
 aliases:
-  - /2023/06/25/awesome-tunneling.html
+- /2023/06/25/awesome-tunneling.html
+categories:
+- web
+tags:
+- tunneling
+- self-hosting
+- networking
+- awesome-list
 ---
 author: DominicusIn
 

--- a/content/blog/2023-08-26-three-virtues.md
+++ b/content/blog/2023-08-26-three-virtues.md
@@ -1,9 +1,15 @@
 ---
 title: Three Virtues
-date: "2023-08-26T03:27:00.000Z"
+date: '2023-08-26T03:27:00.000Z'
 slug: three-virtues
 aliases:
-  - /2023/08/26/three-virtues.html
+- /2023/08/26/three-virtues.html
+categories:
+- philosophy
+tags:
+- programming
+- humor
+- craft
 ---
 author: DominicusIn
 

--- a/content/blog/2023-12-16-alternative-internet.md
+++ b/content/blog/2023-12-16-alternative-internet.md
@@ -1,9 +1,16 @@
 ---
 title: Alternative Internet
-date: "2023-12-16T02:40:00.000Z"
+date: '2023-12-16T02:40:00.000Z'
 slug: alternative-internet
 aliases:
-  - /2023/12/16/alternative-internet.html
+- /2023/12/16/alternative-internet.html
+categories:
+- web
+tags:
+- decentralization
+- privacy
+- networks
+- awesome-list
 ---
 author: DominicusIn
 

--- a/content/blog/2024-10-23-gist-lists.md
+++ b/content/blog/2024-10-23-gist-lists.md
@@ -1,14 +1,15 @@
 ---
 title: lists
-date: "2024-10-23T11:15:44.000Z"
+date: '2024-10-23T11:15:44.000Z'
 slug: gist-lists
 aliases:
-  - /2024/10/23/gist-lists.html
+- /2024/10/23/gist-lists.html
 categories:
-  - gist
+- notes
 tags:
-  - gist
-  - code
+- gist
+- code
+- cli
 gist_id: 4d2dd71dbda592ec3e974f895d9629b6
 gist_url: https://gist.github.com/dominicusin/4d2dd71dbda592ec3e974f895d9629b6
 ---

--- a/content/blog/2025-01-24-gist-chroot.md
+++ b/content/blog/2025-01-24-gist-chroot.md
@@ -1,14 +1,16 @@
 ---
 title: chroot
-date: "2025-01-24T09:46:30.000Z"
+date: '2025-01-24T09:46:30.000Z'
 slug: gist-chroot
 aliases:
-  - /2025/01/24/gist-chroot.html
+- /2025/01/24/gist-chroot.html
 categories:
-  - gist
+- notes
 tags:
-  - gist
-  - code
+- gist
+- code
+- chroot
+- linux
 gist_id: 8402abedb4df49c2852ce150f03a5372
 gist_url: https://gist.github.com/dominicusin/8402abedb4df49c2852ce150f03a5372
 ---

--- a/content/blog/2025-02-07-gist-zpool-create.md
+++ b/content/blog/2025-02-07-gist-zpool-create.md
@@ -1,14 +1,16 @@
 ---
 title: zpool create
-date: "2025-02-07T16:29:56.000Z"
+date: '2025-02-07T16:29:56.000Z'
 slug: gist-zpool-create
 aliases:
-  - /2025/02/07/gist-zpool-create.html
+- /2025/02/07/gist-zpool-create.html
 categories:
-  - gist
+- notes
 tags:
-  - gist
-  - code
+- gist
+- code
+- zfs
+- storage
 gist_id: 64a2951303a20059006c99895f8a35d8
 gist_url: https://gist.github.com/dominicusin/64a2951303a20059006c99895f8a35d8
 ---

--- a/content/blog/2025-03-11-gist-gistfile1txt.md
+++ b/content/blog/2025-03-11-gist-gistfile1txt.md
@@ -1,14 +1,14 @@
 ---
 title: gistfile1 txt
-date: "2025-03-11T06:38:07.000Z"
+date: '2025-03-11T06:38:07.000Z'
 slug: gist-gistfile1txt
 aliases:
-  - /2025/03/11/gist-gistfile1txt.html
+- /2025/03/11/gist-gistfile1txt.html
 categories:
-  - gist
+- notes
 tags:
-  - gist
-  - code
+- gist
+- code
 gist_id: 09e979be90a5a188026c91453113f5fa
 gist_url: https://gist.github.com/dominicusin/09e979be90a5a188026c91453113f5fa
 ---

--- a/content/blog/2025-03-14-ai.md
+++ b/content/blog/2025-03-14-ai.md
@@ -1,9 +1,16 @@
 ---
 title: AI
-date: "2025-03-14T13:43:00.000Z"
+date: '2025-03-14T13:43:00.000Z'
 slug: ai
 aliases:
-  - /2025/03/14/ai.html
+- /2025/03/14/ai.html
+categories:
+- ai
+tags:
+- llm
+- awesome-list
+- applications
+- tools
 ---
 author: DominicusIn
 

--- a/content/blog/2025-03-27-gist-eds.md
+++ b/content/blog/2025-03-27-gist-eds.md
@@ -1,14 +1,15 @@
 ---
 title: ed's
-date: "2025-03-27T06:15:22.000Z"
+date: '2025-03-27T06:15:22.000Z'
 slug: gist-eds
 aliases:
-  - /2025/03/27/gist-eds.html
+- /2025/03/27/gist-eds.html
 categories:
-  - gist
+- notes
 tags:
-  - gist
-  - code
+- gist
+- code
+- cli
 gist_id: 9b501e765b90f223a969b1617e067222
 gist_url: https://gist.github.com/dominicusin/9b501e765b90f223a969b1617e067222
 ---

--- a/content/blog/2025-05-04-gist-flatpaks.md
+++ b/content/blog/2025-05-04-gist-flatpaks.md
@@ -1,14 +1,16 @@
 ---
 title: flatpaks
-date: "2025-05-04T04:56:00.000Z"
+date: '2025-05-04T04:56:00.000Z'
 slug: gist-flatpaks
 aliases:
-  - /2025/05/04/gist-flatpaks.html
+- /2025/05/04/gist-flatpaks.html
 categories:
-  - gist
+- notes
 tags:
-  - gist
-  - code
+- gist
+- code
+- flatpak
+- linux
 gist_id: 93445e617b848ab12e5b0a7026f25752
 gist_url: https://gist.github.com/dominicusin/93445e617b848ab12e5b0a7026f25752
 ---

--- a/content/blog/2025-07-03-gist-arch.md
+++ b/content/blog/2025-07-03-gist-arch.md
@@ -1,14 +1,16 @@
 ---
 title: arch
-date: "2025-07-03T06:54:46.000Z"
+date: '2025-07-03T06:54:46.000Z'
 slug: gist-arch
 aliases:
-  - /2025/07/03/gist-arch.html
+- /2025/07/03/gist-arch.html
 categories:
-  - gist
+- notes
 tags:
-  - gist
-  - code
+- gist
+- code
+- linux
+- arch
 gist_id: 75dc10649ef1619223938456e2f80458
 gist_url: https://gist.github.com/dominicusin/75dc10649ef1619223938456e2f80458
 ---

--- a/content/blog/2025-08-13-gist-dns.md
+++ b/content/blog/2025-08-13-gist-dns.md
@@ -1,14 +1,16 @@
 ---
 title: dns
-date: "2025-08-13T14:32:08.000Z"
+date: '2025-08-13T14:32:08.000Z'
 slug: gist-dns
 aliases:
-  - /2025/08/13/gist-dns.html
+- /2025/08/13/gist-dns.html
 categories:
-  - gist
+- notes
 tags:
-  - gist
-  - code
+- gist
+- code
+- dns
+- networking
 gist_id: df6ba9a693aef08b7cca12f751f784c7
 gist_url: https://gist.github.com/dominicusin/df6ba9a693aef08b7cca12f751f784c7
 ---

--- a/content/blog/2025-08-29-ai2.md
+++ b/content/blog/2025-08-29-ai2.md
@@ -1,9 +1,15 @@
 ---
 title: AI2
-date: "2025-08-29T20:55:00.000Z"
+date: '2025-08-29T20:55:00.000Z'
 slug: ai2
 aliases:
-  - /2025/08/29/ai2.html
+- /2025/08/29/ai2.html
+categories:
+- ai
+tags:
+- llm
+- prompting
+- ml
 ---
 author: DominicusIn
 

--- a/content/blog/2025-09-01-gist-guix0.md
+++ b/content/blog/2025-09-01-gist-guix0.md
@@ -1,14 +1,16 @@
 ---
 title: guix0
-date: "2025-09-01T05:56:11.000Z"
+date: '2025-09-01T05:56:11.000Z'
 slug: gist-guix0
 aliases:
-  - /2025/09/01/gist-guix0.html
+- /2025/09/01/gist-guix0.html
 categories:
-  - gist
+- systems
 tags:
-  - gist
-  - code
+- gist
+- code
+- guix
+- linux
 gist_id: ee9fed0beea74d3e265dc93a53772a53
 gist_url: https://gist.github.com/dominicusin/ee9fed0beea74d3e265dc93a53772a53
 ---

--- a/content/blog/2025-09-03-gist-channelsscm.md
+++ b/content/blog/2025-09-03-gist-channelsscm.md
@@ -1,14 +1,16 @@
 ---
 title: channels.scm
-date: "2025-09-03T08:08:12.000Z"
+date: '2025-09-03T08:08:12.000Z'
 slug: gist-channelsscm
 aliases:
-  - /2025/09/03/gist-channelsscm.html
+- /2025/09/03/gist-channelsscm.html
 categories:
-  - gist
+- notes
 tags:
-  - gist
-  - code
+- gist
+- code
+- scheme
+- plan9
 gist_id: a94364c9e2c9e742d0c94dc58a706361
 gist_url: https://gist.github.com/dominicusin/a94364c9e2c9e742d0c94dc58a706361
 ---

--- a/content/blog/2025-10-14-logiki.md
+++ b/content/blog/2025-10-14-logiki.md
@@ -1,9 +1,15 @@
 ---
 title: λογική
-date: "2025-10-14T04:35:00.000Z"
+date: '2025-10-14T04:35:00.000Z'
 slug: logiki
 aliases:
-  - /2025/10/14/logiki.html
+- /2025/10/14/logiki.html
+categories:
+- philosophy
+tags:
+- logic
+- reasoning
+- essay
 ---
 author: DominicusIn
 

--- a/content/blog/2025-10-20-epistula-ad-programmatorum.md
+++ b/content/blog/2025-10-20-epistula-ad-programmatorum.md
@@ -1,9 +1,15 @@
 ---
 title: Epistula ad Programmatorum
-date: "2025-10-19T21:10:00.000Z"
+date: '2025-10-19T21:10:00.000Z'
 slug: epistula-ad-programmatorum
 aliases:
-  - /2025/10/20/epistula-ad-programmatorum.html
+- /2025/10/20/epistula-ad-programmatorum.html
+categories:
+- philosophy
+tags:
+- craft
+- programming
+- essay
 ---
 author: DominicusIn
 

--- a/content/blog/2025-10-30-unrestricted-ai-tools.md
+++ b/content/blog/2025-10-30-unrestricted-ai-tools.md
@@ -1,9 +1,16 @@
 ---
 title: Unrestricted AI Tools
-date: "2025-10-29T23:04:00.000Z"
+date: '2025-10-29T23:04:00.000Z'
 slug: unrestricted-ai-tools
 aliases:
-  - /2025/10/30/unrestricted-ai-tools.html
+- /2025/10/30/unrestricted-ai-tools.html
+categories:
+- ai
+tags:
+- llm
+- awesome-list
+- tools
+- nsfw
 ---
 author: DominicusIn
 

--- a/content/blog/2025-11-02-yet-another-list-of-movies.md
+++ b/content/blog/2025-11-02-yet-another-list-of-movies.md
@@ -1,9 +1,14 @@
 ---
 title: YA movies's list
-date: "2025-11-02T01:46:00.000Z"
+date: '2025-11-02T01:46:00.000Z'
 slug: yet-another-list-of-movies
 aliases:
-  - /2025/11/02/yet-another-list-of-movies.html
+- /2025/11/02/yet-another-list-of-movies.html
+categories:
+- media
+tags:
+- movies
+- awesome-list
 ---
 author: DominicusIn
 

--- a/content/blog/2025-12-23-awesome-plan9.md
+++ b/content/blog/2025-12-23-awesome-plan9.md
@@ -1,9 +1,15 @@
 ---
 title: Awesome Plan9
-date: "2025-12-23T09:37:00.000Z"
+date: '2025-12-23T09:37:00.000Z'
 slug: awesome-plan9
 aliases:
-  - /2025/12/23/awesome-plan9.html
+- /2025/12/23/awesome-plan9.html
+categories:
+- systems
+tags:
+- plan9
+- awesome-list
+- operating-systems
 ---
 author: DominicusIn
 

--- a/content/blog/2025-12-29-graph.md
+++ b/content/blog/2025-12-29-graph.md
@@ -1,9 +1,15 @@
 ---
 title: Graph
-date: "2025-12-29T20:01:00.000Z"
+date: '2025-12-29T20:01:00.000Z'
 slug: graph
 aliases:
-  - /2025/12/29/graph.html
+- /2025/12/29/graph.html
+categories:
+- web
+tags:
+- knowledge-graph
+- visualization
+- meta
 ---
 
 The interactive knowledge graph has moved to a dedicated, fully-functional

--- a/content/blog/2026-08-15-decentralized-governance-commit-reveal.md
+++ b/content/blog/2026-08-15-decentralized-governance-commit-reveal.md
@@ -1,16 +1,19 @@
 ---
-title: "Децентрализованное управление: commit-reveal голосование и таймлоки"
-date: "2026-08-14T18:00:00.000Z"
+title: 'Децентрализованное управление: commit-reveal голосование и таймлоки'
+date: '2026-08-14T18:00:00.000Z'
 slug: decentralized-governance-commit-reveal
 aliases:
-  - /2026/08/15/decentralized-governance-commit-reveal.html
+- /2026/08/15/decentralized-governance-commit-reveal.html
 categories:
-  - devops
+- dao
 tags:
-  - architecture
-  - security
-  - ai-agents
-description: "Как устроен смарт-контракт DAO в этом репозитории: токен голосования с капом, soulbound-репутация, commit-reveal схема против фронтраннинга и двухдневный таймлок перед исполнением."
+- smart-contracts
+- governance
+- commit-reveal
+- solidity
+description: 'Как устроен смарт-контракт DAO в этом репозитории: токен голосования
+  с капом, soulbound-репутация, commit-reveal схема против фронтраннинга и двухдневный
+  таймлок перед исполнением.'
 ---
 author: DominicusIn
 

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,8 +1,13 @@
 ---
-title: "Blog"
-description: "Engineering blog & decentralized web notes by Dominicus In."
+title: Blog
+description: Engineering blog & decentralized web notes by Dominicus In.
 aliases:
-  - /posts/
+- /posts/
+categories:
+- notes
+tags:
+- meta
+- about
 ---
 author: DominicusIn
 

--- a/docs/TAXONOMY.md
+++ b/docs/TAXONOMY.md
@@ -1,0 +1,60 @@
+# Site Ontology & Taxonomy
+
+This document defines the controlled vocabulary used to classify every page on
+`dominicusin.github.io`. It is the conceptual backbone of the
+[Knowledge Graph](../knowledge-graph/) and the `/categories/` + `/tags/` hubs.
+
+## Model
+
+```
+Domain (category)  ──subsumes──▶  Topic (tag)
+        │                              │
+        └────────── relatedTo ─────────┘   (cross-domain links)
+                  Post ──tagged──▶ Topic
+                  Post ──filed───▶ Domain
+```
+
+- **Category** = top-level *content domain* — what kind of artifact this is.
+  Each post carries **exactly one** category (a few cross-domain posts get two).
+- **Tag** = cross-cutting *topic / technology / theme* — a post carries **2–4**.
+  Tags are shared across categories, which is what makes the graph connect.
+- **Relations** (expressed in the Knowledge Graph):
+  - `category → subsumes → tag` (a domain owns the topics that live inside it)
+  - `post → tagged → tag`, `post → filed → category`
+  - `category → relatedTo → category` (manual, high-level bridges)
+
+## Categories (domains)
+
+| Key | RU label | Scope |
+|-----|----------|-------|
+| `notes` | Заметки | Personal/sysadmin working notes, workstation setup, gists, how-tos |
+| `links` | Подборки ссылок | Curated link collections / awesome-lists / resource roundups |
+| `security` | Безопасность | Privacy, cryptography, anonymity, threat modeling |
+| `ai` | ИИ | AI/ML tools, applications, prompting |
+| `systems` | Системы | OS, distributed systems, Plan9, low-level, networking |
+| `web` | Веб | Web dev, self-hosting, decentralization, tunneling |
+| `career` | Карьера | CV, interviews, professional development |
+| `philosophy` | Философия | Essays on logic, practice, craft |
+| `dao` | DAO | Decentralized governance / smart contracts (engineering focus) |
+| `media` | Медиа | Movies / books lists |
+
+## Tags (topics)
+
+Tags are technology / theme facets. The canonical set grows as content does, but
+the stable core is:
+
+`linux` · `macos` · `windows` · `networking` · `self-hosting` · `privacy` ·
+`tor` · `cryptography` · `ml` · `llm` · `prompting` · `plan9` · `neovim` ·
+`devops` · `interview` · `awesome-list` · `decentralization` ·
+`smart-contracts` · `governance` · `commit-reveal` · `books` · `movies` ·
+`productivity` · `automation` · `free-resources`
+
+## Applying the vocabulary
+
+- Posts are classified by editing their front matter (`categories:`, `tags:`).
+- The Knowledge Graph generator (`scripts/build-knowledge-graph.cjs`) turns
+  every category and tag into a `concept` node and draws `subsumes` edges from
+  each category to the tags that appear inside its posts — so the concept layer
+  is a real hierarchy, not just co-occurrence.
+- `docs/ROADMAP_STATUS.md` tracks coverage; the goal is **0 posts without a
+  category and ≤ 1 tag**.

--- a/scripts/build-knowledge-graph.cjs
+++ b/scripts/build-knowledge-graph.cjs
@@ -84,6 +84,35 @@ if (fs.existsSync(POSTS_DIR)) {
   }
 }
 
+// --- Ontology: category subsumes its tags (concept hierarchy) ---
+// For each post, every tag is "owned" by the post's category(-ies). We draw a
+// `subsumes` edge from each category concept to every tag concept that appears
+// under it. This turns the concept layer into a real hierarchy instead of pure
+// co-occurrence, and is what makes the Knowledge Graph an ontology view.
+const catTags = {}; // catId -> Set(tagId)
+for (const [pid, cs] of Object.entries(postConcept)) {
+  const cats = cs.filter(c => c.startsWith('cat:'));
+  const tags = cs.filter(c => c.startsWith('tag:'));
+  for (const cat of cats) {
+    catTags[cat] = catTags[cat] || new Set();
+    tags.forEach(t => catTags[cat].add(t));
+  }
+}
+for (const [cat, tags] of Object.entries(catTags)) {
+  tags.forEach(t => addEdge(cat, t, 'subsumes'));
+}
+
+// --- Ontology: cross-domain bridges (manual, high-level) ---
+const bridges = [
+  ['cat:security', 'cat:web'],
+  ['cat:systems', 'cat:web'],
+  ['cat:ai', 'cat:security'],
+  ['cat:dao', 'cat:web'],
+  ['cat:philosophy', 'cat:career'],
+  ['cat:systems', 'cat:dao'],
+];
+bridges.forEach(([a, b]) => addEdge(a, b, 'relatedTo'));
+
 // --- Concept co-occurrence ---
 const conceptPosts = {};
 for (const [pid, cs] of Object.entries(postConcept)) cs.forEach(c => { (conceptPosts[c] = conceptPosts[c] || []).push(pid); });

--- a/static/js/knowledge-graph.js
+++ b/static/js/knowledge-graph.js
@@ -75,7 +75,12 @@
     wrap.appendChild(stage);
 
     var legend = el('div', 'kg-legend');
-    types.forEach(function (t) { var i = el('span', 'kg-leg'); i.style.background = COLORS[t]; i.appendChild(el('span', null, LABELS[t])); legend.appendChild(i); });
+    types.forEach(function (t) {
+      var i = el('span', 'kg-leg');
+      var sw = el('span', 'kg-leg-dot'); sw.style.background = COLORS[t];
+      i.appendChild(sw); i.appendChild(el('span', 'kg-leg-label', LABELS[t]));
+      legend.appendChild(i);
+    });
     wrap.appendChild(legend);
 
     var width = Math.max(320, svgHost.clientWidth || svgHost.getBoundingClientRect().width || 800);
@@ -91,7 +96,7 @@
     svg.call(zoom);
 
     var link = g.append('g').attr('stroke', 'var(--kg-edge, rgba(148,163,184,.35))').attr('stroke-width', 1)
-      .selectAll('line').data(links).join('line').attr('class', 'kg-edge');
+      .selectAll('line').data(links).join('line').attr('class', 'kg-edge').attr('data-type', function (l) { return l.type; });
 
     var node = g.append('g').selectAll('g').data(nodes).join('g').attr('class', 'kg-node');
     node.append('circle')
@@ -107,9 +112,9 @@
       .attr('data-type', function (d) { return d.type; });
 
     var sim = d3.forceSimulation(nodes)
-      .force('link', d3.forceLink(links).id(function (d) { return d.id; }).distance(function (l) { return 90 + (Math.min((byId[l.source.id || l.source] || {}).weight || 2, (byId[l.target.id || l.target] || {}).weight || 2)) * 6; }).strength(0.2))
-      .force('charge', d3.forceManyBody().strength(-380))
-      .force('collide', d3.forceCollide(function (d) { return 20 + (d.weight || 2) * 2.8; }))
+      .force('link', d3.forceLink(links).id(function (d) { return d.id; }).distance(function (l) { return 110 + (Math.min((byId[l.source.id || l.source] || {}).weight || 2, (byId[l.target.id || l.target] || {}).weight || 2)) * 7; }).strength(0.15))
+      .force('charge', d3.forceManyBody().strength(-640).distanceMax(900))
+      .force('collide', d3.forceCollide(function (d) { return 26 + (d.weight || 2) * 3; }))
       .on('tick', ticked);
 
     function liveSize() {


### PR DESCRIPTION
Documented a 10-category / 76-tag controlled vocabulary (docs/TAXONOMY.md) and applied it to all 59 posts (0 now lack a category). KG generator now draws category→tag subsumes + cross-domain bridges, turning the concept layer into a real hierarchy (151 nodes / 467 edges). Tuned layout + fixed legend. Build clean, links 0 broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a documented taxonomy for organizing posts by categories and tags.
  - Improved knowledge graph relationships, including category-to-topic connections and related cross-domain concepts.
  - Enhanced the graph legend with clearer labels and visual indicators.
  - Added richer post classification across technology, security, media, productivity, AI, and other topics.

- **Improvements**
  - Refined graph layout, edge visibility, highlighting, spacing, and collision behavior for easier exploration.
  - Standardized post metadata formatting and expanded categorization across the blog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->