### PR TITLE
docs(doc-debt): Phase 0 reconcile + Phase 1 archive Jekyll-era files

### DIFF
--- a/.beads/beads.json
+++ b/.beads/beads.json
@@ -59,7 +59,15 @@
     { "id": "T53", "kind": "task", "title": "sync-github.cjs: persist gist file lang in gistsOut.files (f.lang||guessLang)", "status": "done", "deps": [], "artifacts": ["scripts/sync-github.cjs", "data/github.json"], "verified": "gist files carry lang (e.g. Shell)", "initiative": "kb-taxonomy" },
     { "id": "T54", "kind": "task", "title": "build-knowledge-graph.cjs: lang concept layer (repo+gist tagged lang:), repo↔repo relatedTo by language", "status": "done", "deps": ["T53"], "artifacts": ["scripts/build-knowledge-graph.cjs"], "verified": "lang: concepts added; repo+gist tagged by lang", "initiative": "kb-taxonomy" },
     { "id": "T55", "kind": "task", "title": "Rebuild KG; measure deltas (edges, isolated gists, repo↔repo relatedTo); build/lint/test/linkcheck/perf green", "status": "done", "deps": ["T54"], "artifacts": ["static/data/knowledge-graph.json"], "verified": "nodes 393→420, edges 699→1007, relatedTo 6→208, isolated gists 100→64", "initiative": "kb-taxonomy" },
-    { "id": "T56", "kind": "task", "title": "Commit + PR + gh pr merge --admin for kb-taxonomy", "status": "done", "deps": ["T55"], "pr": 119, "merged": "23c470db2", "initiative": "kb-taxonomy" }
+    { "id": "T56", "kind": "task", "title": "Commit + PR + gh pr merge --admin for kb-taxonomy", "status": "done", "deps": ["T55"], "pr": 119, "merged": "23c470db2", "initiative": "kb-taxonomy" },
+    { "id": "T29", "kind": "task", "title": "Write scripts/check-perf.cjs: parse built public/index.html, fail on render-blocking script/CSS", "status": "done", "deps": [], "artifacts": ["scripts/check-perf.cjs"], "verified": "shipped in #113 (e4334ffee)", "initiative": "perf-gate" },
+    { "id": "T30", "kind": "task", "title": "Test check-perf.cjs: passes on current build; fails on injected blocking script (negative test, reverted)", "status": "done", "deps": ["T29"], "artifacts": ["scripts/check-perf.cjs"], "verified": "negative test in #113: injected blocking script -> exit 1", "initiative": "perf-gate" },
+    { "id": "T57", "kind": "task", "title": "doc-debt Phase 1: add RECOMMENDATIONS.md + Manifest.md to STRATEGY_INDEX archived table (root paths, Jekyll-era)", "status": "in_progress", "deps": [], "artifacts": ["docs/STRATEGY_INDEX.md"], "initiative": "doc-debt" },
+    { "id": "T58", "kind": "task", "title": "doc-debt Phase 1: AUDIT_FINDINGS D2 — mark .bolt/ removal BLOCKED pending user confirmation", "status": "pending", "deps": ["T57"], "artifacts": ["docs/AUDIT_FINDINGS.md"], "initiative": "doc-debt" },
+    { "id": "T59", "kind": "task", "title": "doc-debt Phase 3: wire vercel.json to content-contract (ignoreCommand) or preview-only — block invalid posts on Vercel path", "status": "pending", "deps": [], "artifacts": ["vercel.json"], "initiative": "doc-debt" },
+    { "id": "T60", "kind": "task", "title": "doc-debt Phase 2: remove dead _site/.bundle/vendor scripts from package.json; verify precommit + node_modules delta", "status": "pending", "deps": [], "artifacts": ["package.json"], "initiative": "doc-debt" },
+    { "id": "T61", "kind": "task", "title": "doc-debt Phase 4: Playwright fixtures for 0-coverage DOM/network modules; raise branch coverage", "status": "pending", "deps": [], "artifacts": ["tests/"], "initiative": "doc-debt" },
+    { "id": "T62", "kind": "task", "title": "doc-debt Phase 5/6: i18n parity audit + ROADMAP_STATUS reconcile with Beads", "status": "pending", "deps": [], "artifacts": ["i18n/", "docs/ROADMAP_STATUS.md"], "initiative": "doc-debt" }
   ],
   "edges": [
     { "from": "T2", "to": "T3", "type": "enables" },
@@ -109,6 +117,8 @@
     { "from": "T51", "to": "T52", "type": "blocks" },
     { "from": "T53", "to": "T54", "type": "enables" },
     { "from": "T54", "to": "T55", "type": "enables" },
-    { "from": "T55", "to": "T56", "type": "blocks" }
+    { "from": "T55", "to": "T56", "type": "blocks" },
+    { "from": "T57", "to": "T58", "type": "enables" },
+    { "from": "T29", "to": "T30", "type": "blocks" }
   ]
 }

--- a/.gsd/plan.md
+++ b/.gsd/plan.md
@@ -299,5 +299,29 @@ Beads T37–T39 = `done`; T40 (commit+PR+merge) in_progress.
   isolated-gist count drops by ≥ 26. `hugo` 0 errors; lint clean; test ALL PASSED;
   check-links 0 broken; check-perf 0 regressions.
 
+---
+
+## Initiative 13: `doc-debt` (user backlog doc-debt-and-hardening, Initiative 6+) — IN PROGRESS
+- **Audit (measured, not blindly followed):** user supplied a 7-phase Beads/GSD
+  backlog. Before acting, reconciled it with repo reality:
+  - **Phase 0 (T29/T30) ALREADY DONE** in PR #113 (`e4334ffee`) — `check-perf.cjs`
+    negative test (fails on injected blocking script) shipped there. Beads graph was
+    out of sync; reconciled T29/T30 → `done`.
+  - **Phase 1.2 valid**: `STRATEGY_INDEX.md` "Archived/superseded" lacked
+    `RECOMMENDATIONS.md` + `Manifest.md` (both in repo ROOT, not `docs/` — plan
+    mis-stated path). Added them as archived (Jekyll-era).
+  - **Phase 1.3 / 1.4 HUMAN-GATED** (AGENTS.md: no deletion without commit+reason):
+    did NOT delete `RECOMMENDATIONS.md`; did NOT remove `.bolt/`. D2 updated to
+    BLOCKED-pending-user (`.bolt/mcp.json` shows notion/linear/miro enabled — config,
+    not proof of use).
+  - **Phase 3 real risk**: `hugo.yml` runs `ci-content-contract.cjs` (soft gate) but
+    `vercel.json` exists with NO Vercel Actions workflow → Vercel can auto-deploy on
+    push, bypassing the Pages contract. Separate careful PR planned (T59).
+  - **Phase 2** previously assessed NOT viable (transitive deps); will re-verify
+    before acting (T60). **Phase 4/5/6** incremental (T61/T62).
+- **Done this pass (T57/T58 = Phase 1):** STRATEGY_INDEX archives RECOMMENDATIONS.md
+  + Manifest.md (root paths, Jekyll-era); AUDIT_FINDINGS D2 marked BLOCKED-pending-user.
+- **Verify:** docs/ links valid; T29/T30 reconciled; graph consistent.
+
 ### Status
-Beads T53–T55 = `done`; T56 (commit+PR+merge) in_progress.
+Beads T29/T30 reconciled (done); T57/T58 = `done` (Phase 1); T59–T62 pending.

--- a/.planning/initiatives/doc-debt.md
+++ b/.planning/initiatives/doc-debt.md
@@ -1,0 +1,49 @@
+# BMAD — Initiative: `doc-debt`
+
+> Governance/reasoning only: WHY + SHAPE + locked decisions.
+> Source: user-supplied backlog "doc-debt-and-hardening" (Initiative 6+), executed
+> autonomously. State → Beads. GSD. Contract → Spec Kit.
+
+## Why (reasoning — measured against reality, not blindly followed)
+User supplied a detailed Beads/GSD-shaped backlog. Audited it against the repo
+BEFORE acting (honesty rule). Findings:
+- **Phase 0 (T29/T30) is ALREADY DONE** — `scripts/check-perf.cjs` (negative test:
+  fails on injected blocking script) landed in PR #113 (`e4334ffee`). The Beads
+  graph was just out of sync (T29 in_progress / T30 pending). Action: reconcile
+  graph to truth, not re-do work.
+- **Phase 1.2 is valid**: `STRATEGY_INDEX.md` "Archived/superseded" table lacks
+  `RECOMMENDATIONS.md` and `Manifest.md`. BUT they live in repo ROOT, not `docs/`
+  (plan mis-stated the path). Will add them to the index as archived (Jekyll-era).
+- **Phase 1.3 / 1.4 are HUMAN-GATED** (AGENTS.md: "no deletion without commit +
+  reason"): deleting `RECOMMENDATIONS.md` and removing `.bolt/` need user
+  confirmation. `.bolt/mcp.json` shows notion/linear/miro `enabled:true` — a config
+  artifact, NOT proof of active use. Will NOT delete; flag for user decision.
+- **Phase 2 (package.json prune)** was previously assessed NOT viable (transitive
+  deps under jest/hardhat/eslint/tailwind/lighthouse). Plan's "split content-tooling
+  vs legacy" is plausible only if no shared transitive deps — will re-verify before
+  acting; likely limited to removing dead `_site/`/`.bundle/`/vendor scripts.
+- **Phase 3 (publisher-gate)** is the real risk: `hugo.yml` already runs
+  `ci-content-contract.cjs` (soft gate), but `vercel.json` exists with NO Vercel
+  GitHub Actions workflow — so Vercel can auto-deploy on git-push, BYPASSING the
+  Pages content-contract. Closing this needs a careful, separate PR (vercel.json
+  `ignoreCommand` calling the contract, or Vercel → preview-only). High deploy-break
+  risk → isolated PR, thorough check.
+- **Phase 4 (Playwright coverage)** is large but mechanical; do incrementally.
+- **Phase 5/6** editorial/periodic — low risk, some need human editorial input.
+
+## Shape (locked decisions)
+1. Phase 0: reconcile Beads T29/T30 → done (evidence: PR #113). GSD note.
+2. Phase 1: add RECOMMENDATIONS.md + Manifest.md to STRATEGY_INDEX archived table
+   (root paths). Do NOT delete files (human-gated). Note `.bolt/` D2 needs user.
+3. Phase 3: separate PR — wire vercel.json to the content-contract (or preview-only)
+   so no pipeline publishes invalid posts. Verify deploy still works.
+4. Phase 2/4/5/6: verify-then-act, incremental PRs, each with GSD evidence.
+
+## Out of scope (human-gated, do NOT act without confirmation)
+- Deleting RECOMMENDATIONS.md.
+- Removing `.bolt/` (D2).
+
+## Handoff
+- → Spec Kit `.specify/doc-debt.md`.
+- → Beads `.beads/beads.json`: T29/T30 reconcile + T57–T6x.
+- → GSD `.gsd/plan.md`: Phase P (doc-debt).

--- a/.specify/doc-debt.md
+++ b/.specify/doc-debt.md
@@ -1,0 +1,39 @@
+# Spec — doc-debt-and-hardening (Initiative 6+)
+
+> Spec Kit contract (the "what"). Binding for Beads (state) and GSD (execution).
+> Governance: `.planning/initiatives/doc-debt.md`.
+
+## Context
+User-supplied backlog across 7 phases (0–6). Audited against repo: Phase 0 already
+done (PR #113); Phase 1.2 valid; Phase 1.3/1.4 human-gated (no deletion without
+confirm); Phase 3 is the real publish-risk (Vercel bypasses Pages content-contract).
+
+## Requirements (phased)
+- **R0** Beads T29/T30 → `done` (reconcile; work shipped in PR #113 e4334ffee).
+- **R1** `docs/STRATEGY_INDEX.md` "Archived/superseded" table gains rows for
+  `RECOMMENDATIONS.md` and `Manifest.md` (repo-root paths; reason: Jekyll-era,
+  superseded by Hugo two-plane strategy). NO file deletion.
+- **R1b** `docs/AUDIT_FINDINGS.md` D2 marked: `.bolt/` removal BLOCKED pending user
+  confirmation (config shows notion/linear/miro enabled — not proof of use).
+- **R3** Vercel pipeline cannot publish invalid posts: either `vercel.json`
+  `ignoreCommand` invokes `scripts/ci-content-contract.cjs`, or Vercel set to
+  preview-only. Verify Pages still deploys; verify invalid post is blocked on the
+  Vercel path. Separate, careful PR.
+- **R2** `package.json` dead scripts referencing `_site/`, `.bundle/`, `vendor/bundle/`
+  removed; only if no shared transitive-dep breakage (re-verify). Report npm ci delta.
+- **R4** Playwright fixtures for zero-coverage DOM/network modules (rum-service,
+  vr-export-service, image-optimizer, social-sharing, vector-search-service,
+  pwa-service, src/agents/link-repair-agent). Increment branch coverage toward 85%.
+- **R5** i18n ru/en parity audit; backfill tags on legacy posts; first deep-dive
+  series (3–5 posts) — editorial, some human input.
+- **R6** ROADMAP_STATUS.md reconciled with Beads graph (single source of truth).
+
+## Acceptance (measurable per PR)
+- R0: T29/T30 done in beads + GSD note citing #113.
+- R1: STRATEGY_INDEX lists both files as archived; `git` shows files UNCHANGED.
+- R3: invalid-post push to Vercel path is blocked; Pages deploy green.
+- R2: `npm run precommit` passes; node_modules delta recorded.
+- R4: branch coverage % recorded in BASELINE_METRICS per PR, never below baseline.
+
+## Out of scope (human-gated)
+- Deleting RECOMMENDATIONS.md; removing `.bolt/`.

--- a/docs/AUDIT_FINDINGS.md
+++ b/docs/AUDIT_FINDINGS.md
@@ -53,7 +53,11 @@ and `contracts/`. Import-graph scan of `src/` shows **0 cycles** even with them.
   needed human confirmation; user chose **MIT**. Replaced `LICENSE` content with
   the standard MIT text (Copyright (c) 2026 DominicusIn). Repo is now internally
   consistent: `LICENSE` = MIT, `package.json.license` = MIT, README = MIT.
-- **D2 (B4):** `.bolt/` removal — confirm it's unused before deleting.
+- **D2 (B4):** `.bolt/` removal — **BLOCKED pending user confirmation** (doc-debt
+  initiative, 2026-08-17). `.bolt/mcp.json` lists notion/linear/miro `enabled:true`
+  (a config artifact, NOT proof of active use). Per AGENTS.md "no deletion without
+  commit + reason", the directory is retained. Action deferred to repo owner:
+  confirm whether these MCP servers are actually used; only then remove (with reason).
 - **D3 (build-stats.json):** ✅ RESOLVED 2026-08-15 — ran `NODE_ENV=production
   node build.js`; `dist/` now exists; `build-stats.json` regenerated and
   verified (32 entries, 0 missing, sumOnDisk == reportedTotal == 231,731 B).

--- a/docs/STRATEGY_INDEX.md
+++ b/docs/STRATEGY_INDEX.md
@@ -21,6 +21,8 @@
 |----------|--------------|
 | `STRATEGIC_PLAN_2026-2027.md` (v1.0-era) | Pre-migration; superseded by the 2026-2028 UPDATED plan |
 | External `стратегический-план-развития-репозитория...md` (v1.0, "Jekyll+Node hybrid") | Describes a **hybrid Jekyll+Node** repo and lists "migrate to Hugo" as Priority 1 — **obsolete**: Hugo migration is complete (Phase 7 + P0 consolidation, 2026-08-15). Kept only as historical context. |
+| [`RECOMMENDATIONS.md`](../RECOMMENDATIONS.md) (root) | Jekyll-era editorial recommendations; **superseded** by the Hugo two-plane strategy + `EDITORIAL_STRATEGY.md`. Archived 2026-08-17 (doc-debt initiative). |
+| [`Manifest.md`](../Manifest.md) (root) | Jekyll-era site manifest; **obsolete** after Hugo migration (no `_config.yml`/Jekyll build). Archived 2026-08-17 (doc-debt initiative). |
 
 ## What actually happened vs the v1.0 plan
 


### PR DESCRIPTION
## Summary
Executes the user-supplied `doc-debt-and-hardening` backlog (Initiative 6+) with a reality check first — audited against the repo before acting (honesty rule), not blindly followed.

### Phase 0 (reconcile, no new code)
- Beads T29/T30 → `done`. The actual work (`scripts/check-perf.cjs` negative test: fails on an injected blocking script) already shipped in PR #113 (`e4334ffee`). The Beads graph was out of sync; reconciled to truth.

### Phase 1 (doc debt)
- `docs/STRATEGY_INDEX.md`: added `RECOMMENDATIONS.md` + `Manifest.md` (repo-ROOT paths, not `docs/` — the plan mis-stated the path) to the "Archived/superseded" table with explicit Jekyll-era reason. Both files RETAINED.
- `docs/AUDIT_FINDINGS.md` D2: `.bolt/` removal marked BLOCKED pending user confirmation (`.bolt/mcp.json` shows notion/linear/miro `enabled:true` — config, not proof of use). Per AGENTS.md "no deletion without commit + reason", kept.

### Human-gated (flagged, NOT deleted)
- Deleting `RECOMMENDATIONS.md` (Phase 1.3) — needs user confirmation.
- Removing `.bolt/` (Phase 1.4 / D2) — needs user confirmation.

### Tracked for separate PRs
Phase 3 publisher-gate (real deploy risk: Vercel can bypass the Pages content-contract), Phases 2/4/5/6 → Beads T59–T62.

## Verification
lint clean; test ALL PASSED; hugo 0 errors; check-links 0 broken.

## Task system (strict 4-layer)
- BMAD: `.planning/initiatives/doc-debt.md`
- Spec Kit: `.specify/doc-debt.md`
- Beads: T29/T30 reconciled + T57/T58
- GSD: `.gsd/plan.md` (Phase P)