### PR TITLE
feat(cycle4): backfill social image+alt on 59 legacy posts + og:image guard

### DIFF
--- a/content/blog/2015-11-19-first.md
+++ b/content/blog/2015-11-19-first.md
@@ -10,6 +10,9 @@ tags:
 - jekyll
 - web
 - productivity
+
+image: /assets/images/og-default.png
+alt: "First post"
 ---
 author: DominicusIn
 

--- a/content/blog/2016-11-22-second.md
+++ b/content/blog/2016-11-22-second.md
@@ -8,6 +8,9 @@ categories:
 - media
 tags:
 - movies
+
+image: /assets/images/og-default.png
+alt: "List of favourite movies"
 ---
 author: DominicusIn
 

--- a/content/blog/2016-12-01-rieziumie.md
+++ b/content/blog/2016-12-01-rieziumie.md
@@ -11,6 +11,9 @@ categories:
 tags:
 - cv
 - productivity
+
+image: /assets/images/og-default.png
+alt: "Curriculum Vitae"
 ---
 author: DominicusIn
 

--- a/content/blog/2017-05-29-Interview.md
+++ b/content/blog/2017-05-29-Interview.md
@@ -10,6 +10,9 @@ tags:
 - linux
 - interview
 - devops
+
+image: /assets/images/og-default.png
+alt: "Linux System Administrator(DevOp) Interview Questions"
 ---
 author: DominicusIn
 

--- a/content/blog/2017-06-07-OnionShare.md
+++ b/content/blog/2017-06-07-OnionShare.md
@@ -10,6 +10,8 @@ tags:
 - privacy
 - tor
 - tools
+image: /assets/images/og-default.png
+alt: "OnionShare"
 ---
 author: DominicusIn
 

--- a/content/blog/2017-06-15-free-programming-books.md
+++ b/content/blog/2017-06-15-free-programming-books.md
@@ -10,6 +10,9 @@ tags:
 - books
 - free-resources
 - programming
+
+image: /assets/images/og-default.png
+alt: "Free Programming Books"
 ---
 author: DominicusIn
 

--- a/content/blog/2017-07-28-svn2git.md
+++ b/content/blog/2017-07-28-svn2git.md
@@ -10,6 +10,9 @@ tags:
 - git
 - linux
 - automation
+
+image: /assets/images/og-default.png
+alt: "Migrate a code repository from SourceForge (SVN) to Github (GIT)"
 ---
 author: DominicusIn
 

--- a/content/blog/2017-08-10-imhonet.md
+++ b/content/blog/2017-08-10-imhonet.md
@@ -9,6 +9,9 @@ categories:
 tags:
 - media
 - social
+
+image: /assets/images/og-default.png
+alt: "imhonet is dead"
 ---
 author: DominicusIn
 

--- a/content/blog/2017-08-31-nedaigne.md
+++ b/content/blog/2017-08-31-nedaigne.md
@@ -9,6 +9,9 @@ categories:
 tags:
 - awesome-list
 - media
+
+image: /assets/images/og-default.png
+alt: "nedaigne"
 ---
 author: DominicusIn
 

--- a/content/blog/2017-11-06-Winworkstation.md
+++ b/content/blog/2017-11-06-Winworkstation.md
@@ -10,6 +10,9 @@ tags:
 - windows
 - productivity
 - automation
+
+image: /assets/images/og-default.png
+alt: "Prepare my Windows workstation"
 ---
 author: DominicusIn
 

--- a/content/blog/2017-11-08-links.md
+++ b/content/blog/2017-11-08-links.md
@@ -9,6 +9,9 @@ categories:
 tags:
 - awesome-list
 - web
+
+image: /assets/images/og-default.png
+alt: "Some interesting links"
 ---
 author: DominicusIn
 

--- a/content/blog/2017-11-10-dpiblock.md
+++ b/content/blog/2017-11-10-dpiblock.md
@@ -10,6 +10,9 @@ tags:
 - linux
 - networking
 - privacy
+
+image: /assets/images/og-default.png
+alt: "dpiblock"
 ---
 author: DominicusIn
 

--- a/content/blog/2017-11-15-forth.md
+++ b/content/blog/2017-11-15-forth.md
@@ -9,6 +9,9 @@ categories:
 tags:
 - languages
 - forth
+
+image: /assets/images/og-default.png
+alt: "forth"
 ---
 author: DominicusIn
 

--- a/content/blog/2018-02-03-russia-it-podcast.md
+++ b/content/blog/2018-02-03-russia-it-podcast.md
@@ -9,6 +9,9 @@ categories:
 tags:
 - podcasts
 - awesome-list
+
+image: /assets/images/og-default.png
+alt: "it-podcast"
 ---
 author: DominicusIn
 

--- a/content/blog/2018-02-25-google-interview-questions.md
+++ b/content/blog/2018-02-25-google-interview-questions.md
@@ -9,6 +9,9 @@ categories:
 tags:
 - interview
 - programming
+
+image: /assets/images/og-default.png
+alt: "Google Interview Questions"
 ---
 author: DominicusIn
 

--- a/content/blog/2018-11-09-awesome-machine-learning-for-cyber-security.md
+++ b/content/blog/2018-11-09-awesome-machine-learning-for-cyber-security.md
@@ -11,6 +11,9 @@ tags:
 - ml
 - cybersecurity
 - awesome-list
+
+image: /assets/images/og-default.png
+alt: "Awesome Machine Learning for Cyber Security"
 ---
 author: DominicusIn
 

--- a/content/blog/2018-11-09-my-favorite-movies.md
+++ b/content/blog/2018-11-09-my-favorite-movies.md
@@ -8,6 +8,9 @@ categories:
 - media
 tags:
 - movies
+
+image: /assets/images/og-default.png
+alt: "My favorite movies"
 ---
 author: DominicusIn
 

--- a/content/blog/2019-01-31-linux-networking-commands.md
+++ b/content/blog/2019-01-31-linux-networking-commands.md
@@ -10,6 +10,9 @@ tags:
 - linux
 - networking
 - cli
+
+image: /assets/images/og-default.png
+alt: "Linux Networking commands"
 ---
 author: DominicusIn
 

--- a/content/blog/2019-05-18-SFTP.md
+++ b/content/blog/2019-05-18-SFTP.md
@@ -11,6 +11,9 @@ tags:
 - networking
 - sftp
 - automation
+
+image: /assets/images/og-default.png
+alt: "SFTP"
 ---
 author: DominicusIn
 

--- a/content/blog/2019-06-16-Awesome-Selfhosted.md
+++ b/content/blog/2019-06-16-Awesome-Selfhosted.md
@@ -10,6 +10,9 @@ tags:
 - self-hosting
 - awesome-list
 - free-resources
+
+image: /assets/images/og-default.png
+alt: "Awesome-Selfhosted"
 ---
 author: DominicusIn
 

--- a/content/blog/2019-07-25-gcloud-cheat-sheet.md
+++ b/content/blog/2019-07-25-gcloud-cheat-sheet.md
@@ -10,6 +10,9 @@ tags:
 - gcloud
 - cli
 - cloud
+
+image: /assets/images/og-default.png
+alt: "gcloud cheat sheet"
 ---
 author: DominicusIn
 

--- a/content/blog/2019-12-16-HipChatAlternatives.md
+++ b/content/blog/2019-12-16-HipChatAlternatives.md
@@ -10,6 +10,9 @@ tags:
 - chat
 - privacy
 - awesome-list
+
+image: /assets/images/og-default.png
+alt: "HipChat Alternatives"
 ---
 author: DominicusIn
 

--- a/content/blog/2020-03-08-Russian_programmers.md
+++ b/content/blog/2020-03-08-Russian_programmers.md
@@ -9,6 +9,9 @@ categories:
 tags:
 - programming
 - awesome-list
+
+image: /assets/images/og-default.png
+alt: "programmers"
 ---
 author: DominicusIn
 

--- a/content/blog/2020-03-18-advices.md
+++ b/content/blog/2020-03-18-advices.md
@@ -10,6 +10,9 @@ tags:
 - programming
 - jobs
 - awesome-list
+
+image: /assets/images/og-default.png
+alt: "Advs for programmer"
 ---
 author: DominicusIn
 

--- a/content/blog/2020-03-18-free-courses-ru.md
+++ b/content/blog/2020-03-18-free-courses-ru.md
@@ -10,6 +10,9 @@ tags:
 - free-resources
 - courses
 - awesome-list
+
+image: /assets/images/og-default.png
+alt: "free-courses"
 ---
 author: DominicusIn
 

--- a/content/blog/2020-03-18-free-podcasts-screencasts-ru.md
+++ b/content/blog/2020-03-18-free-podcasts-screencasts-ru.md
@@ -11,6 +11,9 @@ tags:
 - screencasts
 - free-resources
 - awesome-list
+
+image: /assets/images/og-default.png
+alt: "free-podcasts-screencasts"
 ---
 author: DominicusIn
 

--- a/content/blog/2020-03-18-free-programming-books-ru.md
+++ b/content/blog/2020-03-18-free-programming-books-ru.md
@@ -11,6 +11,9 @@ tags:
 - free-resources
 - programming
 - awesome-list
+
+image: /assets/images/og-default.png
+alt: "free-programming-books"
 ---
 author: DominicusIn
 

--- a/content/blog/2020-05-21-poc-in-github.md
+++ b/content/blog/2020-05-21-poc-in-github.md
@@ -10,6 +10,9 @@ tags:
 - git
 - github
 - security
+
+image: /assets/images/og-default.png
+alt: "PoC in GitHub"
 ---
 author: DominicusIn
 

--- a/content/blog/2021-08-29-free-for-dev.md
+++ b/content/blog/2021-08-29-free-for-dev.md
@@ -11,6 +11,9 @@ tags:
 - free-resources
 - cloud
 - awesome-list
+
+image: /assets/images/og-default.png
+alt: "free-for.dev"
 ---
 author: DominicusIn
 

--- a/content/blog/2021-09-06-macOS-Security-and-Privacy-Guide.md
+++ b/content/blog/2021-09-06-macOS-Security-and-Privacy-Guide.md
@@ -10,6 +10,9 @@ tags:
 - macos
 - privacy
 - hardening
+
+image: /assets/images/og-default.png
+alt: "macOS-Security-and-Privacy-Guide"
 ---
 author: DominicusIn
 

--- a/content/blog/2022-03-15-Lua-Neovim.md
+++ b/content/blog/2022-03-15-Lua-Neovim.md
@@ -10,6 +10,9 @@ tags:
 - neovim
 - lua
 - editors
+
+image: /assets/images/og-default.png
+alt: "Lua  Neovim"
 ---
 author: DominicusIn
 

--- a/content/blog/2022-05-16-Awesome-Selfhosted.md
+++ b/content/blog/2022-05-16-Awesome-Selfhosted.md
@@ -10,6 +10,9 @@ tags:
 - self-hosting
 - awesome-list
 - free-resources
+
+image: /assets/images/og-default.png
+alt: "Awesome-Selfhosted"
 ---
 author: DominicusIn
 

--- a/content/blog/2022-07-17-old-programmers.md
+++ b/content/blog/2022-07-17-old-programmers.md
@@ -9,6 +9,9 @@ categories:
 tags:
 - programming
 - awesome-list
+
+image: /assets/images/og-default.png
+alt: "old programmers"
 ---
 author: DominicusIn
 

--- a/content/blog/2023-01-14-a-collection-of-awesome-ai-applications.md
+++ b/content/blog/2023-01-14-a-collection-of-awesome-ai-applications.md
@@ -10,6 +10,9 @@ tags:
 - llm
 - awesome-list
 - applications
+
+image: /assets/images/og-default.png
+alt: "A Collection of Awesome AI Applications"
 ---
 author: DominicusIn
 

--- a/content/blog/2023-01-20-awesome-piracy.md
+++ b/content/blog/2023-01-20-awesome-piracy.md
@@ -10,6 +10,9 @@ tags:
 - awesome-list
 - piracy
 - media
+
+image: /assets/images/og-default.png
+alt: "Awesome Piracy"
 ---
 author: DominicusIn
 

--- a/content/blog/2023-05-18-dark-web-links.md
+++ b/content/blog/2023-05-18-dark-web-links.md
@@ -10,6 +10,9 @@ tags:
 - tor
 - darknet
 - privacy
+
+image: /assets/images/og-default.png
+alt: "Dark Web Links"
 ---
 author: DominicusIn
 

--- a/content/blog/2023-06-25-awesome-tunneling.md
+++ b/content/blog/2023-06-25-awesome-tunneling.md
@@ -11,6 +11,9 @@ tags:
 - self-hosting
 - networking
 - awesome-list
+
+image: /assets/images/og-default.png
+alt: "Awesome tunneling"
 ---
 author: DominicusIn
 

--- a/content/blog/2023-08-26-three-virtues.md
+++ b/content/blog/2023-08-26-three-virtues.md
@@ -10,6 +10,9 @@ tags:
 - programming
 - humor
 - craft
+
+image: /assets/images/og-default.png
+alt: "Three Virtues"
 ---
 author: DominicusIn
 

--- a/content/blog/2023-12-16-alternative-internet.md
+++ b/content/blog/2023-12-16-alternative-internet.md
@@ -11,6 +11,9 @@ tags:
 - privacy
 - networks
 - awesome-list
+
+image: /assets/images/og-default.png
+alt: "Alternative Internet"
 ---
 author: DominicusIn
 

--- a/content/blog/2024-10-23-gist-lists.md
+++ b/content/blog/2024-10-23-gist-lists.md
@@ -12,6 +12,9 @@ tags:
 - cli
 gist_id: 4d2dd71dbda592ec3e974f895d9629b6
 gist_url: https://gist.github.com/dominicusin/4d2dd71dbda592ec3e974f895d9629b6
+
+image: /assets/images/og-default.png
+alt: "lists"
 ---
 author: DominicusIn
 

--- a/content/blog/2025-01-24-gist-chroot.md
+++ b/content/blog/2025-01-24-gist-chroot.md
@@ -13,6 +13,9 @@ tags:
 - linux
 gist_id: 8402abedb4df49c2852ce150f03a5372
 gist_url: https://gist.github.com/dominicusin/8402abedb4df49c2852ce150f03a5372
+
+image: /assets/images/og-default.png
+alt: "chroot"
 ---
 author: DominicusIn
 

--- a/content/blog/2025-02-07-gist-zpool-create.md
+++ b/content/blog/2025-02-07-gist-zpool-create.md
@@ -13,6 +13,9 @@ tags:
 - storage
 gist_id: 64a2951303a20059006c99895f8a35d8
 gist_url: https://gist.github.com/dominicusin/64a2951303a20059006c99895f8a35d8
+
+image: /assets/images/og-default.png
+alt: "zpool create"
 ---
 author: DominicusIn
 

--- a/content/blog/2025-03-11-gist-gistfile1txt.md
+++ b/content/blog/2025-03-11-gist-gistfile1txt.md
@@ -11,6 +11,9 @@ tags:
 - code
 gist_id: 09e979be90a5a188026c91453113f5fa
 gist_url: https://gist.github.com/dominicusin/09e979be90a5a188026c91453113f5fa
+
+image: /assets/images/og-default.png
+alt: "gistfile1 txt"
 ---
 author: DominicusIn
 

--- a/content/blog/2025-03-14-ai.md
+++ b/content/blog/2025-03-14-ai.md
@@ -11,6 +11,9 @@ tags:
 - awesome-list
 - applications
 - tools
+
+image: /assets/images/og-default.png
+alt: "AI"
 ---
 author: DominicusIn
 

--- a/content/blog/2025-03-27-gist-eds.md
+++ b/content/blog/2025-03-27-gist-eds.md
@@ -12,6 +12,9 @@ tags:
 - cli
 gist_id: 9b501e765b90f223a969b1617e067222
 gist_url: https://gist.github.com/dominicusin/9b501e765b90f223a969b1617e067222
+
+image: /assets/images/og-default.png
+alt: "ed's"
 ---
 author: DominicusIn
 

--- a/content/blog/2025-05-04-gist-flatpaks.md
+++ b/content/blog/2025-05-04-gist-flatpaks.md
@@ -13,6 +13,9 @@ tags:
 - linux
 gist_id: 93445e617b848ab12e5b0a7026f25752
 gist_url: https://gist.github.com/dominicusin/93445e617b848ab12e5b0a7026f25752
+
+image: /assets/images/og-default.png
+alt: "flatpaks"
 ---
 author: DominicusIn
 

--- a/content/blog/2025-07-03-gist-arch.md
+++ b/content/blog/2025-07-03-gist-arch.md
@@ -13,6 +13,9 @@ tags:
 - arch
 gist_id: 75dc10649ef1619223938456e2f80458
 gist_url: https://gist.github.com/dominicusin/75dc10649ef1619223938456e2f80458
+
+image: /assets/images/og-default.png
+alt: "arch"
 ---
 author: DominicusIn
 

--- a/content/blog/2025-08-13-gist-dns.md
+++ b/content/blog/2025-08-13-gist-dns.md
@@ -13,6 +13,9 @@ tags:
 - networking
 gist_id: df6ba9a693aef08b7cca12f751f784c7
 gist_url: https://gist.github.com/dominicusin/df6ba9a693aef08b7cca12f751f784c7
+
+image: /assets/images/og-default.png
+alt: "dns"
 ---
 author: DominicusIn
 

--- a/content/blog/2025-08-29-ai2.md
+++ b/content/blog/2025-08-29-ai2.md
@@ -10,6 +10,9 @@ tags:
 - llm
 - prompting
 - ml
+
+image: /assets/images/og-default.png
+alt: "AI2"
 ---
 author: DominicusIn
 

--- a/content/blog/2025-09-01-gist-guix0.md
+++ b/content/blog/2025-09-01-gist-guix0.md
@@ -13,6 +13,9 @@ tags:
 - linux
 gist_id: ee9fed0beea74d3e265dc93a53772a53
 gist_url: https://gist.github.com/dominicusin/ee9fed0beea74d3e265dc93a53772a53
+
+image: /assets/images/og-default.png
+alt: "guix0"
 ---
 author: DominicusIn
 

--- a/content/blog/2025-09-03-gist-channelsscm.md
+++ b/content/blog/2025-09-03-gist-channelsscm.md
@@ -13,6 +13,9 @@ tags:
 - plan9
 gist_id: a94364c9e2c9e742d0c94dc58a706361
 gist_url: https://gist.github.com/dominicusin/a94364c9e2c9e742d0c94dc58a706361
+
+image: /assets/images/og-default.png
+alt: "channels.scm"
 ---
 author: DominicusIn
 

--- a/content/blog/2025-10-14-logiki.md
+++ b/content/blog/2025-10-14-logiki.md
@@ -10,6 +10,9 @@ tags:
 - logic
 - reasoning
 - essay
+
+image: /assets/images/og-default.png
+alt: "λογική"
 ---
 author: DominicusIn
 

--- a/content/blog/2025-10-20-epistula-ad-programmatorum.md
+++ b/content/blog/2025-10-20-epistula-ad-programmatorum.md
@@ -10,6 +10,9 @@ tags:
 - craft
 - programming
 - essay
+
+image: /assets/images/og-default.png
+alt: "Epistula ad Programmatorum"
 ---
 author: DominicusIn
 

--- a/content/blog/2025-10-30-unrestricted-ai-tools.md
+++ b/content/blog/2025-10-30-unrestricted-ai-tools.md
@@ -11,6 +11,9 @@ tags:
 - awesome-list
 - tools
 - nsfw
+
+image: /assets/images/og-default.png
+alt: "Unrestricted AI Tools"
 ---
 author: DominicusIn
 

--- a/content/blog/2025-11-02-yet-another-list-of-movies.md
+++ b/content/blog/2025-11-02-yet-another-list-of-movies.md
@@ -9,6 +9,9 @@ categories:
 tags:
 - movies
 - awesome-list
+
+image: /assets/images/og-default.png
+alt: "YA movies's list"
 ---
 author: DominicusIn
 

--- a/content/blog/2025-12-23-awesome-plan9.md
+++ b/content/blog/2025-12-23-awesome-plan9.md
@@ -10,6 +10,9 @@ tags:
 - plan9
 - awesome-list
 - operating-systems
+
+image: /assets/images/og-default.png
+alt: "Awesome Plan9"
 ---
 author: DominicusIn
 

--- a/content/blog/2025-12-29-graph.md
+++ b/content/blog/2025-12-29-graph.md
@@ -10,6 +10,9 @@ tags:
 - knowledge-graph
 - visualization
 - meta
+
+image: /assets/images/og-default.png
+alt: "Graph"
 ---
 
 The interactive knowledge graph has moved to a dedicated, fully-functional

--- a/content/blog/2026-08-15-decentralized-governance-commit-reveal.md
+++ b/content/blog/2026-08-15-decentralized-governance-commit-reveal.md
@@ -14,6 +14,9 @@ tags:
 description: 'Как устроен смарт-контракт DAO в этом репозитории: токен голосования
   с капом, soulbound-репутация, commit-reveal схема против фронтраннинга и двухдневный
   таймлок перед исполнением.'
+
+image: /assets/images/og-default.png
+alt: "Децентрализованное управление: commit-reveal голосование и таймлоки"
 ---
 author: DominicusIn
 

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -8,6 +8,9 @@ categories:
 tags:
 - meta
 - about
+
+image: /assets/images/og-default.png
+alt: "Blog"
 ---
 author: DominicusIn
 

--- a/scripts/check-og-image.cjs
+++ b/scripts/check-og-image.cjs
@@ -1,0 +1,32 @@
+/**
+ * check-og-image.cjs
+ * Guard: every published BLOG POST page must render a social `og:image`
+ * (either explicit frontmatter `image` or the site defaultSocialImage fallback).
+ * Post pages live at public/<year>/<month>/<day>/<slug>/index.html (dated paths).
+ * List/taxonomy pages (categories/*, tags/*, *\/page/*, blog/page/*) are excluded.
+ * Exits non-zero if any post page lacks og:image — catches fallback-regression.
+ */
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+
+const PUBLIC = path.join(__dirname, '..', 'public');
+if (!fs.existsSync(PUBLIC)) {
+  console.error('public/ not built — run `hugo` first.');
+  process.exit(1);
+}
+
+const postPages = glob.sync('public/[0-9][0-9][0-9][0-9]/**/index.html');
+let missing = 0;
+for (const f of postPages) {
+  const c = fs.readFileSync(f, 'utf-8');
+  if (!/property="og:image"/.test(c)) {
+    missing++;
+    console.error('  MISSING og:image:', f);
+  }
+}
+if (missing > 0) {
+  console.error(`\n❌ ${missing} post page(s) without og:image.`);
+  process.exit(1);
+}
+console.log(`✅ All ${postPages.length} post pages have og:image.`);


### PR DESCRIPTION
## Cycle 4 of 10-iteration autonomous loop

59/59 posts lacked an `image` frontmatter. The site already renders a working fallback (`defaultSocialImage`), so non-blocking — but the schema wants `image` (pattern `^/assets/images/`) + `alt`. Backfilling makes posts schema-consistent and self-describing.

### Changes
- Added `image: /assets/images/og-default.png` + `alt: "<title>"` (quoted; some titles contain `:`) to all 59 posts. Same file the fallback uses — truthful, not a fabricated image.
- `scripts/check-og-image.cjs` — guard: fails if any built post page lacks `og:image`. Catches fallback-regression. Verified 58/58 post pages have og:image.

### Verification
hugo 0 errors; content-contract passes; check-og-image passes; lint clean; test ALL PASSED; check-links 0 broken.

### Task system
Beads T65; GSD Phase P; BMAD/Spec `.planning`/`.specify/doc-debt.md`.