### PR TITLE
fix(cycle48): re-sanitize existing generated content on every deploy

### DIFF
--- a/.beads/beads.json
+++ b/.beads/beads.json
@@ -1336,6 +1336,13 @@
       "status": "done",
       "pr": null,
       "note": "Added .htmlvalidate.json disabling attr-quotes/doctype-style/script-type/void-style — these flag Hugo's intentional minified output (unquoted attrs are valid HTML5), producing ~50 false-positive errors on the non-blocking validate step. Now 0 errors; report is meaningful. Theme-chrome a11y (autocomplete-on-checkbox, aria-hidden-on-focusable) is in pinned Blowfish submodule v2.105.0, untouchable without breaking pin — documented as known-issue."
+    },
+    {
+      "id": "T107",
+      "title": "cycle48: sanitize-generated.cjs + hugo.yml step (re-sanitize existing generated content)",
+      "status": "done",
+      "pr": null,
+      "note": "Found injected <script async src=...> in content/repositories/dominicusin__webring.md (external GitHub README, unsafe=true Hugo). TASK-009 sanitizeExternal only covers FRESH sync; already-written generated content was never re-sanitized. Added scripts/sanitize-generated.cjs (scans content/repositories/*.md + content/gists/*.md, strips <script>/on*=/javascript:/vbscript:/iframe/object/embed) and wired it into hugo.yml deploy workflow right after sync-github.cjs, before build. Verified: scanned 236 generated files, sanitized 1 (webring.md), legit code/links preserved. Cleaned up local sync experiment artifacts (gitignored generated content)."
     }
   ],
   "edges": [
@@ -1612,6 +1619,11 @@
     {
       "from": "T105",
       "to": "T106",
+      "type": "next"
+    },
+    {
+      "from": "T106",
+      "to": "T107",
       "type": "next"
     }
   ]

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -60,6 +60,13 @@ jobs:
         # from the live GitHub API before building. Graceful: never fails deploy.
         run: node scripts/sync-github.cjs
 
+      - name: Sanitize generated content (trust boundary)
+        # Re-strip executable vectors (<script>, inline on*= handlers,
+        # javascript:/vbscript: link schemes, <iframe>/<object>/<embed>) from
+        # every generated repo/gist page. Defense-in-depth over sync-github.cjs:
+        # catches content a skipped/partial sync left untouched. See TASK-009.
+        run: node scripts/sanitize-generated.cjs
+
       - name: Validate content contract
         # Publishing contract (Vector A): new posts in content/blog/ MUST
         # satisfy schema/post-metadata.schema.json (hard gate — a failing new

--- a/scripts/sanitize-generated.cjs
+++ b/scripts/sanitize-generated.cjs
@@ -1,0 +1,58 @@
+/**
+ * sanitize-generated.cjs — one-pass sanitizer for ALREADY-GENERATED content.
+ *
+ * TASK-009 added `sanitizeExternal()` inside scripts/sync-github.cjs so that
+ * freshly-synced GitHub READMEs/gists are stripped of executable vectors
+ * (<script>, inline on*= handlers, javascript:/vbscript: link schemes,
+ * <iframe>/<object>/<embed>) before they are written into content/.
+ *
+ * Gap this script closes: if a sync is skipped (rate-limit / cache / partial
+ * run), previously-written generated content is never re-sanitized. This script
+ * re-runs the same stripping over every existing generated file so a stored-XSS
+ * payload cannot survive a deploy untouched. Run in the Pages deploy workflow
+ * immediately before `hugo build`.
+ *
+ * It is defense-in-depth, NOT a full HTML sanitizer — legitimate code blocks
+ * (e.g. `<a>` inside fenced blocks, `a < b && c > d`) are preserved.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function sanitizeExternal(input) {
+  if (!input) return input;
+  return input
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '')
+    .replace(/<\/script>/gi, '')
+    .replace(/\son[a-z]+\s*=\s*("([^"]*)"|'([^']*)'|[^\s>]+)/gi, '')
+    .replace(/(\[[^\]]*\]\()\s*(javascript:|vbscript:)[^)\s]*/gi, '$1#')
+    .replace(/<(iframe|object|embed)\b[^>]*>[\s\S]*?<\/(iframe|object|embed)>/gi, '')
+    .replace(/<(iframe|object|embed)\b[^>]*\/?>/gi, '');
+}
+
+const TARGETS = [
+  path.join('content', 'repositories'),
+  path.join('content', 'gists'),
+];
+
+let scanned = 0;
+let changed = 0;
+
+for (const dir of TARGETS) {
+  if (!fs.existsSync(dir)) continue;
+  for (const file of fs.readdirSync(dir)) {
+    if (!file.endsWith('.md')) continue;
+    const full = path.join(dir, file);
+    const before = fs.readFileSync(full, 'utf8');
+    const after = sanitizeExternal(before);
+    if (before !== after) {
+      fs.writeFileSync(full, after);
+      changed++;
+      console.log(`  sanitized ${full}`);
+    }
+    scanned++;
+  }
+}
+
+console.log(`🔒 sanitize-generated: scanned ${scanned} generated file(s), sanitized ${changed}.`);
+process.exit(0);


### PR DESCRIPTION
See commit message. Real stored-XSS gap closed: injected <script> in generated webring.md now re-sanitized via scripts/sanitize-generated.cjs wired into hugo.yml. lint clean, jest 277/21, build 0. Edits .github/workflows/hugo.yml so Quality CI needs manual dispatch.