### PR TITLE
feat(kb-taxonomy): deepen multi-layer ontology — language concept layer

### DIFF
--- a/.beads/beads.json
+++ b/.beads/beads.json
@@ -55,7 +55,11 @@
     { "id": "T49", "kind": "task", "title": "writeGistPage: emit gist_name = desc + firstFileName (fallback desc||id)", "status": "done", "deps": [], "artifacts": ["scripts/sync-github.cjs"], "verified": "gist_name: 'zroot zroot' for 21432…", "initiative": "gist-names" },
     { "id": "T50", "kind": "task", "title": "list.html + single.html render gist_name instead of gist_id", "status": "done", "deps": ["T49"], "artifacts": ["layouts/gists/list.html", "layouts/gists/single.html"], "initiative": "gist-names" },
     { "id": "T51", "kind": "task", "title": "Regenerate content/gists; verify built list shows names (zroot zroot), build/lint/test/linkcheck/perf green", "status": "done", "deps": ["T50"], "artifacts": ["public/gists/index.html"], "verified": "0 hash-names of 100 cards; build/lint/test/linkcheck/perf green", "initiative": "gist-names" },
-    { "id": "T52", "kind": "task", "title": "Commit + PR + gh pr merge --admin for gist-names", "status": "done", "deps": ["T51"], "pr": 118, "merged": "30dba679e", "initiative": "gist-names" }
+    { "id": "T52", "kind": "task", "title": "Commit + PR + gh pr merge --admin for gist-names", "status": "done", "deps": ["T51"], "pr": 118, "merged": "30dba679e", "initiative": "gist-names" },
+    { "id": "T53", "kind": "task", "title": "sync-github.cjs: persist gist file lang in gistsOut.files (f.lang||guessLang)", "status": "done", "deps": [], "artifacts": ["scripts/sync-github.cjs", "data/github.json"], "verified": "gist files carry lang (e.g. Shell)", "initiative": "kb-taxonomy" },
+    { "id": "T54", "kind": "task", "title": "build-knowledge-graph.cjs: lang concept layer (repo+gist tagged lang:), repo↔repo relatedTo by language", "status": "done", "deps": ["T53"], "artifacts": ["scripts/build-knowledge-graph.cjs"], "verified": "lang: concepts added; repo+gist tagged by lang", "initiative": "kb-taxonomy" },
+    { "id": "T55", "kind": "task", "title": "Rebuild KG; measure deltas (edges, isolated gists, repo↔repo relatedTo); build/lint/test/linkcheck/perf green", "status": "done", "deps": ["T54"], "artifacts": ["static/data/knowledge-graph.json"], "verified": "nodes 393→420, edges 699→1007, relatedTo 6→208, isolated gists 100→64", "initiative": "kb-taxonomy" },
+    { "id": "T56", "kind": "task", "title": "Commit + PR + gh pr merge --admin for kb-taxonomy", "status": "in_progress", "deps": ["T55"], "initiative": "kb-taxonomy" }
   ],
   "edges": [
     { "from": "T2", "to": "T3", "type": "enables" },
@@ -102,6 +106,9 @@
     { "from": "T47", "to": "T48", "type": "blocks" },
     { "from": "T49", "to": "T50", "type": "enables" },
     { "from": "T50", "to": "T51", "type": "enables" },
-    { "from": "T51", "to": "T52", "type": "blocks" }
+    { "from": "T51", "to": "T52", "type": "blocks" },
+    { "from": "T53", "to": "T54", "type": "enables" },
+    { "from": "T54", "to": "T55", "type": "enables" },
+    { "from": "T55", "to": "T56", "type": "blocks" }
   ]
 }

--- a/.gsd/plan.md
+++ b/.gsd/plan.md
@@ -276,5 +276,28 @@ Beads T37–T39 = `done`; T40 (commit+PR+merge) in_progress.
   gist and names (not hashes) across the list; `hugo` 0 errors; lint clean; test
   ALL PASSED; check-links 0 broken; check-perf 0 regressions.
 
+---
+
+## Initiative 12: `kb-taxonomy` (focus-topic: deepen multi-layer ontology, expand taxonomy) — DONE
+- **Audit (measured):** KG 393 nodes / 699 edges. 100/100 gists isolated (only
+  `authored`); 121/128 repos degree ≤ 1; repo↔repo `relatedTo` = 6; repo `topics`
+  too sparse (7 repos, 9 total). Real fields: repo `language` (70/128); gist file
+  name (100/100) with 26/100 having a code-language extension. Ingest wrote only
+  gist file `name` (no `lang`), so `data/github.json` lacked gist language.
+- **Fix:**
+  - T53 `sync-github.cjs`: `gistsOut.files` now carries `lang` per file
+    (`f.lang || guessLang(f.name)`), so `data/github.json` carries gist languages.
+  - T54 `build-knowledge-graph.cjs`:
+    - repo `tagged` → `lang:<Language>` concept when `r.language` set.
+    - gist `tagged` → `lang:<fileLang>` for its primary code file (known code lang;
+      skip .txt/no-ext). Keeps `authored`.
+    - repo↔repo `relatedTo` when both share a `lang:` concept (bounded by language,
+      not full C(n,2)). Gist↔repo/gist stay linked only via the shared `lang:`
+      concept (correct multi-layer structure).
+- **Verify (deltas):** rebuilt `static/data/knowledge-graph.json`; expect gist
+  `tagged` edges ≈ 26, repo `tagged` lang edges ≈ 70, repo↔repo `relatedTo` > 6,
+  isolated-gist count drops by ≥ 26. `hugo` 0 errors; lint clean; test ALL PASSED;
+  check-links 0 broken; check-perf 0 regressions.
+
 ### Status
-Beads T49–T51 = `done`; T52 (commit+PR+merge) in_progress.
+Beads T53–T55 = `done`; T56 (commit+PR+merge) in_progress.

--- a/.planning/initiatives/kb-taxonomy.md
+++ b/.planning/initiatives/kb-taxonomy.md
@@ -1,0 +1,56 @@
+# BMAD — Initiative: `kb-taxonomy`
+
+> Governance/reasoning only: WHY + SHAPE + locked decisions.
+> Self-identified focus-topic (user): deepen the multi-layer ontology, expand the
+> knowledge-base taxonomy. Contract → Spec Kit. State → Beads. GSD.
+
+## Why (reasoning — measured, not guessed)
+Audited the live KG (`static/data/knowledge-graph.json`, 393 nodes / 699 edges)
+and the raw ingest (`data/github.json`). Connectivity baseline:
+- **100 / 100 gist nodes are isolated** — only `authored` (person:dominicusin).
+  No `tagged`, no concept links, no relation to repos.
+- **121 / 128 repo nodes** have degree ≤ 1 (only `owns` by org).
+- repo↔repo `relatedTo` = **6** (essentially no clustering).
+- `topics` on repos: only 7 repos carry them (9 topics total) — too sparse to be
+  the sole taxonomy axis.
+
+Real, usable fields (verified):
+- repos: `language` present on **70/128** (Python 13, C 8, Shell 6, TS 5, HTML 5,
+  TeX 3, Nix 3, Haskell 2…).
+- gists: `files[].name` present on all 100; **26/100** have a code language in the
+  filename extension (sh/py/js/ts/md/scheme/c/hs/sql/nix/php/ps1…). BUT the ingest
+  `gistsOut.files` (sync-github.cjs line ~308) writes ONLY the file `name`, not its
+  `lang` — so `data/github.json` carries no gist language today.
+
+So the taxonomy can be deepened honestly by adding a **language concept layer**
+(derivable from real fields) and clustering repos by shared language. No fabricated
+topics, no NLP guesses.
+
+## Shape (locked decisions)
+1. **T53 (ingest):** `sync-github.cjs` — in `main()` gist loop, persist `lang` per
+   file into `gistsOut.files` (`f.lang || guessLang(f.name)`). Re-run ingest locally
+   so `data/github.json` carries gist languages (CI regenerates on deploy).
+2. **T54 (KG builder):** `build-knowledge-graph.cjs`
+   - repo gets `tagged` edge to concept `lang:<Language>` when `r.language` exists.
+   - gist gets `tagged` edge to concept `lang:<fileLang>` for its PRIMARY code file
+     (first file whose `lang` is a known code lang; skip `.txt`/no-ext). Keeps the
+     existing `authored` edge.
+   - repo↔repo `relatedTo` when they share the same `lang:` concept (both have that
+     language). This clusters repos into language communities. Bounded: only pairs
+     that share a language, not a full C(n,2) blow-up.
+   - gist↔repo / gist↔gist stay UN-linked directly; they meet via the shared
+     `lang:` concept (correct multi-layer structure, no edge explosion).
+3. **T55 (measure):** rebuild KG; report deltas: total edges 699→?, isolated gists
+   100→?, repo↔repo relatedTo 6→?. Assert no fabricated edges (every edge traceable to
+   a real field).
+4. **T56:** commit + PR + `gh pr merge --admin`.
+
+## Out of scope
+- NLP/topic inference from descriptions (would fabricate concepts).
+- Changing gist display names (done in #118).
+- CLS/perf (separate).
+
+## Handoff
+- → Spec Kit `.specify/kb-taxonomy.md`.
+- → Beads `.beads/beads.json`: T53–T56.
+- → GSD `.gsd/plan.md`: Phase O.

--- a/.specify/kb-taxonomy.md
+++ b/.specify/kb-taxonomy.md
@@ -1,0 +1,34 @@
+# Spec — Deepen KB ontology: language concept layer + repo clustering
+
+> Spec Kit contract (the "what"). Binding for Beads (state) and GSD (execution).
+> Governance: `.planning/initiatives/kb-taxonomy.md`.
+
+## Context
+Live KG: 393 nodes / 699 edges. 100/100 gists isolated (only `authored`); 121/128
+repos degree ≤ 1; repo↔repo `relatedTo` = 6; repo `topics` too sparse (7 repos).
+Real fields: repo `language` (70/128); gist file name (100/100) with 26/100 having
+a code-language extension. Ingest writes only gist file `name` (no `lang`), so
+`data/github.json` lacks gist language today.
+
+## Requirements
+- **R1** `sync-github.cjs` gist loop persists `lang` per file in `gistsOut.files`
+  (`f.lang || guessLang(f.name)`), so `data/github.json` carries gist languages.
+- **R2** `build-knowledge-graph.cjs`:
+  - repo `tagged` → `lang:<Language>` concept when `r.language` set.
+  - gist `tagged` → `lang:<fileLang>` for its primary code file (known code lang;
+    skip `.txt`/no-ext). Keep existing `authored` edge.
+  - repo↔repo `relatedTo` when both share a `lang:` concept (bounded by language,
+    not full C(n,2)).
+  - gist↔repo / gist↔gist stay linked only via the shared `lang:` concept.
+- **R3** Rebuild KG; report measurable deltas: edges, isolated-gist count,
+  repo↔repo relatedTo count. No edge without a real-field trace.
+- **R4** Safety: `hugo` 0 errors; lint clean; test pass; check-links 0 broken;
+  check-perf 0 regressions.
+
+## Acceptance (measurable)
+- built KG: gist `tagged` edges > 0 (≈26); repo `tagged` lang edges ≈ 70;
+  repo↔repo `relatedTo` > 6; isolated-gist count drops (≥26 gists gain a `tagged`).
+- `grep` `static/data/knowledge-graph.json` for `lang:python` / `lang:shell`.
+
+## Out of scope
+- NLP topic inference; gist display names; perf/CLS.

--- a/scripts/build-knowledge-graph.cjs
+++ b/scripts/build-knowledge-graph.cjs
@@ -119,9 +119,11 @@ bridges.forEach(([a, b]) => addEdge(a, b, 'relatedTo'));
 // become `concept` (tag) nodes linked via `tagged`. This turns the graph into a
 // true site ontology spanning posts, concepts, repos, gists and people.
 const githubJson = path.join(ROOT, 'data', 'github.json');
+const CODE_LANGS = new Set(['python', 'javascript', 'typescript', 'c', 'cpp', 'shell', 'bash', 'haskell', 'rust', 'go', 'nix', 'lua', 'lisp', 'scheme', 'sql', 'php', 'tex', 'markdown', 'html', 'yaml', 'json']);
 if (fs.existsSync(githubJson)) {
   try {
     const gh = JSON.parse(fs.readFileSync(githubJson, 'utf8'));
+    const repoLang = {}; // repoId -> language (for repo↔repo clustering)
     for (const r of (gh.repos || [])) {
       const id = 'repo:' + r.fullName;
       addNode({ id, type: 'repository', label: r.name, url: r.html_url, owner: r.owner, weight: 4 });
@@ -132,11 +134,32 @@ if (fs.existsSync(githubJson)) {
         addNode({ id: cid, type: 'concept', label: titleCase(t), kind: 'Tag', weight: 2 });
         addEdge(id, cid, 'tagged');
       }
+      // Language concept layer (real field: r.language). Links repo → lang:<Lang>.
+      if (r.language) {
+        const lid = 'tag:lang-' + slug(r.language);
+        addNode({ id: lid, type: 'concept', label: r.language, kind: 'Language', weight: 3 });
+        addEdge(id, lid, 'tagged');
+        repoLang[id] = lid;
+      }
     }
     for (const g of (gh.gists || [])) {
       const id = 'gist:' + g.id;
       addNode({ id, type: 'gist', label: (g.description || g.id).toString().slice(0, 40), url: g.html_url, weight: 3 });
       addEdge('person:dominicusin', id, 'authored');
+      // Language concept layer for gists: primary code file (real field: file.lang).
+      const codeFile = (g.files || []).find(f => f && f.lang && CODE_LANGS.has(String(f.lang).toLowerCase()));
+      if (codeFile) {
+        const lid = 'tag:lang-' + slug(codeFile.lang);
+        addNode({ id: lid, type: 'concept', label: codeFile.lang, kind: 'Language', weight: 3 });
+        addEdge(id, lid, 'tagged');
+      }
+    }
+    // Repo↔repo clustering by shared language (bounded by language, not C(n,2)).
+    const byLang = {};
+    for (const [rid, lid] of Object.entries(repoLang)) (byLang[lid] = byLang[lid] || []).push(rid);
+    for (const ids of Object.values(byLang)) {
+      for (let i = 0; i < ids.length; i++)
+        for (let j = i + 1; j < ids.length; j++) addEdge(ids[i], ids[j], 'relatedTo');
     }
   } catch (e) { console.warn('kg: github.json parse skipped:', e.message); }
 }

--- a/scripts/sync-github.cjs
+++ b/scripts/sync-github.cjs
@@ -305,7 +305,7 @@ async function main() {
         files.push({ name, lang: meta.language || guessLang(name), content: (raw || '').slice(0, MAX_DOC_BYTES) });
       }
       writeGistPage({ id: g.id, description: g.description, updated_at: g.updated_at, files });
-      gistsOut.push({ id: g.id, description: g.description || '', html_url: g.html_url, updated_at: g.updated_at, files: files.map(f => f.name) });
+      gistsOut.push({ id: g.id, description: g.description || '', html_url: g.html_url, updated_at: g.updated_at, files: files.map(f => ({ name: f.name, lang: f.lang || '' })) });
     } catch (e) { errors.push(`gist ${g.id}: ${e.message}`); }
   }
 


### PR DESCRIPTION
## Summary
Focus-topic: expand the knowledge-base taxonomy into a true multi-layer ontology. Audited the live KG (393 nodes / 699 edges): 100/100 gists isolated (only `authored`), 121/128 repos degree ≤ 1, repo↔repo `relatedTo` = 6, and repo `topics` too sparse (7 repos) to be the sole taxonomy axis.

## Changes
- `scripts/sync-github.cjs`: `gistsOut.files` now carries `lang` per file (`f.lang || guessLang(f.name)`), so `data/github.json` carries gist languages.
- `scripts/build-knowledge-graph.cjs`:
  - repo `tagged` → `lang:<Language>` concept when `r.language` set.
  - gist `tagged` → `lang:<fileLang>` for its primary code file (known code lang; skip .txt/no-ext). Keeps `authored`.
  - repo↔repo `relatedTo` when both share a `lang:` concept (bounded by language). Gist↔repo/gist linked only via the shared `lang:` concept.

## Measured deltas (rebuilt KG)
- nodes 393 → 420 (+27 Language concepts)
- edges 699 → 1007 (+308)
- `tagged`→lang edges: 106 (≈70 repo + 26 gist)
- repo↔repo `relatedTo`: 6 → 208
- isolated gists: 100 → 64 (36 gained `tagged`; 64 have no code lang and stay `authored`)

No fabricated edges — every edge traces to a real field (`r.language` / `file.lang`).

## Verification
`hugo` 0 errors; lint clean; test ALL PASSED; check-links 0 broken; check-perf 0 regressions.

## Task system (strict 4-layer)
- BMAD: `.planning/initiatives/kb-taxonomy.md`
- Spec Kit: `.specify/kb-taxonomy.md`
- Beads: `.beads/beads.json` (T53–T56)
- GSD: `.gsd/plan.md` (Phase O)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Knowledge-graph entries now include supported programming-language metadata for repositories and gists.
  * Repositories using the same languages can be connected through relatedness links.
  * Gist file records now retain both file names and detected languages.
  * Added taxonomy specifications, implementation planning, and verification criteria for language-based enrichment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->