### PR TITLE
chore(cycle31): add .ci/ to .gitignore (generated CI report artifacts)

### DIFF
--- a/.beads/beads.json
+++ b/.beads/beads.json
@@ -1197,8 +1197,8 @@
     {
       "id": "T92",
       "kind": "task",
-      "title": "deploy-ipfs.yml disabled + .ci/ gitignored",
-      "status": "pending",
+      "title": "Hygiene: add .ci/ to .gitignore (deploy-ipfs.yml already disabled+documented)",
+      "status": "done",
       "deps": [
         "T88"
       ],
@@ -1206,7 +1206,8 @@
         ".github/workflows/deploy-ipfs.yml",
         ".gitignore"
       ],
-      "initiative": "autonomous-cycle"
+      "initiative": "autonomous-cycle",
+      "verified": "Added .ci/ to .gitignore (generated CI report artifacts like external-links-report.json, regenerated per run, never commit). deploy-ipfs.yml already has a DISABLED header (Pinata keys compromised 2026-08-14, Jekyll removed in Phase 7) — no change needed. Verified: git check-ignore .ci -> ignored."
     },
     {
       "id": "T93",

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,7 @@ data/github.json
 # OS / misc
 .DS_Store
 Thumbs.db
+
+# Generated CI report artifacts (e.g. external-links-report.json from
+# scripts/check-external-links.cjs). Regenerated per run; never commit.
+.ci/


### PR DESCRIPTION
## Cycle 31 / Phase 4 T92 — add .ci/ to .gitignore (autonomous; user approved)

### Defect (real, audited)
`.ci/` held generated CI report artifacts (e.g. `external-links-report.json` from `scripts/check-external-links.cjs`). It was **not** in `.gitignore`, so a local auditor run produced an untracked file that had to be manually deleted before each commit — a repeatable footgun.

### Fix
Added `.ci/` to `.gitignore` (regenerated per run; never commit). Verified with a probe file: `git check-ignore .ci/test.txt` → ignored.

Note: `deploy-ipfs.yml` was already correctly DISABLED with a header explaining why (Pinata keys compromised 2026-08-14; Jekyll removed in Phase 7) — no change needed there.

### Verification
`git check-ignore .ci/test.txt` → `.ci/test.txt` (IGNORED OK). `.gitignore` valid.

### Task system
Beads T92 (done). GSD Phase P.
