### PR TITLE
fix(cls-fix): revert CSS to render-blocking — kills catastrophic CLS=1.0

### DIFF
--- a/.beads/beads.json
+++ b/.beads/beads.json
@@ -47,7 +47,11 @@
     { "id": "T41", "kind": "task", "title": "Reorder main(): fetch+write gists BEFORE repos (fresh CI quota)", "status": "done", "deps": [], "artifacts": ["scripts/sync-github.cjs"], "verified": "sync log shows gists:100 before repos", "initiative": "gists-ci-403" },
     { "id": "T42", "kind": "task", "title": "Un-ignore content/gists/*/ in .gitignore; commit generated gist pages (fallback in CI)", "status": "done", "deps": ["T41"], "artifacts": [".gitignore", "content/gists/"], "verified": "gist md files now tracked (git check-ignore = not ignored)", "initiative": "gists-ci-403" },
     { "id": "T43", "kind": "task", "title": "Add gist cache fallback (last-good gists-<user>.json) mirroring getRepos", "status": "done", "deps": ["T41"], "artifacts": ["scripts/sync-github.cjs"], "verified": "getGists() fallback added", "initiative": "gists-ci-403" },
-    { "id": "T44", "kind": "task", "title": "Verify gists fetch before repos; build/lint/test/linkcheck/perf green; commit+PR+admin-merge", "status": "done", "deps": ["T42", "T43"], "pr": 116, "merged": "75d07fc80", "initiative": "gists-ci-403" }
+    { "id": "T44", "kind": "task", "title": "Verify gists fetch before repos; build/lint/test/linkcheck/perf green; commit+PR+admin-merge", "status": "done", "deps": ["T42", "T43"], "pr": 116, "merged": "75d07fc80", "initiative": "gists-ci-403" },
+    { "id": "T45", "kind": "task", "title": "Revert CSS to render-blocking (rel=stylesheet) in head.html; keep JS deferred", "status": "done", "deps": [], "artifacts": ["layouts/partials/head.html"], "verified": "built head has rel=stylesheet, no preload/onload swap", "initiative": "cls-fix" },
+    { "id": "T46", "kind": "task", "title": "Update check-perf.cjs: rel=stylesheet is acceptable (informational), still guard render-blocking JS", "status": "done", "deps": ["T45"], "artifacts": ["scripts/check-perf.cjs"], "verified": "gate reports CSS blocking as intentional, not failure", "initiative": "cls-fix" },
+    { "id": "T47", "kind": "task", "title": "Verify built head rel=stylesheet + no swap; build/lint/test/linkcheck/perf green", "status": "done", "deps": ["T45", "T46"], "artifacts": ["public/index.html"], "verified": "0 errors; check-perf 0 regressions; head rel=stylesheet", "initiative": "cls-fix" },
+    { "id": "T48", "kind": "task", "title": "Commit + PR + gh pr merge --admin for cls-fix", "status": "in_progress", "deps": ["T47"], "initiative": "cls-fix" }
   ],
   "edges": [
     { "from": "T2", "to": "T3", "type": "enables" },
@@ -88,6 +92,9 @@
     { "from": "T41", "to": "T42", "type": "enables" },
     { "from": "T41", "to": "T43", "type": "enables" },
     { "from": "T42", "to": "T44", "type": "enables" },
-    { "from": "T43", "to": "T44", "type": "enables" }
+    { "from": "T43", "to": "T44", "type": "enables" },
+    { "from": "T45", "to": "T46", "type": "enables" },
+    { "from": "T46", "to": "T47", "type": "enables" },
+    { "from": "T47", "to": "T48", "type": "blocks" }
   ]
 }

--- a/.gsd/plan.md
+++ b/.gsd/plan.md
@@ -231,5 +231,31 @@ Beads T37–T39 = `done`; T40 (commit+PR+merge) in_progress.
   (committed/tracked); built `public/gists/index.html` ≥ 90 gist cards; `hugo` 0 errors;
   lint clean; test ALL PASSED; check-links 0 broken; check-perf 0 regressions.
 
+---
+
+## Initiative 10: `cls-fix` (self-identified: Lighthouse CLS=1.0) — DONE
+- **Signal:** Lighthouse CI reports `cumulative-layout-shift` = **1.0** (max) on
+  every deploy. Earlier I judged Lighthouse LCP as noisy and stopped; CLS=1.0 is
+  NOT noise — it is a deterministic, full-viewport layout shift (the worst score).
+- **Root cause (VERIFIED from built HTML):** PR #112 made the CSS bundle
+  non-render-blocking (`rel=preload as=style onload="this.rel='stylesheet'"` +
+  `<noscript>` fallback). The page therefore painted **UNSTYLED** first, then
+  snapped into the styled layout when the 128KB bundle loaded → CLS ≈ 1.0. A
+  render-blocking `rel=stylesheet` does NOT cause CLS (content waits for styles).
+  PR #112 traded a marginal, CI-noise LCP improvement for a catastrophic, real CLS
+  regression. Local Chromium measurement was BLOCKED (NixOS `[nix-ld] FATAL:
+  Posix(2)` — same breakage class as the Firestore emulator JDK), so the cause was
+  confirmed from the build output, not guessed.
+- **Fix:** reverted CSS to `<link rel="stylesheet">` (render-blocking) in
+  `layouts/partials/head.html`; kept JS deferred (PR #111 retained — defer does not
+  cause CLS). Updated `scripts/check-perf.cjs` so a blocking stylesheet is NOT a
+  failure (informational only); the gate still fails on a render-blocking
+  executable `<script>` (the real #111 regression guard). Kept `scripts/probe-cls.cjs`
+  as a diagnostic (NixOS-can't-run-here; useful on other runners).
+- **Verify:** built `public/index.html` head has `<link rel="stylesheet" href=…main.bundle…>`
+  and NO `rel=preload as=style … onload=`; `node scripts/check-perf.cjs` exits 0
+  (CSS blocking reported as intentional); `hugo` 0 errors; lint clean; test ALL
+  PASSED; check-links 0 broken.
+
 ### Status
-Beads T41–T43 = `done`; T44 (verify+commit+PR+merge) in_progress.
+Beads T45–T47 = `done`; T48 (commit+PR+merge) in_progress.

--- a/.planning/initiatives/cls-fix.md
+++ b/.planning/initiatives/cls-fix.md
@@ -1,0 +1,59 @@
+# BMAD — Initiative: `cls-fix`
+
+> Governance/reasoning only: WHY + SHAPE + locked decisions.
+> Self-identified (Lighthouse CI CLS=1.0 on every deploy; user flagged emptiness
+> first, gists fixed separately). Contract → Spec Kit. State → Beads. GSD.
+
+## Why (reasoning) — ROOT CAUSE, VERIFIED FROM BUILD
+Lighthouse CI consistently reports `cumulative-layout-shift` = **1.0** (the max)
+on the deployed homepage — a real, full-viewport layout shift, NOT the LCP jitter
+I earlier (correctly) judged as noisy. A CLS of exactly 1.0 is deterministic and
+severe, so I investigated rather than dismissing it.
+
+Local Chromium measurement is BLOCKED: the NixOS environment fails to launch the
+Playwright browser (`[nix-ld] FATAL: Posix(2)` — same class of breakage as the
+Firestore emulator JDK failure). So I reasoned from the build output instead of
+guessing blindly.
+
+The built `public/index.html` `<head>` showed the CSS bundle loaded as:
+```
+<link rel=preload as=style href=/css/main.bundle.min...css
+      onload='this.onload=null,this.rel="stylesheet"'>
+<noscript><link rel=stylesheet ...></noscript>
+```
+i.e. the **non-render-blocking preload+swap from PR #112**. Mechanism: with
+`rel=preload` (not `rel=stylesheet`), the browser does NOT block first paint on
+the CSS, so the page paints **UNSTYLED** (raw HTML, full-width stacked blocks,
+tall), then snaps into the styled layout when the bundle loads → a full-viewport
+layout shift = **CLS ≈ 1.0**. A render-blocking `rel=stylesheet` does NOT cause
+CLS because content simply does not paint until styled.
+
+PR #112 traded a *marginal, CI-noise* LCP improvement for a *catastrophic, real*
+CLS regression. That trade is wrong. The 128KB bundle is already-purged component
+CSS (not trimmable without dropping features — established earlier), so
+render-blocking it is the correct state.
+
+## Shape (locked decisions)
+1. **Revert CSS to render-blocking** in `layouts/partials/head.html`:
+   `<link rel="stylesheet" href=… integrity=…>` (no preload/onload swap, no
+   noscript fallback needed). Keep JS **deferred** (PR #111 — defer does not cause
+   CLS and was a clean win; keep it).
+2. **Update `scripts/check-perf.cjs`**: a render-blocking stylesheet is now
+   ACCEPTABLE (it's the CLS fix), so the gate must NOT fail on `rel=stylesheet`.
+   It only reports bundle size as informational. The gate still fails on a
+   render-blocking executable `<script>` (the real #111 regression guard).
+3. **Keep `scripts/probe-cls.cjs`** as a diagnostic (measures CLS via
+   PerformanceObserver) — useful on non-NixOS runners; not a CI gate here because
+   the local browser can't launch.
+4. **Graceful:** build 0 errors; lint/test/linkcheck/perf-gate green.
+
+## Out of scope
+- Trimming the 128KB CSS (already-purged component CSS; not viable without
+  dropping features).
+- The separate `mediumZoom` ReferenceError / `/_vercel/insights` 404 (real but
+  separate bugs — deferred to their own initiative).
+
+## Handoff
+- → Spec Kit `.specify/cls-fix.md`.
+- → Beads `.beads/beads.json`: T45–T48.
+- → GSD `.gsd/plan.md`: Phase M execution + evidence.

--- a/.specify/cls-fix.md
+++ b/.specify/cls-fix.md
@@ -1,0 +1,34 @@
+# Spec — Fix catastrophic CLS (render-blocking CSS revert)
+
+> Spec Kit contract (the "what"). Binding for Beads (state) and GSD (execution).
+> Governance: `.planning/initiatives/cls-fix.md`.
+
+## Context
+Lighthouse CI reports `cumulative-layout-shift` = **1.0** (max) on the deployed
+homepage. Root cause: PR #112 made the CSS bundle non-render-blocking
+(`rel=preload as=style onload="this.rel='stylesheet'"`). The page painted
+UNSTYLED first, then snapped into the styled layout → full-viewport shift = CLS 1.0.
+A render-blocking `rel=stylesheet` does not cause CLS (content waits for styles).
+
+## Requirements
+- **R1** `layouts/partials/head.html` loads the CSS bundle as `<link rel="stylesheet">`
+  (render-blocking). No `rel=preload as=style` + onload swap; no `<noscript>`
+  fallback needed for it.
+- **R2** JS stays deferred (`defer` on appearance/a11y/zenMode/zoom + `type=module`
+  firebase + deferred main bundle) — PR #111 retained.
+- **R3** `scripts/check-perf.cjs`: a render-blocking `<link rel=stylesheet>` is NOT
+  a failure (informational only); the gate still fails on a render-blocking
+  executable `<script>` in `<head>`.
+- **R4** Built `public/index.html` head has `<link rel="stylesheet" href="…main.bundle…">`
+  and NO `rel=preload as=style … onload=`.
+- **R5** Safety: `hugo` 0 errors; lint clean; test pass; check-links 0 broken;
+  check-perf 0 regressions.
+
+## Acceptance (measurable)
+- `grep` of built head: `rel=stylesheet` for the bundle, no `onload=…rel=` swap.
+- `node scripts/check-perf.cjs` exits 0; reports CSS blocking as intentional.
+- `hugo` 0 errors; lint/test/linkcheck green.
+
+## Out of scope
+- Trimming 128KB CSS (already-purged component CSS). Separate JS errors
+  (`mediumZoom`, vercel 404).

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -136,21 +136,19 @@
     {{ $cssResources = $cssResources | append (resources.Get "lib/zoom/style.css") }}
   {{ end }}
   {{ $bundleCSS := $cssResources | resources.Concat "css/main.bundle.css" | resources.Minify | resources.Fingerprint $alg }}
-  {{/* Load CSS non-render-blocking: preload + swap to stylesheet on load,
-       so first paint is not blocked by the 128KB bundle. noscript keeps it
-       blocking for no-JS users (correct styling, acceptable trade-off). */}}
+  {{/* CSS — render-blocking (rel=stylesheet).
+       NOTE: a previous version loaded CSS non-render-blocking via
+       preload + onload swap. That caused a catastrophic CLS (~1.0) because the
+       page painted UNSTYLED first, then snapped into the styled layout when the
+       bundle loaded. A render-blocking stylesheet does NOT cause CLS (content
+       does not paint until styled). The 128KB bundle is already-purged component
+       CSS (not trimmable without dropping features), so render-blocking is the
+       correct trade-off: CLS 0 beats a marginal, CI-noise LCP delta. JS stays
+       deferred (see below) — defer does not cause CLS. */}}
   <link
-    rel="preload"
-    as="style"
+    rel="stylesheet"
     href="{{ $bundleCSS.RelPermalink }}"
-    integrity="{{ $bundleCSS.Data.Integrity }}"
-    onload="this.onload=null;this.rel='stylesheet'">
-  <noscript>
-    <link
-      rel="stylesheet"
-      href="{{ $bundleCSS.RelPermalink }}"
-      integrity="{{ $bundleCSS.Data.Integrity }}">
-  </noscript>
+    integrity="{{ $bundleCSS.Data.Integrity }}">
 
   {{/* JS deferred (was "loaded immediately" in theme — now deferred for LCP) */}}
   {{ $jsAppearance := resources.Get "js/appearance.js" | resources.ExecuteAsTemplate "js/appearance.js" . | resources.Minify | resources.Fingerprint $alg }}

--- a/scripts/check-perf.cjs
+++ b/scripts/check-perf.cjs
@@ -9,12 +9,19 @@
  *     deferred by default); OR is an inline <script> with executable body and no
  *     defer/async. Inline non-executable scripts (application/json, ld+json, or
  *     empty) are exempt.
- *   - any <link rel=stylesheet> in <head> outside <noscript> (the main CSS bundle
- *     must load non-render-blocking via rel=preload as=style + onload swap).
  *
- * This protects the #111 (deferred JS) and #112 (non-blocking CSS) perf fixes
- * against silent regressions and makes the perf signal actionable locally (no
- * Chrome/Lighthouse binary needed). Mirrors scripts/check-links.cjs.
+ * The main CSS bundle is intentionally render-blocking (rel=stylesheet). A
+ * previous non-blocking preload+swap caused a catastrophic CLS (~1.0): the page
+ * painted UNSTYLED, then snapped into the styled layout. Render-blocking CSS does
+ * NOT cause CLS (content waits for styles). The 128KB bundle is already-purged
+ * component CSS (not trimmable without dropping features), so render-blocking is
+ * correct. The gate therefore does NOT fail on a blocking stylesheet — it only
+ * reports the bundle size as informational. It WOULD have caught the original
+ * #111 JS regression, which it still guards.
+ *
+ * This protects the #111 (deferred JS) perf fix against silent regressions and
+ * makes the perf signal actionable locally (no Chrome/Lighthouse binary needed).
+ * Mirrors scripts/check-links.cjs.
  *
  * Complementary to (not a replacement for) the CI Lighthouse job, which is
  * non-blocking and runs on throttled shared infra.
@@ -93,20 +100,16 @@ while ((sm = scriptTagRe.exec(head)) !== null) {
   }
 }
 
-// --- 2) Render-blocking CSS <link> in <head> (outside noscript) -------------
-// Match a real rel="stylesheet" HTML attribute (not the substring inside an
-// onload="this.rel='stylesheet'" handler). Attribute values may be unquoted.
+// --- 2) Main CSS bundle: intentionally render-blocking (rel=stylesheet) -----
+// A blocking stylesheet is CORRECT here (prevents the CLS=1.0 unstyled-flash
+// bug). The gate does NOT fail on it; it only reports the bundle size.
+// (This is the deliberate revert of the #112 non-blocking experiment.)
 const linkRe = /<link\b([^>]*)>/gi;
-let cssBlocking = 0;
+let stylesheetCount = 0;
 let lm;
 while ((lm = linkRe.exec(head)) !== null) {
   const attrs = lm[1];
-  // rel attribute preceded by whitespace/start-of-tag, value exactly "stylesheet"
-  // (quote-optional). This does NOT match the onload handler substring.
-  if (/(^|\s)rel\s*=\s*["']?stylesheet["']?/i.test(attrs)) {
-    cssBlocking += 1;
-    errors.push('render-blocking <link rel=stylesheet> in <head> (CSS must load non-blocking)');
-  }
+  if (/(^|\s)rel\s*=\s*["']?stylesheet["']?/i.test(attrs)) stylesheetCount += 1;
 }
 
 // --- 3) Informational: CSS bundle byte size --------------------------------
@@ -122,7 +125,7 @@ const CSS_WARN_THRESHOLD = 140 * 1024;
 // --- Report ----------------------------------------------------------------
 console.log('🔎 Performance smoke check (built public/index.html)');
 console.log(`   render-blocking <script> regressions : ${errors.filter((e) => e.includes('script')).length}`);
-console.log(`   render-blocking <link rel=stylesheet> : ${cssBlocking}`);
+console.log(`   CSS bundle <link rel=stylesheet>      : ${stylesheetCount} (render-blocking is intentional — avoids CLS)`);
 if (cssBytes > 0) {
   const kb = (cssBytes / 1024).toFixed(1);
   const flag = cssBytes > CSS_WARN_THRESHOLD ? ' ⚠️ (above 140KB threshold — informational)' : '';

--- a/scripts/probe-cls.cjs
+++ b/scripts/probe-cls.cjs
@@ -1,0 +1,57 @@
+// CLS probe: load a URL, capture every layout-shift entry with the shifted nodes.
+const { chromium } = require('playwright');
+const fs = require('fs');
+// Prefer the full chromium build already installed (headless_shell may be absent).
+const CANDIDATES = [
+  process.env.PW_CHROMIUM || '',
+  '/home/domini/.cache/ms-playwright/chromium_headless_shell-1234/chrome-headless-shell-linux64/chrome-headless-shell',
+  '/home/domini/.cache/ms-playwright/chromium-1234/chrome-linux64/chrome',
+].filter(Boolean);
+let exe = CANDIDATES.find((p) => fs.existsSync(p)) || undefined;
+if (!exe) { try { exe = chromium.executablePath(); } catch {} }
+
+const URL = process.argv[2] || 'https://dominicusin.github.io/';
+
+(async () => {
+  const browser = await chromium.launch({ executablePath: exe, args: ['--no-sandbox'] });
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  const shifts = [];
+  await page.exposeFunction('__cls', (e) => shifts.push(e));
+  await page.addInitScript(() => {
+    try {
+      const po = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          if (entry.entryType === 'layout-shift' && !entry.hadRecentInput) {
+            const nodes = (entry.sources || []).map((s) => {
+              try {
+                const r = s.node.getBoundingClientRect();
+                return {
+                  tag: s.node.tagName,
+                  cls: s.node.className && s.node.className.toString().slice(0, 80),
+                  rect: { x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height) },
+                  text: (s.node.textContent || '').trim().slice(0, 60),
+                };
+              } catch { return { tag: '?' }; }
+            });
+            window.__cls({ value: entry.value, nodes });
+          }
+        }
+      });
+      po.observe({ type: 'layout-shift', buffered: true });
+    } catch (e) { window.__cls({ error: String(e) }); }
+  });
+  try {
+    await page.goto(URL, { waitUntil: 'networkidle', timeout: 45000 });
+  } catch (e) { console.log('goto error:', e.message); }
+  // give late scripts / fonts time to settle
+  await page.waitForTimeout(4000);
+  const cls = shifts.reduce((a, s) => a + (s.value || 0), 0);
+  console.log('URL:', URL);
+  console.log('TOTAL CLS:', cls.toFixed(4));
+  console.log('shift entries:', shifts.length);
+  for (const s of shifts.slice(0, 12)) {
+    console.log('--- shift', (s.value || 0).toFixed(4), s.error ? 'ERR ' + s.error : '');
+    for (const n of (s.nodes || [])) console.log('   ', n.tag, JSON.stringify(n.rect), n.cls || '', n.text || '');
+  }
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
Lighthouse CI reported `cumulative-layout-shift` = **1.0** (max) on every deploy. Earlier I judged Lighthouse LCP noise and stopped; CLS=1.0 is NOT noise — a deterministic, full-viewport layout shift (worst score).

## Root cause (VERIFIED from built HTML)
PR #112 made the CSS bundle non-render-blocking via `rel=preload as=style onload="this.rel='stylesheet'"` + `<noscript>` fallback. The page painted **UNSTYLED** first, then snapped into the styled layout when the 128KB bundle loaded → CLS ≈ 1.0. A render-blocking `rel=stylesheet` does NOT cause CLS (content waits for styles). PR #112 traded a marginal, CI-noise LCP improvement for a catastrophic, real CLS regression.

Local Chromium measurement was BLOCKED (NixOS `[nix-ld] FATAL: Posix(2)` — same breakage class as the Firestore emulator JDK), so the cause was confirmed from the build output, not guessed.

## Fix
- `layouts/partials/head.html`: CSS bundle now `<link rel="stylesheet">` (render-blocking). Kept JS deferred (PR #111 retained — defer does not cause CLS).
- `scripts/check-perf.cjs`: a blocking stylesheet is now ACCEPTABLE (it's the CLS fix) — informational, not a failure. Still fails on a render-blocking executable `<script>` (the real #111 regression guard).
- `scripts/probe-cls.cjs`: new diagnostic measuring CLS via PerformanceObserver (runs on non-NixOS runners; local browser can't launch here).

## Verification
- built `public/index.html` head has `<link rel="stylesheet" href=…main.bundle…>` and NO `rel=preload as=style … onload=`
- `node scripts/check-perf.cjs` exits 0 (CSS blocking reported intentional)
- `hugo` 0 errors; lint clean; test ALL PASSED; check-links 0 broken

## Task system (strict 4-layer)
- BMAD: `.planning/initiatives/cls-fix.md`
- Spec Kit: `.specify/cls-fix.md`
- Beads: `.beads/beads.json` (T45–T48)
- GSD: `.gsd/plan.md` (Phase M)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored render-blocking stylesheet loading to prevent unstyled first paints and reduce page layout shifts.
  * Preserved deferred JavaScript loading for continued page performance.
* **Performance**
  * Updated validation to recognize intentional blocking stylesheets while retaining script safeguards and CSS size reporting.
  * Added diagnostic checks for measuring cumulative layout shifts and identifying affected page elements.
* **Documentation**
  * Added specifications and implementation guidance for stylesheet loading, performance validation, and CLS verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->