### PR TITLE
docs(cycle33): correct ROADMAP_STATUS.md stale CI claims

### DIFF
--- a/.beads/beads.json
+++ b/.beads/beads.json
@@ -1222,6 +1222,17 @@
         "AGENTS.md"
       ],
       "initiative": "autonomous-cycle"
+    },
+    {
+      "id": "T94",
+      "kind": "task",
+      "title": "CYCLE-33: correct ROADMAP_STATUS.md stale CI claims (perf warn budgets, R&D isolation)",
+      "status": "done",
+      "deps": [],
+      "artifacts": [
+        "docs/ROADMAP_STATUS.md"
+      ],
+      "pr": 153
     }
   ],
   "edges": [

--- a/docs/ROADMAP_STATUS.md
+++ b/docs/ROADMAP_STATUS.md
@@ -31,11 +31,11 @@
 | **Content Contract — soft/report for legacy** | ✅ | `ci-content-contract.cjs` split added(hard)/modified(soft) |
 | **giscus + Buttondown community** | ✅ | `layouts/partials/comments.html`; `/community/` page |
 | **Playwright E2E (smoke + a11y/axe-core)** | ✅ | `e2e.yml`, 14 passing (9 smoke + 5 a11y) |
-| **Lighthouse performance budget in CI** | ✅ | `performance.yml` + `.lighthouserc.json` (error asserts, LCP≤2.5s/CLS≤0.1) |
+| **Lighthouse performance budget in CI** | ⚠️ | `performance.yml` + `.lighthouserc.json` — perf/LCP are **warn** budgets (relaxed Cycle 22: LCP≤4000ms, perf≥0.7) because the Hugo+Blowfish site is inherently heavy (vendored D3, KG 3D, PWA); best-practices/seo/CLS remain **error** asserts |
 | **Knowledge Graph public page** | ✅ | `/knowledge-graph/` + `static/js/knowledge-graph.js` + JSON-LD data |
 | **Engineering-plane surfacing (READMEs, /projects/)** | ✅ | `contracts/dao/README.md`, `src/README.md`, `scripts/README.md`, `content/projects/` |
 | **Author backfill on legacy posts** | ✅ | `backfill-frontmatter.cjs` → `author: DominicusIn` on 59 posts |
-| **Consolidated Quality CI (separate from deploy)** | ✅ | `quality.yml` (build/contract/jest/hardhat/lint/links) — green |
+| **Consolidated Quality CI (separate from deploy)** | ✅ | `quality.yml` (build/lint/links/a11y/og/perf-smoke) + separate `test-rnd.yml` (jest src/ + hardhat contracts/dao) — R&D tests isolated so a flake can't block Pages deploy (Cycle 28) |
 | **Broken-link check** | ✅ | `scripts/check-links.cjs` (193 links, 0 broken) |
 | **HTML well-formedness / a11y spot-check** | ✅ | `scripts/check-html.cjs` (corrected: only flags imgs with NO `alt`; 0 warnings after fix) |
 | **JSON-LD structured data** | ✅ | Blowfish `schema.html` emits `WebSite`/`Article` JSON-LD per page |


### PR DESCRIPTION
## Cycle 33 / T94 — correct ROADMAP_STATUS.md stale CI claims (autonomous; user approved)

### Defect (real, audited)
`docs/ROADMAP_STATUS.md` contained two claims now FALSE after earlier cycles:
- Line 34: claimed Lighthouse budgets were "error asserts, LCP≤2.5s/CLS≤0.1". FALSE — Cycle 22 relaxed perf/LCP to **warn** (LCP≤4000ms, perf≥0.7) because the Hugo+Blowfish site is inherently heavy (vendored D3, KG 3D, PWA); only best-practices/seo/CLS remain error asserts.
- Line 38: claimed `quality.yml` ran "build/contract/jest/hardhat/lint/links". FALSE — Cycle 28 moved jest+hardhat OUT of quality.yml into a separate `test-rnd.yml` (R&D isolation so a flake can't block the Pages deploy).

### Fix
Corrected both lines to match the verified current CI. No code changed; docs now agree with the live workflows.

### Verification
Grep of `.github/workflows/` + `.lighthouserc.json` confirms: perf/LCP = warn; quality.yml has no jest/hardhat step; test-rnd.yml exists. STRATEGIC_PLAN_2026-2028 (authoritative) checked — no false node_modules/jest claims.

### Task system
Beads T94 (done). GSD Phase P.
