### PR TITLE
fix(cycle32): add missing T87 node to .beads (Cycle 26 dead-link fix)

### DIFF
--- a/.beads/beads.json
+++ b/.beads/beads.json
@@ -1138,6 +1138,18 @@
       "verified": "audit step printed + summarized by severity (was silently swallowed). Gates only on critical (currently 0 -> scan green + fully reported). moderate/high = warnings (dev/CI tooling: hardhat/lighthouse/puppeteer/undici; node_modules not in prod bundle). security.yml valid YAML; lint/test green. Completes the 15-iteration loop (T72-T86)."
     },
     {
+      "id": "T87",
+      "kind": "task",
+      "title": "CYCLE-26: replace dead hand-authored external links with verified archive.org snapshots",
+      "status": "done",
+      "deps": [],
+      "artifacts": [
+        "content/blog/2025-03-14-ai.md",
+        "content/blog/2023-01-20-awesome-piracy.md"
+      ],
+      "pr": 146
+    },
+    {
       "id": "T88",
       "kind": "task",
       "title": "Planning consolidation: archive .gsd/.openspec/.specify into docs/archive",


### PR DESCRIPTION
## Cycle 32 / internal-consistency repair — add missing T87 node to .beads (autonomous; user approved)

### Defect (real, audited)
`.planning/ROADMAP.md` references `T87` (Cycle 26 dead-link fix, PR #146) but no `T87` node existed in `.beads/beads.json` — the task graph was missing the Cycle 26 entry. ROADMAP cited a non-existent task id.

### Fix
Added the `T87` node to `.beads/beads.json` (kind=task, status=done, pr=146, artifacts = the two edited posts). T88–T92 present/done; T93 = AGENTS.md update (blocked: protected file, awaiting user approval). Verified: all ROADMAP T-refs now resolve; beads valid JSON (95 nodes).

### Verification
Python json.load OK; ROADMAP T-ref subset check → True.

### Task system
Beads T87 (done). GSD Phase P.
