### PR TITLE
feat(performance): load 128KB CSS non-render-blocking

### DIFF
--- a/.beads/beads.json
+++ b/.beads/beads.json
@@ -29,7 +29,9 @@
     { "id": "T23", "kind": "task", "title": "Audit built site: root-cause LCP bottleneck (asset sizes, render-blocking JS/CSS, inline scripts)", "status": "done", "deps": [], "artifacts": ["layouts/partials/head.html"], "verified": "9 head scripts, 8 were render-blocking; no hero image; CSS already bundled", "initiative": "performance" },
     { "id": "T24", "kind": "task", "title": "Defer non-critical JS (appearance/a11y/zenMode/zoom) off critical path via head.html override", "status": "done", "deps": ["T23"], "artifacts": ["layouts/partials/head.html"], "verified": "head scripts: 9→1 non-deferred (JSON-LD/config only, non-executable)", "initiative": "performance" },
     { "id": "T25", "kind": "task", "title": "Optimize critical CSS/hero if needed; reduce critical-path budget (measure before/after)", "status": "done", "deps": ["T23", "T24"], "verified": "no hero image; CSS single minified bundle; no further action", "initiative": "performance" },
-    { "id": "T26", "kind": "task", "title": "Commit + PR + gh pr merge --admin for performance", "status": "done", "deps": ["T25"], "pr": 111, "merged": "0e964181f", "initiative": "performance" }
+    { "id": "T26", "kind": "task", "title": "Commit + PR + gh pr merge --admin for performance", "status": "done", "deps": ["T25"], "pr": 111, "merged": "0e964181f", "initiative": "performance" },
+    { "id": "T27", "kind": "task", "title": "Make 128KB CSS bundle non-render-blocking (preload+onload swap, noscript fallback) in head.html override", "status": "done", "deps": ["T24"], "artifacts": ["layouts/partials/head.html"], "verified": "CSS link now rel=preload as=style + onload swap; noscript fallback present", "initiative": "performance" },
+    { "id": "T28", "kind": "task", "title": "Verify CSS still applies + build/lint/test/linkcheck green; commit+PR+admin-merge (performance CSS)", "status": "in_progress", "deps": ["T27"], "initiative": "performance" }
   ],
   "edges": [
     { "from": "T2", "to": "T3", "type": "enables" },
@@ -55,6 +57,8 @@
     { "from": "T23", "to": "T24", "type": "enables" },
     { "from": "T23", "to": "T25", "type": "feeds" },
     { "from": "T24", "to": "T25", "type": "enables" },
-    { "from": "T25", "to": "T26", "type": "blocks" }
+    { "from": "T25", "to": "T26", "type": "blocks" },
+    { "from": "T24", "to": "T27", "type": "enables" },
+    { "from": "T27", "to": "T28", "type": "blocks" }
   ]
 }

--- a/.gsd/plan.md
+++ b/.gsd/plan.md
@@ -101,3 +101,29 @@ Beads T19–T21 = `done`; T22 = `done` (merged #110 via --admin).
 
 ### Status
 Beads T23–T25 = `done`; T26 (commit+PR+merge) in_progress.
+
+---
+
+## Initiative 5 (cont.) — Phase H: CSS non-render-blocking (DONE)
+- **Re-audit after JS-defer (T24):** Lighthouse LCP still ~5.5s (perf 0.68). JS was
+  secondary. Measured the real bottleneck: **CSS bundle = 128.78 KB**, loaded as a
+  render-blocking `<link rel=stylesheet>` — browser must download+parse 129KB CSS
+  before first paint. Homepage is only 67KB HTML / 697 tags (DOM not the issue);
+  NO web fonts (system stack), NO external stylesheets, NO hero image. So the
+  paint-blocking CSS is THE LCP root cause.
+- **Fix (T27):** in `layouts/partials/head.html` override, changed the CSS `<link>`
+  to the standard non-render-blocking pattern:
+  `<link rel=preload as=style onload="this.rel='stylesheet'">` + `<noscript>`
+  fallback. First paint no longer waits on the 129KB CSS; styles swap in on load
+  (modern browsers) / stay blocking for no-JS.
+- **Verify (structural, real builds):** built site → CSS link is `rel=preload
+  as=style` with onload swap + noscript fallback present; CSS bundle still emitted;
+  build 0 err; lint clean; test pass; check-links 0 broken.
+- **Honest caveat:** cannot run Lighthouse locally (no Chrome/Lighthouse binary;
+  CI Lighthouse runs on shared, throttled, noisy infra — perf 0.64–0.68 across runs).
+  The change is the correct, textbook LCP fix for a render-blocking CSS bundle, but
+  the exact Lighthouse delta must be read from the next CI Performance Monitoring run,
+  not asserted here.
+
+### Status
+Beads T27 = `done`; T28 (commit+PR+merge for CSS fix) in_progress.

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -136,11 +136,21 @@
     {{ $cssResources = $cssResources | append (resources.Get "lib/zoom/style.css") }}
   {{ end }}
   {{ $bundleCSS := $cssResources | resources.Concat "css/main.bundle.css" | resources.Minify | resources.Fingerprint $alg }}
+  {{/* Load CSS non-render-blocking: preload + swap to stylesheet on load,
+       so first paint is not blocked by the 128KB bundle. noscript keeps it
+       blocking for no-JS users (correct styling, acceptable trade-off). */}}
   <link
-    type="text/css"
-    rel="stylesheet"
+    rel="preload"
+    as="style"
     href="{{ $bundleCSS.RelPermalink }}"
-    integrity="{{ $bundleCSS.Data.Integrity }}">
+    integrity="{{ $bundleCSS.Data.Integrity }}"
+    onload="this.onload=null;this.rel='stylesheet'">
+  <noscript>
+    <link
+      rel="stylesheet"
+      href="{{ $bundleCSS.RelPermalink }}"
+      integrity="{{ $bundleCSS.Data.Integrity }}">
+  </noscript>
 
   {{/* JS deferred (was "loaded immediately" in theme — now deferred for LCP) */}}
   {{ $jsAppearance := resources.Get "js/appearance.js" | resources.ExecuteAsTemplate "js/appearance.js" . | resources.Minify | resources.Fingerprint $alg }}


### PR DESCRIPTION
## Summary
- Root-caused the real LCP bottleneck (post-JS-defer #111): the **128.78 KB CSS bundle** was loaded as a render-blocking `<link rel=stylesheet>`. The homepage is only 67KB HTML / 697 DOM nodes, uses a system font stack (no web fonts), no external stylesheets, no hero image — so the paint-blocking CSS was THE LCP cause, not JS.
- `layouts/partials/head.html` (Blowfish override) now loads CSS via the standard non-render-blocking pattern: `rel=preload as=style onload="this.rel='stylesheet'"` + `<noscript>` fallback. First paint no longer waits on the 129KB CSS.

## Verification (real builds)
- built site: CSS `<link>` is `rel=preload as=style` + onload swap; `<noscript>` fallback present; CSS bundle still emitted
- `hugo --gc --minify` → 0 errors
- `npm run lint` clean; `npm run test` ALL PASSED
- `node scripts/check-links.cjs` → 0 broken / 426 pages

## Honest caveat
No local Lighthouse binary; the exact Lighthouse LCP/perf delta must be read from the next CI Performance Monitoring run (shared infra is throttled/noisy — perf 0.64–0.68 across runs). This is the correct textbook fix for a render-blocking CSS bundle.

## Task system (strict 4-layer)
- BMAD: `.planning/initiatives/performance.md` (updated)
- Spec Kit: `.specify/performance.md`
- Beads: `.beads/beads.json` (T27–T28)
- GSD: `.gsd/plan.md` (Phase H execution + evidence)