### PR TITLE
fix(gist-names): show human names (not hash IDs) on /gists/

### DIFF
--- a/.beads/beads.json
+++ b/.beads/beads.json
@@ -51,7 +51,11 @@
     { "id": "T45", "kind": "task", "title": "Revert CSS to render-blocking (rel=stylesheet) in head.html; keep JS deferred", "status": "done", "deps": [], "artifacts": ["layouts/partials/head.html"], "verified": "built head has rel=stylesheet, no preload/onload swap", "initiative": "cls-fix" },
     { "id": "T46", "kind": "task", "title": "Update check-perf.cjs: rel=stylesheet is acceptable (informational), still guard render-blocking JS", "status": "done", "deps": ["T45"], "artifacts": ["scripts/check-perf.cjs"], "verified": "gate reports CSS blocking as intentional, not failure", "initiative": "cls-fix" },
     { "id": "T47", "kind": "task", "title": "Verify built head rel=stylesheet + no swap; build/lint/test/linkcheck/perf green", "status": "done", "deps": ["T45", "T46"], "artifacts": ["public/index.html"], "verified": "0 errors; check-perf 0 regressions; head rel=stylesheet", "initiative": "cls-fix" },
-    { "id": "T48", "kind": "task", "title": "Commit + PR + gh pr merge --admin for cls-fix", "status": "done", "deps": ["T47"], "pr": 117, "merged": "3497571ed", "initiative": "cls-fix" }
+    { "id": "T48", "kind": "task", "title": "Commit + PR + gh pr merge --admin for cls-fix", "status": "done", "deps": ["T47"], "pr": 117, "merged": "3497571ed", "initiative": "cls-fix" },
+    { "id": "T49", "kind": "task", "title": "writeGistPage: emit gist_name = desc + firstFileName (fallback desc||id)", "status": "done", "deps": [], "artifacts": ["scripts/sync-github.cjs"], "verified": "gist_name: 'zroot zroot' for 21432…", "initiative": "gist-names" },
+    { "id": "T50", "kind": "task", "title": "list.html + single.html render gist_name instead of gist_id", "status": "done", "deps": ["T49"], "artifacts": ["layouts/gists/list.html", "layouts/gists/single.html"], "initiative": "gist-names" },
+    { "id": "T51", "kind": "task", "title": "Regenerate content/gists; verify built list shows names (zroot zroot), build/lint/test/linkcheck/perf green", "status": "done", "deps": ["T50"], "artifacts": ["public/gists/index.html"], "verified": "0 hash-names of 100 cards; build/lint/test/linkcheck/perf green", "initiative": "gist-names" },
+    { "id": "T52", "kind": "task", "title": "Commit + PR + gh pr merge --admin for gist-names", "status": "in_progress", "deps": ["T51"], "initiative": "gist-names" }
   ],
   "edges": [
     { "from": "T2", "to": "T3", "type": "enables" },
@@ -95,6 +99,9 @@
     { "from": "T43", "to": "T44", "type": "enables" },
     { "from": "T45", "to": "T46", "type": "enables" },
     { "from": "T46", "to": "T47", "type": "enables" },
-    { "from": "T47", "to": "T48", "type": "blocks" }
+    { "from": "T47", "to": "T48", "type": "blocks" },
+    { "from": "T49", "to": "T50", "type": "enables" },
+    { "from": "T50", "to": "T51", "type": "enables" },
+    { "from": "T51", "to": "T52", "type": "blocks" }
   ]
 }

--- a/.gsd/plan.md
+++ b/.gsd/plan.md
@@ -257,5 +257,24 @@ Beads T37–T39 = `done`; T40 (commit+PR+merge) in_progress.
   (CSS blocking reported as intentional); `hugo` 0 errors; lint clean; test ALL
   PASSED; check-links 0 broken.
 
+---
+
+## Initiative 11: `gist-names` (user-requested: show names not hashes on /gists/) — DONE
+- **Request:** on `/gists/`, cards (and single page) showed `gist_id` (32-char hash
+  like `21432fc5f29c73591044eafa09e6fafc`). User wants the human name, e.g. that
+  gist → **"zroot zroot"**.
+- **Root cause (VERIFIED):** `layouts/gists/list.html` rendered `{{ .Params.gist_id }}`.
+  The generated page frontmatter already carried the name parts (`title`=description,
+  `files`=file names) but no single display name. For gist `21432…`:
+  `description='zroot'`, `files=['zroot']` → "zroot zroot".
+- **Fix:** `scripts/sync-github.cjs writeGistPage` now emits `gist_name` =
+  `(description ? description + ' ' : '') + firstFileName` (fallback description||id).
+  `layouts/gists/list.html` and `single.html` render `{{ .Params.gist_name }}`. The
+  hash stays only in the URL slug (links preserved).
+- **Verify:** regenerated `content/gists/*.md` (gist_name present); built
+  `public/gists/index.html` shows "zroot zroot" as the card text for the example
+  gist and names (not hashes) across the list; `hugo` 0 errors; lint clean; test
+  ALL PASSED; check-links 0 broken; check-perf 0 regressions.
+
 ### Status
-Beads T45–T47 = `done`; T48 (commit+PR+merge) in_progress.
+Beads T49–T51 = `done`; T52 (commit+PR+merge) in_progress.

--- a/.planning/initiatives/gist-names.md
+++ b/.planning/initiatives/gist-names.md
@@ -1,0 +1,42 @@
+# BMAD — Initiative: `gist-names`
+
+> Governance/reasoning only: WHY + SHAPE + locked decisions.
+> User-requested (focus-topic): on /gists/ show human names, not hash IDs.
+> Contract → Spec Kit. State → Beads. GSD.
+
+## Why (reasoning)
+On `/gists/` every card shows `gist_id` (a 32-char hash like
+`21432fc5f29c73591044eafa09e6fafc`) as the card name. That is unreadable and
+useless to a visitor. The user explicitly wants the **name** — e.g. the gist
+`21432…` whose `description` is `zroot` and whose first file is `zroot` should
+render as **"zroot zroot"**, not the hash.
+
+The data already carries the name parts: `description` + first `file.name`.
+The generated page frontmatter (from `scripts/sync-github.cjs writeGistPage`)
+has `title` (= description), `files` (= list of file names), and `gist_id`
+(= hash). The list template currently renders `.Params.gist_id`. So the fix is
+purely: derive a `gist_name` and render it instead of the hash.
+
+## Shape (locked decisions)
+1. `scripts/sync-github.cjs writeGistPage`: add `gist_name` to frontmatter =
+   `(description ? description + ' ' : '') + firstFileName`. If a gist has no
+   files, fall back to `description || gist.id`. This yields "zroot zroot" for the
+   example and a readable name for every gist.
+2. `layouts/gists/list.html`: render `{{ .Params.gist_name }}` (not `gist_id`) as
+   the card name. Keep the hash available only as the URL (already is).
+3. `layouts/gists/single.html`: show `gist_name` on the page header (in addition
+   to the existing `<h1>{{ .Title }}>` — or replace the h1 with gist_name so the
+   single page title is also human-readable). Keep `gist_id` in frontmatter for
+   data fidelity (not displayed).
+4. Regenerate `content/gists/*.md` via the sync script, rebuild, verify the card
+   text is the name (not the hash) for the example gist and for the list overall.
+5. Safety: hugo 0 errors; lint/test/linkcheck/perf green.
+
+## Out of scope
+- Changing the URL slug (must stay `<id>` so live links keep working).
+- Ontology/taxonomy expansion (separate initiative).
+
+## Handoff
+- → Spec Kit `.specify/gist-names.md`.
+- → Beads `.beads/beads.json`: T49–T52.
+- → GSD `.gsd/plan.md`: Phase N.

--- a/.specify/gist-names.md
+++ b/.specify/gist-names.md
@@ -1,0 +1,30 @@
+# Spec — Show human names (not hash IDs) on /gists/
+
+> Spec Kit contract (the "what"). Binding for Beads (state) and GSD (execution).
+> Governance: `.planning/initiatives/gist-names.md`.
+
+## Context
+`/gists/` cards (and the single-gist page title) render `gist_id` — a 32-char hash
+(e.g. `21432fc5f29c73591044eafa09e6fafc`). Unreadable. The user wants the human
+name. For gist `21432…`: `description='zroot'`, `files=['zroot']` → should show
+**"zroot zroot"**.
+
+## Requirements
+- **R1** `scripts/sync-github.cjs writeGistPage` emits a new `gist_name` frontmatter
+  field = `(description ? description + ' ' : '') + firstFileName`; if no files,
+  `description || gist.id`.
+- **R2** `layouts/gists/list.html` shows `{{ .Params.gist_name }}` as the card name
+  (replaces `{{ .Params.gist_id }}`). URL stays `<id>` (no slug change).
+- **R3** `layouts/gists/single.html` shows `gist_name` (page header), not the hash.
+- **R4** Regenerate `content/gists/*.md`, rebuild; verify the example gist card reads
+  "zroot zroot" and the list shows names not hashes.
+- **R5** Safety: `hugo` 0 errors; lint clean; test pass; check-links 0 broken;
+  check-perf 0 regressions.
+
+## Acceptance (measurable)
+- `grep` built `public/gists/index.html` for `zroot zroot` → present; `21432fc…`
+  appears only in `href` (URL), NOT as visible card text.
+- `node scripts/check-perf.cjs` exits 0.
+
+## Out of scope
+- URL slug change; ontology/taxonomy expansion.

--- a/content/gists/0402593be174cc12e93186f6d2f14ad8.md
+++ b/content/gists/0402593be174cc12e93186f6d2f14ad8.md
@@ -2,6 +2,7 @@
 title: "clearlinux"
 type: gist
 gist_id: "0402593be174cc12e93186f6d2f14ad8"
+gist_name: "clearlinux clearlinux.sh"
 gist_url: https://gist.github.com/dominicusin/0402593be174cc12e93186f6d2f14ad8
 updated_at: "2021-02-23T23:34:55Z"
 files: ["clearlinux.sh"]

--- a/content/gists/090792be4cd6fb1ecdf34379b1e9fc77.md
+++ b/content/gists/090792be4cd6fb1ecdf34379b1e9fc77.md
@@ -2,6 +2,7 @@
 title: "cloud os"
 type: gist
 gist_id: "090792be4cd6fb1ecdf34379b1e9fc77"
+gist_name: "cloud os gistfile1.txt"
 gist_url: https://gist.github.com/dominicusin/090792be4cd6fb1ecdf34379b1e9fc77
 updated_at: "2024-10-21T21:26:36Z"
 files: ["gistfile1.txt"]

--- a/content/gists/09e979be90a5a188026c91453113f5fa.md
+++ b/content/gists/09e979be90a5a188026c91453113f5fa.md
@@ -2,6 +2,7 @@
 title: "09e979be90a5a188026c91453113f5fa"
 type: gist
 gist_id: "09e979be90a5a188026c91453113f5fa"
+gist_name: "gistfile1.txt"
 gist_url: https://gist.github.com/dominicusin/09e979be90a5a188026c91453113f5fa
 updated_at: "2025-03-11T09:39:53Z"
 files: ["gistfile1.txt"]

--- a/content/gists/0abe19e3545774eddcb15b567dade8ab.md
+++ b/content/gists/0abe19e3545774eddcb15b567dade8ab.md
@@ -2,6 +2,7 @@
 title: "0abe19e3545774eddcb15b567dade8ab"
 type: gist
 gist_id: "0abe19e3545774eddcb15b567dade8ab"
+gist_name: "lede2"
 gist_url: https://gist.github.com/dominicusin/0abe19e3545774eddcb15b567dade8ab
 updated_at: "2017-12-24T17:15:33Z"
 files: ["lede2"]

--- a/content/gists/0ac9c98bdf73c355bb1e43c85a979940.md
+++ b/content/gists/0ac9c98bdf73c355bb1e43c85a979940.md
@@ -2,6 +2,7 @@
 title: "List of Top Public Time Servers"
 type: gist
 gist_id: "0ac9c98bdf73c355bb1e43c85a979940"
+gist_name: "List of Top Public Time Servers Top_Public_Time_Servers.md"
 gist_url: https://gist.github.com/dominicusin/0ac9c98bdf73c355bb1e43c85a979940
 updated_at: "2023-06-02T04:23:29Z"
 files: ["Top_Public_Time_Servers.md"]

--- a/content/gists/0b0c0d8df603820dee6f1d7713e0cb7f.md
+++ b/content/gists/0b0c0d8df603820dee6f1d7713e0cb7f.md
@@ -2,6 +2,7 @@
 title: "0b0c0d8df603820dee6f1d7713e0cb7f"
 type: gist
 gist_id: "0b0c0d8df603820dee6f1d7713e0cb7f"
+gist_name: "gistfile1.txt"
 gist_url: https://gist.github.com/dominicusin/0b0c0d8df603820dee6f1d7713e0cb7f
 updated_at: "2024-03-04T23:00:02Z"
 files: ["gistfile1.txt"]

--- a/content/gists/0ea3ae96212f9b9a1b9e93560a146ee6.md
+++ b/content/gists/0ea3ae96212f9b9a1b9e93560a146ee6.md
@@ -2,6 +2,7 @@
 title: "0ea3ae96212f9b9a1b9e93560a146ee6"
 type: gist
 gist_id: "0ea3ae96212f9b9a1b9e93560a146ee6"
+gist_name: "win"
 gist_url: https://gist.github.com/dominicusin/0ea3ae96212f9b9a1b9e93560a146ee6
 updated_at: "2018-10-12T09:01:37Z"
 files: ["win"]

--- a/content/gists/0f60728b8189f97801d19cfca33ff968.md
+++ b/content/gists/0f60728b8189f97801d19cfca33ff968.md
@@ -2,6 +2,7 @@
 title: "Keybase CP script."
 type: gist
 gist_id: "0f60728b8189f97801d19cfca33ff968"
+gist_name: "Keybase CP script.  keybase_cp.sh"
 gist_url: https://gist.github.com/dominicusin/0f60728b8189f97801d19cfca33ff968
 updated_at: "2022-08-24T07:38:47Z"
 files: ["keybase_cp.sh"]

--- a/content/gists/12b6b10e2b4b5f93e6e560242f7356a7.md
+++ b/content/gists/12b6b10e2b4b5f93e6e560242f7356a7.md
@@ -2,6 +2,7 @@
 title: "full"
 type: gist
 gist_id: "12b6b10e2b4b5f93e6e560242f7356a7"
+gist_name: "full gistfile1.txt"
 gist_url: https://gist.github.com/dominicusin/12b6b10e2b4b5f93e6e560242f7356a7
 updated_at: "2024-02-20T13:27:21Z"
 files: ["gistfile1.txt"]

--- a/content/gists/1424a4bdbf5a26a74670e25c28adeea7.md
+++ b/content/gists/1424a4bdbf5a26a74670e25c28adeea7.md
@@ -2,6 +2,7 @@
 title: "Microsoft Visual C++ Redistributable Packages"
 type: gist
 gist_id: "1424a4bdbf5a26a74670e25c28adeea7"
+gist_name: "Microsoft Visual C++ Redistributable Packages redist.md"
 gist_url: https://gist.github.com/dominicusin/1424a4bdbf5a26a74670e25c28adeea7
 updated_at: "2017-12-26T14:53:16Z"
 files: ["redist.md"]

--- a/content/gists/1670c40044de7d658bca2140e5812ca7.md
+++ b/content/gists/1670c40044de7d658bca2140e5812ca7.md
@@ -2,6 +2,7 @@
 title: "How to convert Windows Evaluation to Volume License editions"
 type: gist
 gist_id: "1670c40044de7d658bca2140e5812ca7"
+gist_name: "How to convert Windows Evaluation to Volume License editions win-convert-eval-kms.txt"
 gist_url: https://gist.github.com/dominicusin/1670c40044de7d658bca2140e5812ca7
 updated_at: "2020-03-20T05:51:12Z"
 files: ["win-convert-eval-kms.txt"]

--- a/content/gists/172819efc15499c2b286d452822c5002.md
+++ b/content/gists/172819efc15499c2b286d452822c5002.md
@@ -2,6 +2,7 @@
 title: "172819efc15499c2b286d452822c5002"
 type: gist
 gist_id: "172819efc15499c2b286d452822c5002"
+gist_name: "keybase.md"
 gist_url: https://gist.github.com/dominicusin/172819efc15499c2b286d452822c5002
 updated_at: "2018-10-29T14:21:19Z"
 files: ["keybase.md"]

--- a/content/gists/182513020e92900ede07f5e69ff49b8f.md
+++ b/content/gists/182513020e92900ede07f5e69ff49b8f.md
@@ -2,6 +2,7 @@
 title: "182513020e92900ede07f5e69ff49b8f"
 type: gist
 gist_id: "182513020e92900ede07f5e69ff49b8f"
+gist_name: "exherbo"
 gist_url: https://gist.github.com/dominicusin/182513020e92900ede07f5e69ff49b8f
 updated_at: "2018-01-09T00:46:26Z"
 files: ["exherbo"]

--- a/content/gists/19b4162c96e1a934b33db13989130e54.md
+++ b/content/gists/19b4162c96e1a934b33db13989130e54.md
@@ -2,6 +2,7 @@
 title: "devuan"
 type: gist
 gist_id: "19b4162c96e1a934b33db13989130e54"
+gist_name: "devuan devuan"
 gist_url: https://gist.github.com/dominicusin/19b4162c96e1a934b33db13989130e54
 updated_at: "2023-09-04T22:58:58Z"
 files: ["devuan"]

--- a/content/gists/1c480d8ff2a34b42d279b14ad6f85e38.md
+++ b/content/gists/1c480d8ff2a34b42d279b14ad6f85e38.md
@@ -2,6 +2,7 @@
 title: "1c480d8ff2a34b42d279b14ad6f85e38"
 type: gist
 gist_id: "1c480d8ff2a34b42d279b14ad6f85e38"
+gist_name: "reps"
 gist_url: https://gist.github.com/dominicusin/1c480d8ff2a34b42d279b14ad6f85e38
 updated_at: "2020-11-28T02:30:58Z"
 files: ["reps"]

--- a/content/gists/212af111f65ca7e6529dc58b36eac38a.md
+++ b/content/gists/212af111f65ca7e6529dc58b36eac38a.md
@@ -2,6 +2,7 @@
 title: "212af111f65ca7e6529dc58b36eac38a"
 type: gist
 gist_id: "212af111f65ca7e6529dc58b36eac38a"
+gist_name: "gistfile1.txt"
 gist_url: https://gist.github.com/dominicusin/212af111f65ca7e6529dc58b36eac38a
 updated_at: "2020-04-01T19:08:52Z"
 files: ["gistfile1.txt"]

--- a/content/gists/21432fc5f29c73591044eafa09e6fafc.md
+++ b/content/gists/21432fc5f29c73591044eafa09e6fafc.md
@@ -2,6 +2,7 @@
 title: "zroot"
 type: gist
 gist_id: "21432fc5f29c73591044eafa09e6fafc"
+gist_name: "zroot zroot"
 gist_url: https://gist.github.com/dominicusin/21432fc5f29c73591044eafa09e6fafc
 updated_at: "2024-12-19T22:38:57Z"
 files: ["zroot"]

--- a/content/gists/218ad69e78f67f8d1b739697c95157df.md
+++ b/content/gists/218ad69e78f67f8d1b739697c95157df.md
@@ -2,6 +2,7 @@
 title: "How To Create Windows 10 China Government Edition EnterpriseG Volume:GVLK"
 type: gist
 gist_id: "218ad69e78f67f8d1b739697c95157df"
+gist_name: "How To Create Windows 10 China Government Edition EnterpriseG Volume:GVLK How To Create Windows 10 China Government Edition EnterpriseG Volume:GVLK"
 gist_url: https://gist.github.com/dominicusin/218ad69e78f67f8d1b739697c95157df
 updated_at: "2020-12-20T10:12:56Z"
 files: ["How To Create Windows 10 China Government Edition EnterpriseG Volume:GVLK", "Upgrade from any Previous Windows 10 Edition [Win 10 Version 1703 or above & Chinese Simplified Language Only!]"]

--- a/content/gists/251edc4716fbd7e6db34fd1fd18ca622.md
+++ b/content/gists/251edc4716fbd7e6db34fd1fd18ca622.md
@@ -2,6 +2,7 @@
 title: "/usr/share/polkit-1/actions/org.opensuse.pkexec.yast2.policy"
 type: gist
 gist_id: "251edc4716fbd7e6db34fd1fd18ca622"
+gist_name: " /usr/share/polkit-1/actions/org.opensuse.pkexec.yast2.policy  org.opensuse.pkexec.yast2.policy"
 gist_url: https://gist.github.com/dominicusin/251edc4716fbd7e6db34fd1fd18ca622
 updated_at: "2019-11-03T03:30:50Z"
 files: ["org.opensuse.pkexec.yast2.policy"]

--- a/content/gists/2fbfdcb6ff72ab2debe1a4dbebe0b509.md
+++ b/content/gists/2fbfdcb6ff72ab2debe1a4dbebe0b509.md
@@ -2,6 +2,7 @@
 title: "/etc/apt/sources.list.d/Debian.sources"
 type: gist
 gist_id: "2fbfdcb6ff72ab2debe1a4dbebe0b509"
+gist_name: "/etc/apt/sources.list.d/Debian.sources Debian.sources"
 gist_url: https://gist.github.com/dominicusin/2fbfdcb6ff72ab2debe1a4dbebe0b509
 updated_at: "2024-03-04T03:58:27Z"
 files: ["Debian.sources"]

--- a/content/gists/307f29255d8a9a2e27e0db7807cc4d0e.md
+++ b/content/gists/307f29255d8a9a2e27e0db7807cc4d0e.md
@@ -2,6 +2,7 @@
 title: "/etc/apt/sources.list.d/00-ubuntu.sources  apt-fast.sources  sublime.sources"
 type: gist
 gist_id: "307f29255d8a9a2e27e0db7807cc4d0e"
+gist_name: "/etc/apt/sources.list.d/00-ubuntu.sources  apt-fast.sources  sublime.sources 00-ubuntu.sources  apt-fast.sources  sublime.sources"
 gist_url: https://gist.github.com/dominicusin/307f29255d8a9a2e27e0db7807cc4d0e
 updated_at: "2024-02-07T20:42:57Z"
 files: ["00-ubuntu.sources  apt-fast.sources  sublime.sources"]

--- a/content/gists/316ab2c4be582d19ddd5bc612f9edeeb.md
+++ b/content/gists/316ab2c4be582d19ddd5bc612f9edeeb.md
@@ -2,6 +2,7 @@
 title: "How to setup a community version of Proxmox VE 5.x-6.x"
 type: gist
 gist_id: "316ab2c4be582d19ddd5bc612f9edeeb"
+gist_name: "How to setup a community version of Proxmox VE 5.x-6.x gistfile1.txt"
 gist_url: https://gist.github.com/dominicusin/316ab2c4be582d19ddd5bc612f9edeeb
 updated_at: "2021-10-26T13:30:59Z"
 files: ["gistfile1.txt"]

--- a/content/gists/32c65db74ea47f695d092b3e82e9a7fc.md
+++ b/content/gists/32c65db74ea47f695d092b3e82e9a7fc.md
@@ -2,6 +2,7 @@
 title: "/etc/firewall.user"
 type: gist
 gist_id: "32c65db74ea47f695d092b3e82e9a7fc"
+gist_name: "/etc/firewall.user gistfile1.sh"
 gist_url: https://gist.github.com/dominicusin/32c65db74ea47f695d092b3e82e9a7fc
 updated_at: "2018-03-21T18:15:25Z"
 files: ["gistfile1.sh"]

--- a/content/gists/3767b0adad98ac016c32a981d931c113.md
+++ b/content/gists/3767b0adad98ac016c32a981d931c113.md
@@ -2,6 +2,7 @@
 title: "Trolling #haskell"
 type: gist
 gist_id: "3767b0adad98ac016c32a981d931c113"
+gist_name: "Trolling #haskell trolling_haskell"
 gist_url: https://gist.github.com/dominicusin/3767b0adad98ac016c32a981d931c113
 updated_at: "2022-05-01T21:21:08Z"
 files: ["trolling_haskell"]

--- a/content/gists/39e81e44e8bdaeadeb7b69c7928aea08.md
+++ b/content/gists/39e81e44e8bdaeadeb7b69c7928aea08.md
@@ -2,6 +2,7 @@
 title: "Куайн, Запрос который выводит сам себя"
 type: gist
 gist_id: "39e81e44e8bdaeadeb7b69c7928aea08"
+gist_name: "Куайн, Запрос который выводит сам себя gistfile1.sql"
 gist_url: https://gist.github.com/dominicusin/39e81e44e8bdaeadeb7b69c7928aea08
 updated_at: "2018-12-04T02:53:41Z"
 files: ["gistfile1.sql"]

--- a/content/gists/434ec639b48a6946b5b69de3bd80fa04.md
+++ b/content/gists/434ec639b48a6946b5b69de3bd80fa04.md
@@ -2,6 +2,7 @@
 title: "bcf"
 type: gist
 gist_id: "434ec639b48a6946b5b69de3bd80fa04"
+gist_name: "bcf bcachefs"
 gist_url: https://gist.github.com/dominicusin/434ec639b48a6946b5b69de3bd80fa04
 updated_at: "2025-09-17T00:20:19Z"
 files: ["bcachefs"]

--- a/content/gists/452ef1dfef6ee6d31bcbd6e0c3cf54e3.md
+++ b/content/gists/452ef1dfef6ee6d31bcbd6e0c3cf54e3.md
@@ -2,6 +2,7 @@
 title: "452ef1dfef6ee6d31bcbd6e0c3cf54e3"
 type: gist
 gist_id: "452ef1dfef6ee6d31bcbd6e0c3cf54e3"
+gist_name: "gistfile1.txt"
 gist_url: https://gist.github.com/dominicusin/452ef1dfef6ee6d31bcbd6e0c3cf54e3
 updated_at: "2026-07-03T18:41:14Z"
 files: ["gistfile1.txt"]

--- a/content/gists/453331637420dcb50d285b2de7aee442.md
+++ b/content/gists/453331637420dcb50d285b2de7aee442.md
@@ -2,6 +2,7 @@
 title: "UniGetUI package backups - DO NOT RENAME OR MODIFY @[UNIGETUI_BACKUP_V1]"
 type: gist
 gist_id: "453331637420dcb50d285b2de7aee442"
+gist_name: "UniGetUI package backups - DO NOT RENAME OR MODIFY @[UNIGETUI_BACKUP_V1] - UniGetUI Package Backups"
 gist_url: https://gist.github.com/dominicusin/453331637420dcb50d285b2de7aee442
 updated_at: "2026-07-24T06:27:15Z"
 files: ["- UniGetUI Package Backups", "@[PACKAGES] HELLY\\domini"]

--- a/content/gists/482d659ac820bab728e62fde1d03c12f.md
+++ b/content/gists/482d659ac820bab728e62fde1d03c12f.md
@@ -2,6 +2,7 @@
 title: "Mac"
 type: gist
 gist_id: "482d659ac820bab728e62fde1d03c12f"
+gist_name: "Mac Mac"
 gist_url: https://gist.github.com/dominicusin/482d659ac820bab728e62fde1d03c12f
 updated_at: "2023-02-26T04:04:12Z"
 files: ["Mac"]

--- a/content/gists/4a047210e796441807a58e16db6ad798.md
+++ b/content/gists/4a047210e796441807a58e16db6ad798.md
@@ -2,6 +2,7 @@
 title: "4a047210e796441807a58e16db6ad798"
 type: gist
 gist_id: "4a047210e796441807a58e16db6ad798"
+gist_name: "Flatpak-Repos"
 gist_url: https://gist.github.com/dominicusin/4a047210e796441807a58e16db6ad798
 updated_at: "2019-09-09T11:15:54Z"
 files: ["Flatpak-Repos"]

--- a/content/gists/4d2dd71dbda592ec3e974f895d9629b6.md
+++ b/content/gists/4d2dd71dbda592ec3e974f895d9629b6.md
@@ -2,6 +2,7 @@
 title: "lists"
 type: gist
 gist_id: "4d2dd71dbda592ec3e974f895d9629b6"
+gist_name: "lists lists"
 gist_url: https://gist.github.com/dominicusin/4d2dd71dbda592ec3e974f895d9629b6
 updated_at: "2024-10-23T14:15:44Z"
 files: ["lists"]

--- a/content/gists/528a20e611d5592b180305f9057b8741.md
+++ b/content/gists/528a20e611d5592b180305f9057b8741.md
@@ -2,6 +2,7 @@
 title: "Fix homebrew permissions"
 type: gist
 gist_id: "528a20e611d5592b180305f9057b8741"
+gist_name: "Fix homebrew permissions homebrew-permissions.sh"
 gist_url: https://gist.github.com/dominicusin/528a20e611d5592b180305f9057b8741
 updated_at: "2022-04-03T23:33:39Z"
 files: ["homebrew-permissions.sh"]

--- a/content/gists/583235312bacc9983952507a53735115.md
+++ b/content/gists/583235312bacc9983952507a53735115.md
@@ -2,6 +2,7 @@
 title: "So Long and Thanks for all the fish!"
 type: gist
 gist_id: "583235312bacc9983952507a53735115"
+gist_name: "So Long and Thanks for all the fish! So Long and Thanks for all the fish!"
 gist_url: https://gist.github.com/dominicusin/583235312bacc9983952507a53735115
 updated_at: "2018-06-12T10:05:11Z"
 files: ["So Long and Thanks for all the fish!"]

--- a/content/gists/58ae13c2ddf55b6966595a0182567a30.md
+++ b/content/gists/58ae13c2ddf55b6966595a0182567a30.md
@@ -2,6 +2,7 @@
 title: "TrueOS"
 type: gist
 gist_id: "58ae13c2ddf55b6966595a0182567a30"
+gist_name: "TrueOS TrueOS"
 gist_url: https://gist.github.com/dominicusin/58ae13c2ddf55b6966595a0182567a30
 updated_at: "2017-11-20T21:55:01Z"
 files: ["TrueOS"]

--- a/content/gists/58e2c9b787741ff9d62e30ce030f58a1.md
+++ b/content/gists/58e2c9b787741ff9d62e30ce030f58a1.md
@@ -2,6 +2,7 @@
 title: "synology"
 type: gist
 gist_id: "58e2c9b787741ff9d62e30ce030f58a1"
+gist_name: "synology gistfile1.txt"
 gist_url: https://gist.github.com/dominicusin/58e2c9b787741ff9d62e30ce030f58a1
 updated_at: "2025-04-26T20:39:01Z"
 files: ["gistfile1.txt"]

--- a/content/gists/5926cdfee45ec2e1d664ced1abf5628f.md
+++ b/content/gists/5926cdfee45ec2e1d664ced1abf5628f.md
@@ -2,6 +2,7 @@
 title: "5926cdfee45ec2e1d664ced1abf5628f"
 type: gist
 gist_id: "5926cdfee45ec2e1d664ced1abf5628f"
+gist_name: "kali"
 gist_url: https://gist.github.com/dominicusin/5926cdfee45ec2e1d664ced1abf5628f
 updated_at: "2018-01-31T14:10:06Z"
 files: ["kali"]

--- a/content/gists/5fa3919280cfc3fc2ce574245aa999d0.md
+++ b/content/gists/5fa3919280cfc3fc2ce574245aa999d0.md
@@ -2,6 +2,7 @@
 title: "Welcome file"
 type: gist
 gist_id: "5fa3919280cfc3fc2ce574245aa999d0"
+gist_name: "Welcome file Фрактальная архитектура знака.md"
 gist_url: https://gist.github.com/dominicusin/5fa3919280cfc3fc2ce574245aa999d0
 updated_at: "2026-01-05T10:20:01Z"
 files: ["Фрактальная архитектура знака.md"]

--- a/content/gists/60410f39210a1682aa656501f3b0fc9a.md
+++ b/content/gists/60410f39210a1682aa656501f3b0fc9a.md
@@ -2,6 +2,7 @@
 title: "sources"
 type: gist
 gist_id: "60410f39210a1682aa656501f3b0fc9a"
+gist_name: "sources sources"
 gist_url: https://gist.github.com/dominicusin/60410f39210a1682aa656501f3b0fc9a
 updated_at: "2024-10-23T14:13:40Z"
 files: ["sources"]

--- a/content/gists/64a2951303a20059006c99895f8a35d8.md
+++ b/content/gists/64a2951303a20059006c99895f8a35d8.md
@@ -2,6 +2,7 @@
 title: "zpool create"
 type: gist
 gist_id: "64a2951303a20059006c99895f8a35d8"
+gist_name: "zpool create myzfs"
 gist_url: https://gist.github.com/dominicusin/64a2951303a20059006c99895f8a35d8
 updated_at: "2025-02-08T06:21:36Z"
 files: ["myzfs"]

--- a/content/gists/67baf68d2ee158622beafaa127746e0f.md
+++ b/content/gists/67baf68d2ee158622beafaa127746e0f.md
@@ -2,6 +2,7 @@
 title: "sudo leafpad /etc/polkit-1/rules.d/49-nopasswd_global.rules"
 type: gist
 gist_id: "67baf68d2ee158622beafaa127746e0f"
+gist_name: "sudo leafpad /etc/polkit-1/rules.d/49-nopasswd_global.rules wheel!"
 gist_url: https://gist.github.com/dominicusin/67baf68d2ee158622beafaa127746e0f
 updated_at: "2020-10-03T20:46:40Z"
 files: ["wheel!"]

--- a/content/gists/67c26030eb6b6c718a2d6b80dda24861.md
+++ b/content/gists/67c26030eb6b6c718a2d6b80dda24861.md
@@ -2,6 +2,7 @@
 title: "67c26030eb6b6c718a2d6b80dda24861"
 type: gist
 gist_id: "67c26030eb6b6c718a2d6b80dda24861"
+gist_name: "lede"
 gist_url: https://gist.github.com/dominicusin/67c26030eb6b6c718a2d6b80dda24861
 updated_at: "2018-01-11T00:59:16Z"
 files: ["lede"]

--- a/content/gists/68ff653bc0c361e07ce010d497199133.md
+++ b/content/gists/68ff653bc0c361e07ce010d497199133.md
@@ -2,6 +2,7 @@
 title: "X11 in docker on macOS"
 type: gist
 gist_id: "68ff653bc0c361e07ce010d497199133"
+gist_name: "X11 in docker on macOS x11_docker_mac.md"
 gist_url: https://gist.github.com/dominicusin/68ff653bc0c361e07ce010d497199133
 updated_at: "2022-05-17T21:52:15Z"
 files: ["x11_docker_mac.md"]

--- a/content/gists/6ba96be2e7937e2cd37a6e170cb48ded.md
+++ b/content/gists/6ba96be2e7937e2cd37a6e170cb48ded.md
@@ -2,6 +2,7 @@
 title: "Procmail config and PHP script for sending email source address and subject to given callsigns through APRS-IS."
 type: gist
 gist_id: "6ba96be2e7937e2cd37a6e170cb48ded"
+gist_name: "Procmail config and PHP script for sending email source address and subject to given callsigns through APRS-IS. .procmailrc"
 gist_url: https://gist.github.com/dominicusin/6ba96be2e7937e2cd37a6e170cb48ded
 updated_at: "2018-03-23T00:08:05Z"
 files: [".procmailrc", "mail2aprs.php"]

--- a/content/gists/6d204b10f018be92b47d0f42ff07182b.md
+++ b/content/gists/6d204b10f018be92b47d0f42ff07182b.md
@@ -2,6 +2,7 @@
 title: "win fod"
 type: gist
 gist_id: "6d204b10f018be92b47d0f42ff07182b"
+gist_name: "win fod gistfile1.txt"
 gist_url: https://gist.github.com/dominicusin/6d204b10f018be92b47d0f42ff07182b
 updated_at: "2023-08-15T22:20:32Z"
 files: ["gistfile1.txt"]

--- a/content/gists/72111096fb643bb37bfc58d8e4bcce4b.md
+++ b/content/gists/72111096fb643bb37bfc58d8e4bcce4b.md
@@ -2,6 +2,7 @@
 title: "How To Create Windows 10 China Government Edition EnterpriseG Volume:GVLK"
 type: gist
 gist_id: "72111096fb643bb37bfc58d8e4bcce4b"
+gist_name: "How To Create Windows 10 China Government Edition EnterpriseG Volume:GVLK How To Create Windows 10 China Government Edition EnterpriseG Volume:GVLK"
 gist_url: https://gist.github.com/dominicusin/72111096fb643bb37bfc58d8e4bcce4b
 updated_at: "2025-05-14T02:42:09Z"
 files: ["How To Create Windows 10 China Government Edition EnterpriseG Volume:GVLK", "Upgrade from any Previous Windows 10 Edition [Win 10 Version 1703 or above & Chinese Simplified Language Only!]"]

--- a/content/gists/722103bc60a802e97ccbe9ca1b6d06fa.md
+++ b/content/gists/722103bc60a802e97ccbe9ca1b6d06fa.md
@@ -2,6 +2,7 @@
 title: "zfs"
 type: gist
 gist_id: "722103bc60a802e97ccbe9ca1b6d06fa"
+gist_name: "zfs zfs"
 gist_url: https://gist.github.com/dominicusin/722103bc60a802e97ccbe9ca1b6d06fa
 updated_at: "2024-10-01T16:00:32Z"
 files: ["zfs"]

--- a/content/gists/7248e4acb831d3e27e7e561fb63edd74.md
+++ b/content/gists/7248e4acb831d3e27e7e561fb63edd74.md
@@ -2,6 +2,7 @@
 title: "brow"
 type: gist
 gist_id: "7248e4acb831d3e27e7e561fb63edd74"
+gist_name: "brow gistfile1.txt"
 gist_url: https://gist.github.com/dominicusin/7248e4acb831d3e27e7e561fb63edd74
 updated_at: "2024-09-07T16:33:07Z"
 files: ["gistfile1.txt"]

--- a/content/gists/730ac6432c0e7ef910f4755cf908274f.md
+++ b/content/gists/730ac6432c0e7ef910f4755cf908274f.md
@@ -2,6 +2,7 @@
 title: "install scoop & choco"
 type: gist
 gist_id: "730ac6432c0e7ef910f4755cf908274f"
+gist_name: "install scoop & choco chocoscoop.ps1"
 gist_url: https://gist.github.com/dominicusin/730ac6432c0e7ef910f4755cf908274f
 updated_at: "2023-07-07T18:45:18Z"
 files: ["chocoscoop.ps1"]

--- a/content/gists/7504f081b5676dd5e0089adb01123e89.md
+++ b/content/gists/7504f081b5676dd5e0089adb01123e89.md
@@ -2,6 +2,7 @@
 title: "Brain"
 type: gist
 gist_id: "7504f081b5676dd5e0089adb01123e89"
+gist_name: "Brain Brain"
 gist_url: https://gist.github.com/dominicusin/7504f081b5676dd5e0089adb01123e89
 updated_at: "2020-10-09T14:02:43Z"
 files: ["Brain"]

--- a/content/gists/755c277ba83be5c20a7ecd19b07c2923.md
+++ b/content/gists/755c277ba83be5c20a7ecd19b07c2923.md
@@ -2,6 +2,7 @@
 title: "guix"
 type: gist
 gist_id: "755c277ba83be5c20a7ecd19b07c2923"
+gist_name: "guix guix"
 gist_url: https://gist.github.com/dominicusin/755c277ba83be5c20a7ecd19b07c2923
 updated_at: "2021-07-27T09:10:48Z"
 files: ["guix"]

--- a/content/gists/75dc10649ef1619223938456e2f80458.md
+++ b/content/gists/75dc10649ef1619223938456e2f80458.md
@@ -2,6 +2,7 @@
 title: "arch"
 type: gist
 gist_id: "75dc10649ef1619223938456e2f80458"
+gist_name: "arch gistfile1.txt"
 gist_url: https://gist.github.com/dominicusin/75dc10649ef1619223938456e2f80458
 updated_at: "2025-07-03T09:54:46Z"
 files: ["gistfile1.txt"]

--- a/content/gists/75ee8041e0427c2d89898e35e0728e44.md
+++ b/content/gists/75ee8041e0427c2d89898e35e0728e44.md
@@ -2,6 +2,7 @@
 title: "Install scripts for installing Arch Linux on ZFS. Not runnable, just listed commands."
 type: gist
 gist_id: "75ee8041e0427c2d89898e35e0728e44"
+gist_name: "Install scripts for installing Arch Linux on ZFS. Not runnable, just listed commands. zfsinstall-1-setup.sh"
 gist_url: https://gist.github.com/dominicusin/75ee8041e0427c2d89898e35e0728e44
 updated_at: "2018-03-14T18:32:51Z"
 files: ["zfsinstall-1-setup.sh", "zfsinstall-2.sh", "zfsinstall-3-postinstall.sh"]

--- a/content/gists/7608481de54a0a9c915dab48aa283c26.md
+++ b/content/gists/7608481de54a0a9c915dab48aa283c26.md
@@ -2,6 +2,7 @@
 title: "VMware Workstation"
 type: gist
 gist_id: "7608481de54a0a9c915dab48aa283c26"
+gist_name: "VMware Workstation VMware Workstation"
 gist_url: https://gist.github.com/dominicusin/7608481de54a0a9c915dab48aa283c26
 updated_at: "2022-12-17T13:46:20Z"
 files: ["VMware Workstation"]

--- a/content/gists/7739a675fd94b0daa58742c4247d3804.md
+++ b/content/gists/7739a675fd94b0daa58742c4247d3804.md
@@ -2,6 +2,7 @@
 title: "7739a675fd94b0daa58742c4247d3804"
 type: gist
 gist_id: "7739a675fd94b0daa58742c4247d3804"
+gist_name: "dochroot"
 gist_url: https://gist.github.com/dominicusin/7739a675fd94b0daa58742c4247d3804
 updated_at: "2022-04-10T19:43:22Z"
 files: ["dochroot"]

--- a/content/gists/773bf55727894f0c44e0ffc70f903d08.md
+++ b/content/gists/773bf55727894f0c44e0ffc70f903d08.md
@@ -2,6 +2,7 @@
 title: "NOPASSWD"
 type: gist
 gist_id: "773bf55727894f0c44e0ffc70f903d08"
+gist_name: "NOPASSWD NOPASSWD"
 gist_url: https://gist.github.com/dominicusin/773bf55727894f0c44e0ffc70f903d08
 updated_at: "2023-09-03T00:58:19Z"
 files: ["NOPASSWD"]

--- a/content/gists/804db252184e80489a35d881d1f08f06.md
+++ b/content/gists/804db252184e80489a35d881d1f08f06.md
@@ -2,6 +2,7 @@
 title: "btrfs"
 type: gist
 gist_id: "804db252184e80489a35d881d1f08f06"
+gist_name: "btrfs gistfile1.txt"
 gist_url: https://gist.github.com/dominicusin/804db252184e80489a35d881d1f08f06
 updated_at: "2026-08-04T14:31:04Z"
 files: ["gistfile1.txt"]

--- a/content/gists/8402abedb4df49c2852ce150f03a5372.md
+++ b/content/gists/8402abedb4df49c2852ce150f03a5372.md
@@ -2,6 +2,7 @@
 title: "chroot"
 type: gist
 gist_id: "8402abedb4df49c2852ce150f03a5372"
+gist_name: "chroot make chroot"
 gist_url: https://gist.github.com/dominicusin/8402abedb4df49c2852ce150f03a5372
 updated_at: "2025-09-18T03:49:03Z"
 files: ["make chroot"]

--- a/content/gists/8bc6247e5619122fa18f83c702c017d7.md
+++ b/content/gists/8bc6247e5619122fa18f83c702c017d7.md
@@ -2,6 +2,7 @@
 title: "ugly hacky script to rebuild all dkms modules plus manually force zfs if it's intree for debian/ubuntu"
 type: gist
 gist_id: "8bc6247e5619122fa18f83c702c017d7"
+gist_name: "ugly hacky script to rebuild all dkms modules plus manually force zfs if it's intree for debian/ubuntu reinstall-dkms-modules-pluszfs.sh"
 gist_url: https://gist.github.com/dominicusin/8bc6247e5619122fa18f83c702c017d7
 updated_at: "2018-03-18T16:41:23Z"
 files: ["reinstall-dkms-modules-pluszfs.sh"]

--- a/content/gists/90e429c44e469029745bdb0a178b2eec.md
+++ b/content/gists/90e429c44e469029745bdb0a178b2eec.md
@@ -2,6 +2,7 @@
 title: "90e429c44e469029745bdb0a178b2eec"
 type: gist
 gist_id: "90e429c44e469029745bdb0a178b2eec"
+gist_name: "backuphost.nix"
 gist_url: https://gist.github.com/dominicusin/90e429c44e469029745bdb0a178b2eec
 updated_at: "2018-02-20T18:13:28Z"
 files: ["backuphost.nix"]

--- a/content/gists/93445e617b848ab12e5b0a7026f25752.md
+++ b/content/gists/93445e617b848ab12e5b0a7026f25752.md
@@ -2,6 +2,7 @@
 title: "flatpaks"
 type: gist
 gist_id: "93445e617b848ab12e5b0a7026f25752"
+gist_name: "flatpaks gistfile1.txt"
 gist_url: https://gist.github.com/dominicusin/93445e617b848ab12e5b0a7026f25752
 updated_at: "2025-05-04T07:56:00Z"
 files: ["gistfile1.txt"]

--- a/content/gists/953c8be270e8a4b89bc295c1a938610e.md
+++ b/content/gists/953c8be270e8a4b89bc295c1a938610e.md
@@ -2,6 +2,7 @@
 title: "Get-Service | Set-Service -StartupType Manual"
 type: gist
 gist_id: "953c8be270e8a4b89bc295c1a938610e"
+gist_name: "Get-Service | Set-Service -StartupType Manual Get-Service | Set-Service -StartupType Manual"
 gist_url: https://gist.github.com/dominicusin/953c8be270e8a4b89bc295c1a938610e
 updated_at: "2023-12-07T13:19:37Z"
 files: ["Get-Service | Set-Service -StartupType Manual"]

--- a/content/gists/97f63e4542b22301893514820887bf94.md
+++ b/content/gists/97f63e4542b22301893514820887bf94.md
@@ -2,6 +2,7 @@
 title: "bosto digitizer"
 type: gist
 gist_id: "97f63e4542b22301893514820887bf94"
+gist_name: "bosto digitizer BOSTO"
 gist_url: https://gist.github.com/dominicusin/97f63e4542b22301893514820887bf94
 updated_at: "2021-04-19T01:58:08Z"
 files: ["BOSTO"]

--- a/content/gists/9b501e765b90f223a969b1617e067222.md
+++ b/content/gists/9b501e765b90f223a969b1617e067222.md
@@ -2,6 +2,7 @@
 title: "ed's"
 type: gist
 gist_id: "9b501e765b90f223a969b1617e067222"
+gist_name: "ed's ed's"
 gist_url: https://gist.github.com/dominicusin/9b501e765b90f223a969b1617e067222
 updated_at: "2025-03-27T09:15:22Z"
 files: ["ed's"]

--- a/content/gists/9e405de964d9f42c34833cecac25e568.md
+++ b/content/gists/9e405de964d9f42c34833cecac25e568.md
@@ -2,6 +2,7 @@
 title: "do-release-upgrade"
 type: gist
 gist_id: "9e405de964d9f42c34833cecac25e568"
+gist_name: "do-release-upgrade  do-release-upgrade"
 gist_url: https://gist.github.com/dominicusin/9e405de964d9f42c34833cecac25e568
 updated_at: "2025-04-04T08:27:54Z"
 files: ["do-release-upgrade"]

--- a/content/gists/9ecefd2a09d90f0fe6ce465f60051e61.md
+++ b/content/gists/9ecefd2a09d90f0fe6ce465f60051e61.md
@@ -2,6 +2,7 @@
 title: "From: Chris Wanstrath <chris@github.com>"
 type: gist
 gist_id: "9ecefd2a09d90f0fe6ce465f60051e61"
+gist_name: "From: Chris Wanstrath <chris@github.com> From: Chris Wanstrath <chris@github.com>"
 gist_url: https://gist.github.com/dominicusin/9ecefd2a09d90f0fe6ce465f60051e61
 updated_at: "2026-04-20T15:43:40Z"
 files: ["From: Chris Wanstrath <chris@github.com>"]

--- a/content/gists/a4ad9e564ff2e3216ac7fd2f5a761309.md
+++ b/content/gists/a4ad9e564ff2e3216ac7fd2f5a761309.md
@@ -2,6 +2,7 @@
 title: "phpBB 2 Flarum"
 type: gist
 gist_id: "a4ad9e564ff2e3216ac7fd2f5a761309"
+gist_name: "phpBB 2 Flarum Flarum"
 gist_url: https://gist.github.com/dominicusin/a4ad9e564ff2e3216ac7fd2f5a761309
 updated_at: "2022-09-15T17:35:49Z"
 files: ["Flarum"]

--- a/content/gists/a549a30e4e3e34b89664e88907b87c02.md
+++ b/content/gists/a549a30e4e3e34b89664e88907b87c02.md
@@ -2,6 +2,7 @@
 title: "mport search '*'|cut -f1|sort -u|xargs mport install"
 type: gist
 gist_id: "a549a30e4e3e34b89664e88907b87c02"
+gist_name: "mport search '*'|cut -f1|sort -u|xargs mport install mport"
 gist_url: https://gist.github.com/dominicusin/a549a30e4e3e34b89664e88907b87c02
 updated_at: "2022-04-12T23:11:11Z"
 files: ["mport"]

--- a/content/gists/a624d42e157928c124e582a44f552d15.md
+++ b/content/gists/a624d42e157928c124e582a44f552d15.md
@@ -2,6 +2,7 @@
 title: "Hexlet programming principles"
 type: gist
 gist_id: "a624d42e157928c124e582a44f552d15"
+gist_name: "Hexlet programming principles hexlet-principles.md"
 gist_url: https://gist.github.com/dominicusin/a624d42e157928c124e582a44f552d15
 updated_at: "2018-01-17T16:51:34Z"
 files: ["hexlet-principles.md"]

--- a/content/gists/a94364c9e2c9e742d0c94dc58a706361.md
+++ b/content/gists/a94364c9e2c9e742d0c94dc58a706361.md
@@ -2,6 +2,7 @@
 title: "channels.scm"
 type: gist
 gist_id: "a94364c9e2c9e742d0c94dc58a706361"
+gist_name: "channels.scm channels.scm"
 gist_url: https://gist.github.com/dominicusin/a94364c9e2c9e742d0c94dc58a706361
 updated_at: "2025-09-03T11:47:01Z"
 files: ["channels.scm"]

--- a/content/gists/aa31915edbc0f3552967de367f03e6ee.md
+++ b/content/gists/aa31915edbc0f3552967de367f03e6ee.md
@@ -2,6 +2,7 @@
 title: "Setup unattended installation for moving `USERS` and `AppData` folder on Windows 8"
 type: gist
 gist_id: "aa31915edbc0f3552967de367f03e6ee"
+gist_name: "Setup unattended installation for moving `USERS` and `AppData` folder on Windows 8 unattended installation.md"
 gist_url: https://gist.github.com/dominicusin/aa31915edbc0f3552967de367f03e6ee
 updated_at: "2020-04-04T22:35:35Z"
 files: ["unattended installation.md"]

--- a/content/gists/b21cc5f08605850ca1b1932e12a1e886.md
+++ b/content/gists/b21cc5f08605850ca1b1932e12a1e886.md
@@ -2,6 +2,7 @@
 title: "b21cc5f08605850ca1b1932e12a1e886"
 type: gist
 gist_id: "b21cc5f08605850ca1b1932e12a1e886"
+gist_name: "gistfile1.txt"
 gist_url: https://gist.github.com/dominicusin/b21cc5f08605850ca1b1932e12a1e886
 updated_at: "2020-04-01T19:08:53Z"
 files: ["gistfile1.txt"]

--- a/content/gists/b4c9b272fc9e4dd512af0298ab5ad5fa.md
+++ b/content/gists/b4c9b272fc9e4dd512af0298ab5ad5fa.md
@@ -2,6 +2,7 @@
 title: "wind"
 type: gist
 gist_id: "b4c9b272fc9e4dd512af0298ab5ad5fa"
+gist_name: "wind gistfile1.txt"
 gist_url: https://gist.github.com/dominicusin/b4c9b272fc9e4dd512af0298ab5ad5fa
 updated_at: "2024-10-12T23:25:58Z"
 files: ["gistfile1.txt"]

--- a/content/gists/b6b1dda15f789d36ea10d0139197c812.md
+++ b/content/gists/b6b1dda15f789d36ea10d0139197c812.md
@@ -2,6 +2,7 @@
 title: "How to Install Niresh Yosemite on Your PC"
 type: gist
 gist_id: "b6b1dda15f789d36ea10d0139197c812"
+gist_name: "How to Install Niresh Yosemite on Your PC install_niresh_hackintosh.md"
 gist_url: https://gist.github.com/dominicusin/b6b1dda15f789d36ea10d0139197c812
 updated_at: "2020-10-20T18:09:20Z"
 files: ["install_niresh_hackintosh.md"]

--- a/content/gists/b76c13feb514468c2fd0751fe8c211fd.md
+++ b/content/gists/b76c13feb514468c2fd0751fe8c211fd.md
@@ -2,6 +2,7 @@
 title: "b76c13feb514468c2fd0751fe8c211fd"
 type: gist
 gist_id: "b76c13feb514468c2fd0751fe8c211fd"
+gist_name: "WDMCH"
 gist_url: https://gist.github.com/dominicusin/b76c13feb514468c2fd0751fe8c211fd
 updated_at: "2023-08-22T19:36:22Z"
 files: ["WDMCH"]

--- a/content/gists/bb91fc051d96cb5d7582eaedead01c3b.md
+++ b/content/gists/bb91fc051d96cb5d7582eaedead01c3b.md
@@ -2,6 +2,7 @@
 title: "OpenZFS on OS X on boot installer script"
 type: gist
 gist_id: "bb91fc051d96cb5d7582eaedead01c3b"
+gist_name: "OpenZFS on OS X on boot installer script zfsonosxonboot.sh"
 gist_url: https://gist.github.com/dominicusin/bb91fc051d96cb5d7582eaedead01c3b
 updated_at: "2022-06-08T00:06:08Z"
 files: ["zfsonosxonboot.sh"]

--- a/content/gists/bc11f740687bcde1b2578bd00b6fbb1a.md
+++ b/content/gists/bc11f740687bcde1b2578bd00b6fbb1a.md
@@ -2,6 +2,7 @@
 title: "unsubscribe all youtube channels script v2"
 type: gist
 gist_id: "bc11f740687bcde1b2578bd00b6fbb1a"
+gist_name: "unsubscribe all youtube channels script v2 unsubscrive-youtube-v2.js"
 gist_url: https://gist.github.com/dominicusin/bc11f740687bcde1b2578bd00b6fbb1a
 updated_at: "2022-03-30T17:08:29Z"
 files: ["unsubscrive-youtube-v2.js"]

--- a/content/gists/c108d48c03aef7dc18fcbe7b1c19fb82.md
+++ b/content/gists/c108d48c03aef7dc18fcbe7b1c19fb82.md
@@ -2,6 +2,7 @@
 title: "onelinecmd"
 type: gist
 gist_id: "c108d48c03aef7dc18fcbe7b1c19fb82"
+gist_name: "onelinecmd gistfile1.txt"
 gist_url: https://gist.github.com/dominicusin/c108d48c03aef7dc18fcbe7b1c19fb82
 updated_at: "2023-12-22T04:17:14Z"
 files: ["gistfile1.txt"]

--- a/content/gists/c1e0b1421301393357f81556bd6d53ca.md
+++ b/content/gists/c1e0b1421301393357f81556bd6d53ca.md
@@ -2,6 +2,7 @@
 title: "gentoo_make"
 type: gist
 gist_id: "c1e0b1421301393357f81556bd6d53ca"
+gist_name: "gentoo_make gentoo_make"
 gist_url: https://gist.github.com/dominicusin/c1e0b1421301393357f81556bd6d53ca
 updated_at: "2024-03-13T05:35:44Z"
 files: ["gentoo_make"]

--- a/content/gists/c3b20da8c315b7a2852641533fffca74.md
+++ b/content/gists/c3b20da8c315b7a2852641533fffca74.md
@@ -2,6 +2,7 @@
 title: "Fedora with Root on ZFS - installation notes"
 type: gist
 gist_id: "c3b20da8c315b7a2852641533fffca74"
+gist_name: "Fedora with Root on ZFS - installation notes Fedora_Root_On_ZFS.md"
 gist_url: https://gist.github.com/dominicusin/c3b20da8c315b7a2852641533fffca74
 updated_at: "2020-12-24T04:03:12Z"
 files: ["Fedora_Root_On_ZFS.md"]

--- a/content/gists/c484e8ede9e3145862e04331505e970e.md
+++ b/content/gists/c484e8ede9e3145862e04331505e970e.md
@@ -2,6 +2,7 @@
 title: "old opkg conf"
 type: gist
 gist_id: "c484e8ede9e3145862e04331505e970e"
+gist_name: "old opkg conf old opkg conf"
 gist_url: https://gist.github.com/dominicusin/c484e8ede9e3145862e04331505e970e
 updated_at: "2022-04-12T23:10:30Z"
 files: ["old opkg conf"]

--- a/content/gists/c71a615c6a428abce7b764f864b9e23a.md
+++ b/content/gists/c71a615c6a428abce7b764f864b9e23a.md
@@ -2,6 +2,7 @@
 title: "Massive list of user agents for User Agent Switcher by Chris Pederik http://forums.chrispederick.com/categories/user-agent-switcher"
 type: gist
 gist_id: "c71a615c6a428abce7b764f864b9e23a"
+gist_name: "Massive list of user agents for User Agent Switcher by Chris Pederik http://forums.chrispederick.com/categories/user-agent-switcher useragentswitcher.xml"
 gist_url: https://gist.github.com/dominicusin/c71a615c6a428abce7b764f864b9e23a
 updated_at: "2017-11-20T19:41:14Z"
 files: ["useragentswitcher.xml"]

--- a/content/gists/c7a0c4349e49bc82614ab96c031c3493.md
+++ b/content/gists/c7a0c4349e49bc82614ab96c031c3493.md
@@ -2,6 +2,7 @@
 title: "korora"
 type: gist
 gist_id: "c7a0c4349e49bc82614ab96c031c3493"
+gist_name: "korora korora"
 gist_url: https://gist.github.com/dominicusin/c7a0c4349e49bc82614ab96c031c3493
 updated_at: "2020-09-12T11:10:39Z"
 files: ["korora"]

--- a/content/gists/c848a318d8e7d4aaa4efbc4208df1a52.md
+++ b/content/gists/c848a318d8e7d4aaa4efbc4208df1a52.md
@@ -2,6 +2,7 @@
 title: "c848a318d8e7d4aaa4efbc4208df1a52"
 type: gist
 gist_id: "c848a318d8e7d4aaa4efbc4208df1a52"
+gist_name: "config.scm"
 gist_url: https://gist.github.com/dominicusin/c848a318d8e7d4aaa4efbc4208df1a52
 updated_at: "2018-02-19T22:29:17Z"
 files: ["config.scm"]

--- a/content/gists/cca3224f48ef7fcd127f06f7f046cdd4.md
+++ b/content/gists/cca3224f48ef7fcd127f06f7f046cdd4.md
@@ -2,6 +2,7 @@
 title: "Debian GNU Hurd installation in real hardware"
 type: gist
 gist_id: "cca3224f48ef7fcd127f06f7f046cdd4"
+gist_name: "Debian GNU Hurd installation in real hardware Debian_Hurd_Install.md"
 gist_url: https://gist.github.com/dominicusin/cca3224f48ef7fcd127f06f7f046cdd4
 updated_at: "2020-12-24T03:56:23Z"
 files: ["Debian_Hurd_Install.md"]

--- a/content/gists/cd0c76e376926be69d9423f54bad04af.md
+++ b/content/gists/cd0c76e376926be69d9423f54bad04af.md
@@ -2,6 +2,7 @@
 title: "Things to commit just before leaving your job"
 type: gist
 gist_id: "cd0c76e376926be69d9423f54bad04af"
+gist_name: "Things to commit just before leaving your job preprocessor_fun.h"
 gist_url: https://gist.github.com/dominicusin/cd0c76e376926be69d9423f54bad04af
 updated_at: "2018-09-17T06:32:45Z"
 files: ["preprocessor_fun.h"]

--- a/content/gists/cf9aaab4b1d07b86477a4a595500db24.md
+++ b/content/gists/cf9aaab4b1d07b86477a4a595500db24.md
@@ -2,6 +2,7 @@
 title: "VMWare Fusion Images with a static IP Address on Mac OS X Snow Leopard"
 type: gist
 gist_id: "cf9aaab4b1d07b86477a4a595500db24"
+gist_name: "VMWare Fusion Images with a static IP Address on Mac OS X Snow Leopard setup-vmware-image-with-static-IP.markdown"
 gist_url: https://gist.github.com/dominicusin/cf9aaab4b1d07b86477a4a595500db24
 updated_at: "2022-05-17T21:52:43Z"
 files: ["setup-vmware-image-with-static-IP.markdown"]

--- a/content/gists/d039ea1ba50b58d59e1013807a6168c7.md
+++ b/content/gists/d039ea1ba50b58d59e1013807a6168c7.md
@@ -2,6 +2,7 @@
 title: "d039ea1ba50b58d59e1013807a6168c7"
 type: gist
 gist_id: "d039ea1ba50b58d59e1013807a6168c7"
+gist_name: "exherbo"
 gist_url: https://gist.github.com/dominicusin/d039ea1ba50b58d59e1013807a6168c7
 updated_at: "2018-01-09T00:46:28Z"
 files: ["exherbo"]

--- a/content/gists/d07f06feb4263eaade37355099c8161c.md
+++ b/content/gists/d07f06feb4263eaade37355099c8161c.md
@@ -2,6 +2,7 @@
 title: "d07f06feb4263eaade37355099c8161c"
 type: gist
 gist_id: "d07f06feb4263eaade37355099c8161c"
+gist_name: "VS"
 gist_url: https://gist.github.com/dominicusin/d07f06feb4263eaade37355099c8161c
 updated_at: "2023-05-15T02:47:46Z"
 files: ["VS"]

--- a/content/gists/d2bdeb0251cce6969c3899624f3e5413.md
+++ b/content/gists/d2bdeb0251cce6969c3899624f3e5413.md
@@ -2,6 +2,7 @@
 title: "Моё резюме, написанное на Haskell"
 type: gist
 gist_id: "d2bdeb0251cce6969c3899624f3e5413"
+gist_name: "Моё резюме, написанное на Haskell CV.hs"
 gist_url: https://gist.github.com/dominicusin/d2bdeb0251cce6969c3899624f3e5413
 updated_at: "2018-01-17T15:03:08Z"
 files: ["CV.hs"]

--- a/content/gists/d36e39ec0183f56f230ffed9dacfbab4.md
+++ b/content/gists/d36e39ec0183f56f230ffed9dacfbab4.md
@@ -2,6 +2,7 @@
 title: "raid_bootloader_install"
 type: gist
 gist_id: "d36e39ec0183f56f230ffed9dacfbab4"
+gist_name: "raid_bootloader_install raid_bootloader_install.sh"
 gist_url: https://gist.github.com/dominicusin/d36e39ec0183f56f230ffed9dacfbab4
 updated_at: "2024-06-19T07:43:53Z"
 files: ["raid_bootloader_install.sh"]

--- a/content/gists/d52bb02582485fa5956de290d8c35639.md
+++ b/content/gists/d52bb02582485fa5956de290d8c35639.md
@@ -2,6 +2,7 @@
 title: "Void Linux Installation Guide (UEFI + chroot + brtfs + LUKS-encrypted root and swapfile)"
 type: gist
 gist_id: "d52bb02582485fa5956de290d8c35639"
+gist_name: "Void Linux Installation Guide (UEFI + chroot + brtfs + LUKS-encrypted root and swapfile) README.md"
 gist_url: https://gist.github.com/dominicusin/d52bb02582485fa5956de290d8c35639
 updated_at: "2022-02-13T20:44:04Z"
 files: ["README.md"]

--- a/content/gists/d62243a22926774129eb32dfa067da16.md
+++ b/content/gists/d62243a22926774129eb32dfa067da16.md
@@ -2,6 +2,7 @@
 title: "win net"
 type: gist
 gist_id: "d62243a22926774129eb32dfa067da16"
+gist_name: "win net winda"
 gist_url: https://gist.github.com/dominicusin/d62243a22926774129eb32dfa067da16
 updated_at: "2021-03-03T09:49:02Z"
 files: ["winda"]

--- a/content/gists/db842f92c4bdf62cd9cebddaff0da00b.md
+++ b/content/gists/db842f92c4bdf62cd9cebddaff0da00b.md
@@ -2,6 +2,7 @@
 title: "strip package version gentoo"
 type: gist
 gist_id: "db842f92c4bdf62cd9cebddaff0da00b"
+gist_name: "strip package version gentoo strip version"
 gist_url: https://gist.github.com/dominicusin/db842f92c4bdf62cd9cebddaff0da00b
 updated_at: "2022-03-28T23:32:11Z"
 files: ["strip version"]

--- a/content/gists/df6ba9a693aef08b7cca12f751f784c7.md
+++ b/content/gists/df6ba9a693aef08b7cca12f751f784c7.md
@@ -2,6 +2,7 @@
 title: "dns"
 type: gist
 gist_id: "df6ba9a693aef08b7cca12f751f784c7"
+gist_name: "dns gistfile1.txt"
 gist_url: https://gist.github.com/dominicusin/df6ba9a693aef08b7cca12f751f784c7
 updated_at: "2025-08-13T17:32:08Z"
 files: ["gistfile1.txt"]

--- a/content/gists/df715e4ac4000e4997881c07068f7ded.md
+++ b/content/gists/df715e4ac4000e4997881c07068f7ded.md
@@ -2,6 +2,7 @@
 title: "Принципы programming"
 type: gist
 gist_id: "df715e4ac4000e4997881c07068f7ded"
+gist_name: " Принципы programming  programming-principles.md"
 gist_url: https://gist.github.com/dominicusin/df715e4ac4000e4997881c07068f7ded
 updated_at: "2018-01-17T16:53:07Z"
 files: ["programming-principles.md"]

--- a/content/gists/e03c970e1ffef961859e7252fbd25120.md
+++ b/content/gists/e03c970e1ffef961859e7252fbd25120.md
@@ -2,6 +2,7 @@
 title: "BlockList"
 type: gist
 gist_id: "e03c970e1ffef961859e7252fbd25120"
+gist_name: "BlockList BlockList"
 gist_url: https://gist.github.com/dominicusin/e03c970e1ffef961859e7252fbd25120
 updated_at: "2022-03-27T04:32:27Z"
 files: ["BlockList"]

--- a/content/gists/e5f6346eaa312024c9500af4bf4443c3.md
+++ b/content/gists/e5f6346eaa312024c9500af4bf4443c3.md
@@ -2,6 +2,7 @@
 title: "suse"
 type: gist
 gist_id: "e5f6346eaa312024c9500af4bf4443c3"
+gist_name: "suse leap"
 gist_url: https://gist.github.com/dominicusin/e5f6346eaa312024c9500af4bf4443c3
 updated_at: "2017-12-29T17:00:42Z"
 files: ["leap"]

--- a/content/gists/ee9fed0beea74d3e265dc93a53772a53.md
+++ b/content/gists/ee9fed0beea74d3e265dc93a53772a53.md
@@ -2,6 +2,7 @@
 title: "guix0"
 type: gist
 gist_id: "ee9fed0beea74d3e265dc93a53772a53"
+gist_name: "guix0 gistfile1.txt"
 gist_url: https://gist.github.com/dominicusin/ee9fed0beea74d3e265dc93a53772a53
 updated_at: "2025-09-01T08:57:17Z"
 files: ["gistfile1.txt"]

--- a/content/gists/f22be14730b39628de19e166f07f1f57.md
+++ b/content/gists/f22be14730b39628de19e166f07f1f57.md
@@ -2,6 +2,7 @@
 title: "How to setup your own CA with OpenSSL"
 type: gist
 gist_id: "f22be14730b39628de19e166f07f1f57"
+gist_name: "How to setup your own CA with OpenSSL ca.md"
 gist_url: https://gist.github.com/dominicusin/f22be14730b39628de19e166f07f1f57
 updated_at: "2024-09-23T18:13:53Z"
 files: ["ca.md"]

--- a/content/gists/fad6557156c4c49ffb529b2aa4d0b278.md
+++ b/content/gists/fad6557156c4c49ffb529b2aa4d0b278.md
@@ -2,6 +2,7 @@
 title: "debs"
 type: gist
 gist_id: "fad6557156c4c49ffb529b2aa4d0b278"
+gist_name: "debs gistfile1.txt"
 gist_url: https://gist.github.com/dominicusin/fad6557156c4c49ffb529b2aa4d0b278
 updated_at: "2023-07-25T05:35:05Z"
 files: ["gistfile1.txt"]

--- a/layouts/gists/list.html
+++ b/layouts/gists/list.html
@@ -8,7 +8,7 @@
     {{ range .RegularPages.ByTitle }}
       <a class="repo-card" href="{{ .RelPermalink }}">
         <div class="repo-card-top">
-          <span class="repo-card-name">{{ .Params.gist_id }}</span>
+          <span class="repo-card-name">{{ .Params.gist_name }}</span>
         </div>
         <p class="repo-card-desc">{{ .Params.description | truncate 120 }}</p>
         <div class="repo-card-meta">

--- a/layouts/gists/single.html
+++ b/layouts/gists/single.html
@@ -2,7 +2,7 @@
   {{ .Scratch.Set "scope" "single" }}
   <article class="gist-page">
     <header class="gist-header">
-      <h1 class="mt-5 text-4xl font-extrabold text-neutral-900 dark:text-neutral">{{ .Title }}</h1>
+      <h1 class="mt-5 text-4xl font-extrabold text-neutral-900 dark:text-neutral">{{ .Params.gist_name | default .Title }}</h1>
       <div class="gist-links">
         <a class="repo-btn" href="{{ .Params.gist_url }}" target="_blank" rel="noopener">Открыть гист ↗</a>
         {{ with .Params.updated_at }}<span class="repo-pill">обновлён {{ dateFormat "2006-01-02" . }}</span>{{ end }}

--- a/scripts/sync-github.cjs
+++ b/scripts/sync-github.cjs
@@ -190,11 +190,18 @@ function writeGistPage(gist) {
   // .RegularPages in the list template, leaving /gists/ empty. Flat layout fixes it.
   const file = path.join(GIST_OUT, `${gist.id}.md`);
   fs.mkdirSync(GIST_OUT, { recursive: true });
+  // Human-readable name for the /gists/ list: "description firstFileName".
+  // For gist 21432… (description "zroot", file "zroot") this yields "zroot zroot".
+  const firstName = (gist.files && gist.files[0] && gist.files[0].name) || '';
+  const gistName = gist.description
+    ? (firstName ? `${gist.description} ${firstName}` : gist.description)
+    : (firstName || gist.id);
   const fm = [
     '---',
     `title: ${yamlish(gist.description || gist.id)}`,
     'type: gist',
     `gist_id: ${JSON.stringify(gist.id)}`,
+    `gist_name: ${JSON.stringify(gistName)}`,
     `gist_url: https://gist.github.com/${GIST_USER}/${gist.id}`,
     `updated_at: ${JSON.stringify(gist.updated_at || '')}`,
     `files: ${qlist(gist.files.map(f => f.name))}`,


### PR DESCRIPTION
## Summary
On `/gists/` every card showed the 32-char `gist_id` hash (e.g. `21432fc5f29c73591044eafa09e6fafc`) instead of a readable name. The example gist should render as **"zroot zroot"** (description "zroot" + file "zroot").

## Root cause (VERIFIED)
`layouts/gists/list.html` rendered `{{ .Params.gist_id }}`. The generated page frontmatter already carried the name parts (`title`=description, `files`=file names) but no single display name. For gist `21432…`: `description='zroot'`, `files=['zroot']` → "zroot zroot".

## Fix
- `scripts/sync-github.cjs writeGistPage` now emits `gist_name` = `(description ? description + ' ' : '') + firstFileName` (fallback description || id).
- `layouts/gists/list.html` renders `{{ .Params.gist_name }}` (was gist_id).
- `layouts/gists/single.html` renders `gist_name` in the h1. The hash stays only in the URL slug (live links preserved).

## Verification
- built `public/gists/index.html`: **0 of 100 cards** show a 32-char hex hash as the visible name; example card reads "zroot zroot"; hash appears only in href.
- `hugo` 0 errors; lint clean; test ALL PASSED; check-links 0 broken; check-perf 0 regressions.

## Task system (strict 4-layer)
- BMAD: `.planning/initiatives/gist-names.md`
- Spec Kit: `.specify/gist-names.md`
- Beads: `.beads/beads.json` (T49–T52)
- GSD: `.gsd/plan.md` (Phase N)