### PR TITLE
feat(cycle35): wire DAO security static audit into deploy-dao.yml

### DIFF
--- a/.beads/beads.json
+++ b/.beads/beads.json
@@ -1247,26 +1247,15 @@
       "pr": 153
     },
     {
-      "id": "T95",
+      "id": "T96",
       "kind": "task",
-      "title": "CYCLE-34: correct BASELINE_METRICS.md stale numbers (jest 273/21, HTML 553, coverage 77.44/65.41)",
+      "title": "CYCLE-35: wire scripts/audit-dao.cjs into deploy-dao.yml test job (DAO security static audit)",
       "status": "done",
       "deps": [],
       "artifacts": [
-        "docs/BASELINE_METRICS.md"
+        ".github/workflows/deploy-dao.yml"
       ],
-      "pr": 154
-    },
-    {
-      "id": "T99",
-      "kind": "task",
-      "title": "CYCLE-39/40: ROADMAP.md accuracy + loop 26-40 closeout (T93 AGENTS.md blocked GATE-2)",
-      "status": "done",
-      "deps": [],
-      "artifacts": [
-        ".planning/ROADMAP.md"
-      ],
-      "pr": 158
+      "pr": 155
     }
   ],
   "edges": [

--- a/.github/workflows/deploy-dao.yml
+++ b/.github/workflows/deploy-dao.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Test (hardhat)
         run: npx hardhat test
 
+      - name: DAO security static audit
+        # scripts/audit-dao.cjs checks the compiled contracts for safety patterns
+        # (AccessControl gating, non-transferable Soulbound, restricted mint). It is
+        # a static analysis gate (no secrets) — documented in BASELINE_METRICS.md.
+        run: node scripts/audit-dao.cjs
+
   deploy:
     name: Deploy DAO contracts
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Cycle 35 / T96 — wire DAO security static audit into deploy-dao.yml (autonomous; user approved)

### Defect (real, audited)
`scripts/audit-dao.cjs` (static safety-pattern check for the DAO contracts: AccessControl gating, non-transferable Soulbound, restricted mint) exists and passes (exit 0), and `docs/BASELINE_METRICS.md` + `docs/DAO_ROADMAP.md` cite it as a security gate — but NO workflow actually invoked it. The `deploy-dao.yml` test job ran only `hardhat compile` + `hardhat test`. So the documented DAO security audit was never running in CI (silent gap).

### Fix
Added a "DAO security static audit" step to the `deploy-dao.yml` test job (after `npx hardhat test`), running `node scripts/audit-dao.cjs`. It is a static analysis gate with no secrets (safe on PRs). Now the documented gate actually executes on every `contracts/**` change.

### Verification
deploy-dao.yml valid YAML (js-yaml). `node scripts/audit-dao.cjs` → "Audit PASSED: all safety patterns present." (exit 0).

### Task system
Beads T96 (done). GSD Phase P.
