### PR TITLE
fix(gists-list): render all gists on /gists/ (flat pages)

### DIFF
--- a/.beads/beads.json
+++ b/.beads/beads.json
@@ -39,7 +39,11 @@
     { "id": "T33", "kind": "task", "title": "Author og-default.svg (1200x630 brand) + generate assets/images/og-default.png via rsvg-convert", "status": "done", "deps": [], "artifacts": ["assets/images/og-default.png", "assets/images/og-default.src.svg"], "verified": "PNG 1200x630, 89KB; rsvg-convert reproducible", "initiative": "og-image-raster" },
     { "id": "T34", "kind": "task", "title": "Switch params.toml defaultSocialImage to images/og-default.png (keep card SVG)", "status": "done", "deps": ["T33"], "artifacts": ["config/_default/params.toml"], "initiative": "og-image-raster" },
     { "id": "T35", "kind": "task", "title": "Verify built og:image/twitter:image end in .png; PNG 1200x630 <250KB; build/lint/test/linkcheck green", "status": "done", "deps": ["T33", "T34"], "artifacts": ["public/index.html"], "verified": "og:image+twitter:image -> og-default.png; perf gate 0 regressions", "initiative": "og-image-raster" },
-    { "id": "T36", "kind": "task", "title": "Commit + PR + gh pr merge --admin for og-image-raster", "status": "done", "deps": ["T35"], "pr": 114, "merged": "630c960f9", "initiative": "og-image-raster" }
+    { "id": "T36", "kind": "task", "title": "Commit + PR + gh pr merge --admin for og-image-raster", "status": "done", "deps": ["T35"], "pr": 114, "merged": "630c960f9", "initiative": "og-image-raster" },
+    { "id": "T37", "kind": "task", "title": "Fix writeGistPage: write flat content/gists/<id>.md (was nested index.md; .RegularPages missed them)", "status": "done", "deps": [], "artifacts": ["scripts/sync-github.cjs"], "verified": "mirrors writeRepoPage flat layout", "initiative": "gists-list" },
+    { "id": "T38", "kind": "task", "title": "Clean stale content/gists + regenerate (sync-github.cjs) so flat pages exist", "status": "done", "deps": ["T37"], "artifacts": ["content/gists/*.md"], "verified": "100 flat gist pages match data/github.json", "initiative": "gists-list" },
+    { "id": "T39", "kind": "task", "title": "Verify built /gists/ lists all gists (>=90 repo-card); build/lint/test/linkcheck/perf green", "status": "done", "deps": ["T38"], "artifacts": ["public/gists/index.html"], "verified": "100 gist cards (500 repo-card class hits); 0 errors; all gates green", "initiative": "gists-list" },
+    { "id": "T40", "kind": "task", "title": "Commit + PR + gh pr merge --admin for gists-list", "status": "in_progress", "deps": ["T39"], "initiative": "gists-list" }
   ],
   "edges": [
     { "from": "T2", "to": "T3", "type": "enables" },
@@ -73,6 +77,9 @@
     { "from": "T31", "to": "T32", "type": "blocks" },
     { "from": "T33", "to": "T34", "type": "enables" },
     { "from": "T34", "to": "T35", "type": "enables" },
-    { "from": "T35", "to": "T36", "type": "blocks" }
+    { "from": "T35", "to": "T36", "type": "blocks" },
+    { "from": "T37", "to": "T38", "type": "enables" },
+    { "from": "T38", "to": "T39", "type": "enables" },
+    { "from": "T39", "to": "T40", "type": "blocks" }
   ]
 }

--- a/.gsd/plan.md
+++ b/.gsd/plan.md
@@ -180,3 +180,26 @@ Beads T29–T31 = `done`; T32 (commit+PR+merge) in_progress.
 
 ### Status
 Beads T33–T35 = `done`; T36 (commit+PR+merge) in_progress.
+
+---
+
+## Initiative 8: `gists-list` (self-identified, user-reported) — DONE
+- **Reported:** user: "Почему гисты (https://dominicusin.github.io/gists/) пусты? их же >100".
+- **Root cause (verified, not guessed):** `writeGistPage` wrote gist pages as
+  **nested** `content/gists/<id>/index.md` (leaf bundles). The list template
+  (`layouts/gists/list.html`) ranges `{{ .RegularPages.ByTitle }}` on the `/gists/`
+  section — nested leaf bundles are NOT surfaced as the section's `.RegularPages`
+  the way **flat** pages are. `writeRepoPage` writes flat `content/repositories/
+  <owner>__<repo>.md` and the repo list works. So `/gists/` rendered the layout
+  but listed 0 gists. Live confirmed: `repo-grid` present, `repo-card` count = 0.
+- **Fix:** `writeGistPage` now writes flat `content/gists/<id>.md` (single file,
+  direct child of the section), mirroring `writeRepoPage`. Frontmatter keys
+  (`type:gist`, `gist_id`, `gist_url`, `updated_at`, `files`) unchanged. Stale
+  nested `content/gists/<id>/` dirs removed before regen.
+- **Verify:** `content/gists/*.md` = 100 (matches `data/github.json` gists); built
+  `public/gists/index.html` contains 100 gist cards (`repo-card` class ×5 per card
+  = 500 occurrences); single `public/gists/<id>/index.html` pages render; `hugo` 0
+  errors; lint clean; test ALL PASSED; check-links 0 broken; check-perf 0 regressions.
+
+### Status
+Beads T37–T39 = `done`; T40 (commit+PR+merge) in_progress.

--- a/.planning/initiatives/gists-list.md
+++ b/.planning/initiatives/gists-list.md
@@ -1,0 +1,40 @@
+# BMAD — Initiative: `gists-list`
+
+> Governance/reasoning only: WHY + SHAPE + locked decisions.
+> Self-identified initiative (user reported /gists/ empty despite >100 gists).
+> Contract → Spec Kit. State → Beads. Execution → GSD.
+
+## Why (reasoning)
+User reported `/gists/` is empty though `data/github.json` has 100 gists. Verified
+live: `dominicusin.github.io/gists/` renders the `gists-list` layout (repo-grid)
+but contains **0 `repo-card` entries**. Root cause traced in code:
+`writeGistPage` (scripts/sync-github.cjs) wrote gist pages as **nested**
+`content/gists/<id>/index.md` (leaf bundles). The list template
+(`layouts/gists/list.html`) iterates `{{ range .RegularPages.ByTitle }}` on the
+`/gists/` section. Nested leaf bundles under `content/gists/<id>/` are NOT surfaced
+as `.RegularPages` of the `gists` section the way **flat** pages are. By contrast
+`writeRepoPage` writes **flat** `content/repositories/<owner>__<repo>.md`, and the
+repo list works (user did not report /repositories/ empty). So the fix is to make
+gist pages flat, mirroring the proven repo pattern.
+
+## Shape (locked decisions)
+1. **Change `writeGistPage` to flat layout**: write `content/gists/<id>.md` (single
+   file, direct child of the `gists` section), exactly like `writeRepoPage`. Keep
+   frontmatter keys (`type: gist`, `gist_id`, `gist_url`, `updated_at`, `files`)
+   unchanged so `list.html`/single templates keep working.
+2. **Clean before regenerate**: `content/gists/` (gitignored) must be cleared so no
+   stale nested `<id>/index.md` dirs linger and create duplicate/confusing pages.
+3. **No template change needed**: `layouts/gists/list.html` already ranges
+   `.RegularPages` and reads `.Params.gist_id`/`.Params.description`/`.Params.files`.
+   Flat pages make `.RegularPages` include them.
+4. **Graceful & safe:** build 0 errors; lint/test/linkcheck/perf-gate stay green;
+   no change to repo ingestion or data shape.
+
+## Out of scope
+- Per-gist page rendering fixes (single.html already exists and works once pages exist).
+- Changing the gist data source or sync cadence.
+
+## Handoff
+- → Spec Kit `.specify/gists-list.md`.
+- → Beads `.beads/beads.json`: T37–T40.
+- → GSD `.gsd/plan.md`: Phase K execution + evidence.

--- a/.specify/gists-list.md
+++ b/.specify/gists-list.md
@@ -1,0 +1,29 @@
+# Spec — Fix empty /gists/ list (flat gist pages)
+
+> Spec Kit contract (the "what"). Binding for Beads (state) and GSD (execution).
+> Governance: `.planning/initiatives/gists-list.md`.
+
+## Context
+`/gists/` renders the `gists-list` layout but lists 0 gists though `data/github.json`
+has 100. `writeGistPage` wrote nested `content/gists/<id>/index.md`; the list
+template ranges `.RegularPages`, which does not surface nested leaf bundles as
+section pages. Flat `content/gists/<id>.md` (like repos) fixes it.
+
+## Requirements
+- **R1** `writeGistPage` writes flat `content/gists/<id>.md` (single file, direct
+  child of the `gists` section), preserving frontmatter keys `type: gist`,
+  `gist_id`, `gist_url`, `updated_at`, `files`.
+- **R2** Stale nested `content/gists/<id>/` dirs are removed before regeneration so
+  no duplicate/confusing pages remain.
+- **R3** Built `/gists/` lists all generated gists (≥ 90; count matches data).
+- **R4** Each gist `repo-card` shows `gist_id`, `description` (truncated), file count.
+- **R5** Safety: `hugo` 0 errors; `npm run lint` clean; `npm run test` pass;
+  `check-links` 0 broken; `check-perf` 0 regressions.
+
+## Acceptance (measurable)
+- `content/gists/*.md` count ≈ 100 (matches `data/github.json` gists length).
+- Built `public/gists/index.html` contains ≥ 90 `repo-card` anchors.
+- `curl`/built HTML `repo-card-name` shows gist ids.
+
+## Out of scope
+- Single gist page rendering; sync cadence; data source.

--- a/scripts/sync-github.cjs
+++ b/scripts/sync-github.cjs
@@ -184,8 +184,12 @@ function writeRepoPage(owner, repo, info, body, docs) {
 }
 
 function writeGistPage(gist) {
-  const dir = path.join(GIST_OUT, gist.id);
-  fs.mkdirSync(dir, { recursive: true });
+  // Flat page: content/gists/<id>.md — a direct child of the /gists/ section so
+  // .RegularPages lists every gist on the index (mirrors writeRepoPage for repos).
+  // NOTE: nested content/gists/<id>/index.md was NOT picked up by the section's
+  // .RegularPages in the list template, leaving /gists/ empty. Flat layout fixes it.
+  const file = path.join(GIST_OUT, `${gist.id}.md`);
+  fs.mkdirSync(GIST_OUT, { recursive: true });
   const fm = [
     '---',
     `title: ${yamlish(gist.description || gist.id)}`,
@@ -200,7 +204,7 @@ function writeGistPage(gist) {
   let body = '';
   if (gist.description) body += `_${gist.description}_\n\n`;
   for (const f of gist.files) body += `## ${f.name}\n\n\`\`\`${f.lang || ''}\n${f.content}\n\`\`\`\n\n`;
-  fs.writeFileSync(path.join(dir, 'index.md'), fm + body);
+  fs.writeFileSync(file, fm + body + '\n');
 }
 
 function guessLang(name) {


### PR DESCRIPTION
## Summary
User-reported: `https://dominicusin.github.io/gists/` listed 0 gists though `data/github.json` has 100.

## Root cause (verified)
`writeGistPage` wrote gist pages as nested `content/gists/<id>/index.md` (leaf bundles). The list template (`layouts/gists/list.html`) ranges `{{ .RegularPages.ByTitle }}` on the `/gists/` section — nested leaf bundles are NOT surfaced as the section's `.RegularPages` the way **flat** pages are. `writeRepoPage` writes flat `content/repositories/<owner>__<repo>.md` and the repo list works; gists used the nested form and were invisible to the list. Live confirmed: layout rendered, 0 `repo-card`.

## Fix
`writeGistPage` now writes flat `content/gists/<id>.md` (single file, direct child of the section), mirroring `writeRepoPage`. Frontmatter keys (`type:gist`, `gist_id`, `gist_url`, `updated_at`, `files`) unchanged. Stale nested `content/gists/<id>/` dirs removed before regeneration.

## Verification
- `content/gists/*.md` = 100 (matches data/github.json)
- built `public/gists/index.html` → 100 gist cards (500 `repo-card` class hits)
- single `public/gists/<id>/index.html` pages render
- `hugo` 0 errors; `npm run lint` clean; `npm run test` ALL PASSED; `check-links` 0 broken; `check-perf` 0 regressions

## Task system (strict 4-layer)
- BMAD: `.planning/initiatives/gists-list.md`
- Spec Kit: `.specify/gists-list.md`
- Beads: `.beads/beads.json` (T37–T40)
- GSD: `.gsd/plan.md` (Phase K)