### PR TITLE
style(cycle21b): fix eslint prefer-const on jsonBytes (unblock Quality CI)

### DIFF
--- a/src/services/vr-export-service.js
+++ b/src/services/vr-export-service.js
@@ -533,7 +533,7 @@ export class KnowledgeGraphVRExporter {
   convertToGLB(gltf) {
     const enc = new TextEncoder();
     const jsonChunk = JSON.stringify(gltf);
-    let jsonBytes = enc.encode(jsonChunk);
+    const jsonBytes = enc.encode(jsonChunk);
 
     // Pad the JSON chunk to a multiple of 4 BYTES (glTF requires 4-byte
     // alignment of chunks). Use 0x00 padding — valid per the glTF spec.


### PR DESCRIPTION
## Cycle 21 follow-up — fix Quality CI lint failure

### Root cause
#139 merged `convertToGLB()` with `let jsonBytes` (never reassigned) → eslint
`prefer-const` error → Quality CI failed. This PR corrects it to `const`.

### Change
`src/services/vr-export-service.js`: `let jsonBytes` → `const jsonBytes`.
Only change vs main (verified: `git diff origin/main --stat` = 1 file, 1 line).

### Verification
`npm run lint` clean. Rebased onto main.

### Task system
Beads T82 (lint fix). GSD Phase P.
