### PR TITLE
fix(cycle51): repair ai-review.cjs (ReferenceError + broken schema call)

### DIFF
--- a/.beads/beads.json
+++ b/.beads/beads.json
@@ -1343,6 +1343,13 @@
       "status": "done",
       "pr": null,
       "note": "Found injected <script async src=...> in content/repositories/dominicusin__webring.md (external GitHub README, unsafe=true Hugo). TASK-009 sanitizeExternal only covers FRESH sync; already-written generated content was never re-sanitized. Added scripts/sanitize-generated.cjs (scans content/repositories/*.md + content/gists/*.md, strips <script>/on*=/javascript:/vbscript:/iframe/object/embed) and wired it into hugo.yml deploy workflow right after sync-github.cjs, before build. Verified: scanned 236 generated files, sanitized 1 (webring.md), legit code/links preserved. Cleaned up local sync experiment artifacts (gitignored generated content)."
+    },
+    {
+      "id": "T108",
+      "title": "cycle51: fix ai-review.cjs (ReferenceError + broken schema subprocess call)",
+      "status": "done",
+      "pr": null,
+      "note": "scripts/ai-review.cjs had two real bugs: (1) `externalWarnings` was declared inside an `if` block but referenced in the sibling `else if` -> ReferenceError on any post with external links (caught soft by ci-content-contract, but silent failure); fixed by hoisting `let externalWarnings = []`. (2) schema-validation step called `validate-frontmatter.js` but the file is `validate-frontmatter.cjs` -> execFileSync always threw MODULE_NOT_FOUND -> 'Schema validation failed' on EVERY post (false negative vs the working standalone validator). Fixed to `.cjs`. Verified: ai-review now reports 'Schema validation passed' and no ReferenceError on all posts; ci-content-contract.cjs still exits 0. NOTE: a legacy 2019 post (SFTP) has an inverted markdown link [url](text) that ai-review flags as broken internal link - this is content, not script, bug; left as-is per cycle-43 no-mass-edit precedent. ai-review.cjs is a soft (non-blocking) gate."
     }
   ],
   "edges": [
@@ -1624,6 +1631,11 @@
     {
       "from": "T106",
       "to": "T107",
+      "type": "next"
+    },
+    {
+      "from": "T107",
+      "to": "T108",
       "type": "next"
     }
   ]

--- a/scripts/ai-review.cjs
+++ b/scripts/ai-review.cjs
@@ -343,12 +343,13 @@ async function reviewPost(filePath) {
   
   const internalErrors = validateInternalLinks(links, allPosts);
   report.errors.push(...internalErrors);
-  
+
+  let externalWarnings = [];
   if (CONFIG.checkExternalLinks && links.external.length > 0) {
-    const externalWarnings = await validateExternalLinks(links);
+    externalWarnings = await validateExternalLinks(links);
     report.warnings.push(...externalWarnings);
   }
-  
+
   if (internalErrors.length === 0 && links.external.length === 0) {
     log(colors.green, '   All links valid');
   } else if (internalErrors.length === 0) {
@@ -382,7 +383,7 @@ async function reviewPost(filePath) {
   // 5. Schema Validation (call external script)
   log(colors.cyan, '\n✅ Running schema validation...');
   try {
-    execFileSync('node', [path.join(__dirname, 'validate-frontmatter.js'), filePath], {
+    execFileSync('node', [path.join(__dirname, 'validate-frontmatter.cjs'), filePath], {
       stdio: 'pipe',
       encoding: 'utf8'
     });


### PR DESCRIPTION
See commit message. Two real bugs fixed in the soft AI-review gate: externalWarnings ReferenceError + validate-frontmatter.js->.cjs (schema validation now runs). lint clean, jest 277/21, ci-content-contract still exits 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an error that could interrupt AI review processing when reporting external-link warnings.
  * Corrected schema validation so front matter checks run successfully with the intended validator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->