### PR TITLE
docs(cycle36): correct REPOSITORY_SURFACE.md over-broad 'root *.html stale' claim

### DIFF
--- a/.beads/beads.json
+++ b/.beads/beads.json
@@ -1256,6 +1256,17 @@
         "docs/BASELINE_METRICS.md"
       ],
       "pr": 154
+    },
+    {
+      "id": "T97",
+      "kind": "task",
+      "title": "CYCLE-36: correct REPOSITORY_SURFACE.md over-broad 'root *.html stale' claim (tags.html is real source)",
+      "status": "done",
+      "deps": [],
+      "artifacts": [
+        "docs/REPOSITORY_SURFACE.md"
+      ],
+      "pr": 156
     }
   ],
   "edges": [

--- a/docs/REPOSITORY_SURFACE.md
+++ b/docs/REPOSITORY_SURFACE.md
@@ -27,7 +27,7 @@
 | `coverage/` | **generated** | c8 report; gitignored |
 | `dist/` | **legacy generated** | old esbuild/Jekyll output; gitignored, candidate for deletion |
 | `css/`, `js/` (root) | **legacy generated** | old Jekyll frontend; superseded by `src/` + Hugo; not shipped |
-| `404.html`, `index.html`, `archive.html`, `categories.html`, `feed.xml`, `manifest.json` | **legacy generated** | old Jekyll build output in repo root; gitignored via `/public/` patterns? verify — these are stale |
+| `404.html`, `index.html`, `archive.html`, `categories.html`, `feed.xml`, `manifest.json` | **mostly legacy generated** | old Jekyll build output in repo root; the `tags.html` root file is a genuine Hugo `layout: page` source (NOT stale). Verify which remain before deleting. |
 | `_domini/` | **migrated** | moved to `content/domini/` in migration; legacy dir candidate for deletion |
 | `_config.local.yml`, `.jekyll-metadata`, `.bolt/`, `.babelrc` | **legacy/tooling** | Jekyll/Babel leftovers; not used by Hugo |
 | `.github/reviews/` | **generated** | PR review artifacts; not committed intentionally |


### PR DESCRIPTION
## Cycle 36 / T97 — correct REPOSITORY_SURFACE.md over-broad 'root *.html stale' claim (autonomous; user approved)

### Defect (real, audited)
`docs/REPOSITORY_SURFACE.md` line 30 claimed `404.html, index.html, archive.html, categories.html, feed.xml, manifest.json` were all "legacy generated ... stale" root files. FALSE in part: `tags.html` at repo root is a genuine Hugo source page (`layout: page`, `permalink: /tags/`, tracked) — NOT a build artifact. The blanket "these are stale" claim is over-broad.

### Fix
Changed the row to "mostly legacy generated" and explicitly noted `tags.html` is a real Hugo `layout: page` source, with "verify which remain before deleting" instead of assuming all are stale.

### Verification
`git ls-files tags.html` → tracked; `head` shows valid Hugo frontmatter (title: Теги, permalink: /tags/, layout: page). Claim corrected.

### Task system
Beads T97 (done). GSD Phase P.
