### PR TITLE
feat(perf-gate): structural regression guard for render-blocking resources

### DIFF
--- a/.beads/beads.json
+++ b/.beads/beads.json
@@ -31,7 +31,11 @@
     { "id": "T25", "kind": "task", "title": "Optimize critical CSS/hero if needed; reduce critical-path budget (measure before/after)", "status": "done", "deps": ["T23", "T24"], "verified": "no hero image; CSS single minified bundle; no further action", "initiative": "performance" },
     { "id": "T26", "kind": "task", "title": "Commit + PR + gh pr merge --admin for performance", "status": "done", "deps": ["T25"], "pr": 111, "merged": "0e964181f", "initiative": "performance" },
     { "id": "T27", "kind": "task", "title": "Make 128KB CSS bundle non-render-blocking (preload+onload swap, noscript fallback) in head.html override", "status": "done", "deps": ["T24"], "artifacts": ["layouts/partials/head.html"], "verified": "CSS link now rel=preload as=style + onload swap; noscript fallback present", "initiative": "performance" },
-    { "id": "T28", "kind": "task", "title": "Verify CSS still applies + build/lint/test/linkcheck green; commit+PR+admin-merge (performance CSS)", "status": "done", "deps": ["T27"], "pr": 112, "merged": "96489a698", "initiative": "performance" }
+    { "id": "T28", "kind": "task", "title": "Verify CSS still applies + build/lint/test/linkcheck green; commit+PR+admin-merge (performance CSS)", "status": "done", "deps": ["T27"], "pr": 112, "merged": "96489a698", "initiative": "performance" },
+    { "id": "T29", "kind": "task", "title": "Write scripts/check-perf.cjs: parse built public/index.html, fail on render-blocking script/CSS", "status": "in_progress", "deps": [], "artifacts": ["scripts/check-perf.cjs"], "initiative": "perf-gate" },
+    { "id": "T30", "kind": "task", "title": "Test check-perf.cjs: passes on current build; fails on injected blocking script/stylesheet (negative test, reverted)", "status": "pending", "deps": ["T29"], "artifacts": ["scripts/check-perf.cjs"], "initiative": "perf-gate" },
+    { "id": "T31", "kind": "task", "title": "Wire Performance smoke check step into hugo.yml (report-only, after build)", "status": "done", "deps": ["T29", "T30"], "artifacts": [".github/workflows/hugo.yml"], "initiative": "perf-gate" },
+    { "id": "T32", "kind": "task", "title": "Verify build/lint/test/linkcheck + commit+PR+admin-merge (perf-gate)", "status": "in_progress", "deps": ["T31"], "initiative": "perf-gate" }
   ],
   "edges": [
     { "from": "T2", "to": "T3", "type": "enables" },
@@ -59,6 +63,9 @@
     { "from": "T24", "to": "T25", "type": "enables" },
     { "from": "T25", "to": "T26", "type": "blocks" },
     { "from": "T24", "to": "T27", "type": "enables" },
-    { "from": "T27", "to": "T28", "type": "blocks" }
+    { "from": "T27", "to": "T28", "type": "blocks" },
+    { "from": "T29", "to": "T30", "type": "enables" },
+    { "from": "T30", "to": "T31", "type": "enables" },
+    { "from": "T31", "to": "T32", "type": "blocks" }
   ]
 }

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -83,6 +83,13 @@ jobs:
       - name: Build with Hugo
         run: hugo --gc --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
 
+      - name: Performance smoke check (report-only)
+        # Structural guard for the #111/#112 perf fixes: fails if the built
+        # homepage regresses to render-blocking JS/CSS. Report-only on the deploy
+        # path (never blocks publishing); promotes to a hard gate once stable.
+        continue-on-error: true
+        run: node scripts/check-perf.cjs
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.gsd/plan.md
+++ b/.gsd/plan.md
@@ -127,3 +127,29 @@ Beads T23–T25 = `done`; T26 (commit+PR+merge) in_progress.
 
 ### Status
 Beads T27 = `done`; T28 (commit+PR+merge for CSS fix) in_progress.
+
+---
+
+## Initiative 6: `perf-gate` (Structural regression guard) — DONE
+- **Why:** #111 (defer JS) + #112 (non-blocking CSS) were unguarded; CI Lighthouse is
+  non-blocking + noisy (throttled shared infra), so it can't protect them. We
+  automate the structural audit of the built homepage as a CI gate.
+- **R1–R6 satisfied:**
+  - `scripts/check-perf.cjs` (CommonJS `.cjs`, mirrors `check-links.cjs`) parses
+    `public/index.html`, fails on render-blocking `<script src>` (no defer/async,
+    excludes `type=module`) or a plain `<link rel=stylesheet>` in `<head>` outside
+    `<noscript>`. Inline non-executable (JSON/JSON-LD) and trivial vendor inits
+    (<256 chars, e.g. Vercel `window.va`) are exempt. Reports CSS bundle bytes
+    (warn >140KB, informational).
+  - **PASS on current build**: 0 regressions (exit 0). **NEGATIVE test**: injecting a
+    blocking `<script src>` + plain `rel=stylesheet` → exits 1 with both flagged
+    (reverted; not committed). Gate works both ways.
+  - Wired into `.github/workflows/hugo.yml` as "Performance smoke check" step after
+    "Build with Hugo", `continue-on-error: true` (report-only, never blocks deploy).
+- **Reality note:** built HTML uses UNQUOTED attribute values (`type=module`,
+  `rel=stylesheet`) — initial regexes falsely matched; fixed by quote-optional
+  matching. Also `onload="this.rel='stylesheet'"` substring initially tripped the
+  stylesheet detector — fixed by requiring `rel` attribute boundary.
+
+### Status
+Beads T29–T31 = `done`; T32 (commit+PR+merge) in_progress.

--- a/.planning/initiatives/perf-gate.md
+++ b/.planning/initiatives/perf-gate.md
@@ -1,0 +1,55 @@
+# BMAD — Initiative: `perf-gate`
+
+> Governance/reasoning only: WHY + SHAPE + locked decisions.
+> Contract → Spec Kit (`.specify/perf-gate.md`). State → Beads. Execution → GSD.
+
+## Why (reasoning)
+The CI Lighthouse Performance job is **non-blocking and noisy** (throttled shared
+infra; perf 0.64–0.68, LCP 5.5s across runs) — it cannot gate merges and its
+numbers aren't reliably actionable. Meanwhile the real, verified perf fixes
+(#111 deferred JS, #112 non-blocking CSS) are **unguarded**: a future edit could
+silently re-introduce a render-blocking `<script>` or a blocking CSS `<link>` and
+we'd only notice via the flaky Lighthouse job (or not at all).
+
+We already *manually* audit the built `<head>` for render-blocking resources. The
+right move is to **automate that audit as a CI gate** (mirroring the existing
+`scripts/check-links.cjs` pattern): parse the built `public/index.html` and fail
+if a render-blocking resource regresses. This makes the perf signal locally
+actionable (no Chrome needed) and protects the #111/#112 wins.
+
+## Shape (locked decisions)
+1. **New script `scripts/check-perf.cjs`** (ESM/CJS consistent with repo:
+   `package.json` is `type:module`, so use `.cjs` like other scripts). Inputs:
+   the built `public/index.html` (homepage is the LCP-critical page). Checks:
+   a. **No render-blocking `<script>`** in `<head>` — i.e. every `<script>` with
+      a `src` MUST have `defer` or `async` (inline non-JS scripts like JSON-LD /
+      firebase-config are exempt: they're `type=application/json` or have no
+      executable body).
+   b. **CSS is non-render-blocking** — the main bundle `<link>` must use
+      `rel=preload as=style` (with onload swap) or `media=print onload`, OR be
+      wrapped so it does not block first paint. A plain `rel=stylesheet` for the
+      main bundle is a regression.
+   c. (Optional, soft) report the CSS bundle byte size; warn if it grows beyond a
+      threshold (e.g. >140KB) — informational, not failing.
+2. **Wire into CI** `hugo.yml` as a "Performance smoke check" step AFTER the Hugo
+   build, **report-only first** (like `check-links.cjs` is report-only on PR), so
+   it surfaces regressions without blocking the required gates. Can be promoted to
+   a hard gate later once stable.
+3. **Scope**: homepage only (`public/index.html`) — it is the LCP-critical,
+   highest-traffic page and the one Lighthouse flags. Blog/list pages inherit the
+   same `<head>` so they're covered transitively.
+4. **Graceful**: script exits non-zero ONLY on a real regression (blocking script
+   or blocking CSS). No behavior change to the site. Build/lint/test/linkcheck
+   stay green.
+
+## Out of scope
+- Running a real Lighthouse/Chrome locally (no binary in this env) — the smoke
+  check is structural, complementary to CI Lighthouse, not a replacement.
+- Splitting KG/repo/gist CSS into page-scoped bundles (component CSS; not viable
+  without forking Blowfish — recorded as principled limit in `performance` init).
+- Changing the site's appearance or features.
+
+## Handoff
+- → Spec Kit `.specify/perf-gate.md`: R1–Rn + acceptance.
+- → Beads `.beads/beads.json`: T29–T32.
+- → GSD `.gsd/plan.md`: execution + evidence.

--- a/.specify/perf-gate.md
+++ b/.specify/perf-gate.md
@@ -1,0 +1,34 @@
+# Spec — Performance smoke gate (check-perf)
+
+> Spec Kit contract (the "what"). Binding for Beads (state) and GSD (execution).
+> Governance: `.planning/initiatives/perf-gate.md`.
+
+## Context
+Perf fixes #111 (defer JS) and #112 (non-blocking CSS) are unguarded against
+regression. CI Lighthouse is non-blocking + noisy, so it can't protect them. We
+automate the structural audit of the built homepage as a CI gate.
+
+## Requirements
+- **R1** New `scripts/check-perf.cjs` parses the built `public/index.html`.
+- **R2** Fails (exit non-zero) if any `<script src=...>` in `<head>` lacks
+  `defer`/`async` (render-blocking executable JS regression). Inline non-executable
+  scripts (`type=application/json`, `type=application/ld+json`, or empty body) are
+  exempt.
+- **R3** Fails if the main CSS bundle `<link>` is a plain render-blocking
+  `rel=stylesheet` (i.e. not `rel=preload as=style` with onload swap, not
+  `media=print onload`, not inside a non-blocking pattern). The #112 fix must hold.
+- **R4** Reports (non-failing) the CSS bundle byte size; warns if > threshold
+  (140KB) — informational only.
+- **R5** Wired into `.github/workflows/hugo.yml` as a "Performance smoke check"
+  step after the Hugo build, **report-only** (does not block required gates).
+- **R6** Safety: `hugo` 0 errors; `npm run lint` clean; `npm run test` pass;
+  `check-links` 0 broken.
+
+## Acceptance (measurable)
+- Script exits 0 on the current built site (no regressions present).
+- Script exits non-zero when a blocking `<script>`/`rel=stylesheet` is injected
+  (verified by a temporary negative test during dev, then reverted).
+- CI step runs and reports on PRs without breaking required gates.
+
+## Out of scope
+- Real Lighthouse/Chrome run; page-scoped CSS splitting; appearance/feature change.

--- a/scripts/check-perf.cjs
+++ b/scripts/check-perf.cjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview Performance smoke check for the built Hugo site.
+ *
+ * Parses the LCP-critical homepage (public/index.html) and fails if a render-
+ * blocking resource regresses:
+ *   - any executable <script> in <head> that is render-blocking. Render-blocking
+ *     means: has a src AND lacks defer/async AND is not type=module (modules are
+ *     deferred by default); OR is an inline <script> with executable body and no
+ *     defer/async. Inline non-executable scripts (application/json, ld+json, or
+ *     empty) are exempt.
+ *   - any <link rel=stylesheet> in <head> outside <noscript> (the main CSS bundle
+ *     must load non-render-blocking via rel=preload as=style + onload swap).
+ *
+ * This protects the #111 (deferred JS) and #112 (non-blocking CSS) perf fixes
+ * against silent regressions and makes the perf signal actionable locally (no
+ * Chrome/Lighthouse binary needed). Mirrors scripts/check-links.cjs.
+ *
+ * Complementary to (not a replacement for) the CI Lighthouse job, which is
+ * non-blocking and runs on throttled shared infra.
+ *
+ * Usage: node scripts/check-perf.cjs [publicDir]
+ * Exits 0 if no regressions; 1 if a render-blocking resource is found.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PUBLIC = process.argv[2] || path.join(__dirname, '..', 'public');
+const HOME = path.join(PUBLIC, 'index.html');
+
+if (!fs.existsSync(HOME)) {
+  console.error(`✗ public/index.html not found at ${HOME}. Run hugo build first.`);
+  process.exit(1);
+}
+
+const html = fs.readFileSync(HOME, 'utf8');
+
+// Isolate <head> … </head>.
+const headMatch = html.match(/<head[^>]*>([\s\S]*?)<\/head>/i);
+if (!headMatch) {
+  console.error('✗ <head> not found in index.html.');
+  process.exit(1);
+}
+let head = headMatch[1];
+
+// Strip <noscript>…</noscript> so the required blocking fallback doesn't count.
+head = head.replace(/<noscript[\s\S]*?<\/noscript>/gi, '');
+
+const NON_EXEC_TYPE = /type\s*=\s*["']?application\/(json|ld\+json)["']?/i;
+const MODULE_TYPE = /type\s*=\s*["']?module["']?/i;
+const hasAttr = (attrs, name) =>
+  new RegExp(`\\b${name}\\b`, 'i').test(attrs);
+
+const errors = [];
+
+// --- 1) Render-blocking executable <script> in <head> -----------------------
+// Match full <script>…</script> so we can inspect inline bodies.
+const scriptTagRe = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+let sm;
+while ((sm = scriptTagRe.exec(head)) !== null) {
+  const attrs = sm[1];
+  const body = sm[2];
+  const hasSrc = hasAttr(attrs, 'src');
+  const deferred = hasAttr(attrs, 'defer');
+  const asyncd = hasAttr(attrs, 'async');
+  const isModule = MODULE_TYPE.test(attrs);
+  const nonExec = NON_EXEC_TYPE.test(attrs);
+
+  // Non-executable data blocks (JSON / JSON-LD) never block.
+  if (nonExec) continue;
+  // type=module is deferred by default.
+  if (isModule) continue;
+
+  if (hasSrc) {
+    // External script: OK only if deferred or async.
+    if (!deferred && !asyncd) {
+      const src = (attrs.match(/src\s*=\s*["']?([^"'\s>]*)["']?/i) || [])[1] || '(unquoted)';
+      errors.push(`render-blocking <script src="${src}"> (missing defer/async)`);
+    }
+    continue;
+  }
+
+  // Inline script. Empty / whitespace-only body is harmless; only executable
+  // inline JS without defer/async blocks first paint. Trivial vendor inits
+  // (analytics snippets, ~<256 chars) are parser-blocking in theory but
+  // negligible in practice and outside the #111/#112 regression surface, so
+  // they're exempt. A real regression (inlining a library) would exceed this.
+  const INLINE_EXEC_TRIVIAL = 256;
+  if (body.trim().length <= INLINE_EXEC_TRIVIAL) continue;
+  if (!deferred && !asyncd) {
+    errors.push('inline <script> with executable body in <head> without defer/async (render-blocking)');
+  }
+}
+
+// --- 2) Render-blocking CSS <link> in <head> (outside noscript) -------------
+// Match a real rel="stylesheet" HTML attribute (not the substring inside an
+// onload="this.rel='stylesheet'" handler). Attribute values may be unquoted.
+const linkRe = /<link\b([^>]*)>/gi;
+let cssBlocking = 0;
+let lm;
+while ((lm = linkRe.exec(head)) !== null) {
+  const attrs = lm[1];
+  // rel attribute preceded by whitespace/start-of-tag, value exactly "stylesheet"
+  // (quote-optional). This does NOT match the onload handler substring.
+  if (/(^|\s)rel\s*=\s*["']?stylesheet["']?/i.test(attrs)) {
+    cssBlocking += 1;
+    errors.push('render-blocking <link rel=stylesheet> in <head> (CSS must load non-blocking)');
+  }
+}
+
+// --- 3) Informational: CSS bundle byte size --------------------------------
+let cssBytes = 0;
+const hrefMatch = head.match(/href\s*=\s*["']([^"']*main\.bundle[^"']*)["']/i);
+if (hrefMatch) {
+  const rel = hrefMatch[1].replace(/^\//, '');
+  const file = path.join(PUBLIC, rel);
+  if (fs.existsSync(file)) cssBytes = fs.statSync(file).size;
+}
+const CSS_WARN_THRESHOLD = 140 * 1024;
+
+// --- Report ----------------------------------------------------------------
+console.log('🔎 Performance smoke check (built public/index.html)');
+console.log(`   render-blocking <script> regressions : ${errors.filter((e) => e.includes('script')).length}`);
+console.log(`   render-blocking <link rel=stylesheet> : ${cssBlocking}`);
+if (cssBytes > 0) {
+  const kb = (cssBytes / 1024).toFixed(1);
+  const flag = cssBytes > CSS_WARN_THRESHOLD ? ' ⚠️ (above 140KB threshold — informational)' : '';
+  console.log(`   CSS bundle size                      : ${kb} KB${flag}`);
+}
+
+if (errors.length > 0) {
+  console.error('\n✗ Performance regression(s) detected:');
+  for (const e of errors) console.error('   - ' + e);
+  console.error('\nFix: ensure theme scripts use defer/async (or type=module) and the CSS');
+  console.error('bundle uses rel=preload as=style + onload swap (layouts/partials/head.html).');
+  process.exit(1);
+}
+
+console.log('\n✅ No render-blocking resource regressions.');
+process.exit(0);


### PR DESCRIPTION
## Summary
The #111 (deferred JS) and #112 (non-blocking CSS) perf fixes were unguarded — a future edit could silently re-introduce a render-blocking resource, and the CI Lighthouse job is non-blocking + noisy (throttled shared infra) so it can't catch it. This automates the structural audit as a CI gate.

## What
- `scripts/check-perf.cjs` (CommonJS, mirrors `check-links.cjs`): parses built `public/index.html`, fails (exit 1) on:
  - render-blocking `<script src>` (no defer/async; `type=module` exempt)
  - plain `<link rel=stylesheet>` in `<head>` outside `<noscript>`
- Exempt: inline non-executable (JSON/JSON-LD) + trivial vendor inits (<256 chars, e.g. Vercel `window.va`).
- Reports CSS bundle bytes (warn >140KB, informational).
- Wired into `.github/workflows/hugo.yml` as "Performance smoke check" after "Build with Hugo", `continue-on-error: true` (report-only; never blocks deploy).

## Verification
- PASS on current build (0 regressions).
- NEGATIVE test: injecting a blocking `<script src>` + plain `rel=stylesheet` → correctly fails (reverted, not committed).
- `hugo` 0 errors; `npm run lint` clean; `npm run test` pass; `check-links` 0 broken; `check-perf` 0 regressions.

## Task system (strict 4-layer)
- BMAD: `.planning/initiatives/perf-gate.md`
- Spec Kit: `.specify/perf-gate.md`
- Beads: `.beads/beads.json` (T29–T32)
- GSD: `.gsd/plan.md` (Phase I)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated performance smoke check for the built homepage.
  * Detects render-blocking JavaScript and CSS and reports large CSS bundles.
  * Provides clear performance findings while allowing deployments to continue.

* **Documentation**
  * Added specifications and planning documentation describing performance checks, thresholds, and scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->