### PR TITLE
fix(cycle43): exclude mirrored third-party lists from internal-link audit

### DIFF
--- a/.beads/beads.json
+++ b/.beads/beads.json
@@ -1283,6 +1283,19 @@
         "layouts/partials/crosslinks.html",
         "config/_default/hugo.toml"
       ]
+    },
+    {
+      "id": "T102",
+      "title": "cycle43: exclude mirrored 3rd-party lists from internal-link audit",
+      "status": "done",
+      "priority": "P2",
+      "owner": "audit-loop",
+      "depends_on": [
+        "T101"
+      ],
+      "pr": 162,
+      "evidence": "audit-internal-links.cjs BROKEN 20->0 after IGNORE added for 8 mirrored posts",
+      "verification": "node --check + audit re-run 0 broken + jest 277/21 + build 0"
     }
   ],
   "edges": [
@@ -1535,6 +1548,11 @@
       "from": "T29",
       "to": "T30",
       "type": "blocks"
+    },
+    {
+      "from": "T101",
+      "to": "T102",
+      "type": "next"
     }
   ]
 }

--- a/scripts/audit-internal-links.cjs
+++ b/scripts/audit-internal-links.cjs
@@ -20,7 +20,20 @@ const REPO_ROOT = path.join(__dirname, '..');
 const rootFiles = new Set(fs.readdirSync(REPO_ROOT));
 
 // Auto-generated / CI-fallback content must NOT be edited (regenerated each sync).
-const IGNORE = ['content/gists/**'];
+// Also ignore intentionally-mirrored third-party lists whose relative links
+// point into the *upstream source repo* (e.g. ./CONTRIBUTING.md, AUTHORS.md),
+// not this site. These are not author content and their broken links are expected.
+const IGNORE = [
+  'content/gists/**',
+  'blog/2017-11-06-Winworkstation.md',
+  'blog/2018-11-09-awesome-machine-learning-for-cyber-security.md',
+  'blog/2019-06-16-Awesome-Selfhosted.md',
+  'blog/2022-05-16-Awesome-Selfhosted.md',
+  'blog/2023-01-14-a-collection-of-awesome-ai-applications.md',
+  'blog/2023-01-20-awesome-piracy.md',
+  'blog/2023-05-18-dark-web-links.md',
+  'blog/2025-12-23-awesome-plan9.md',
+];
 
 const linkRe = /\[[^\]]*\]\(([^)]+)\)/g;
 const mdFiles = glob.sync('**/*.md', { cwd: CONTENT_DIR, absolute: true, ignore: IGNORE });


### PR DESCRIPTION
See commit message. BROKEN internal links 20->0; jest 277/21; build 0. Audit-only change (IGNORE 8 mirrored posts).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal-link auditing by excluding mirrored third-party content and specified blog posts from the audit.
  * Continued excluding generated gist content from audit results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->