### PR TITLE
fix(cycle53): wire audit-internal-links.cjs into CI (was dead code)

### DIFF
--- a/.beads/beads.json
+++ b/.beads/beads.json
@@ -1357,6 +1357,13 @@
       "status": "done",
       "pr": null,
       "note": "scripts/check-external-links.cjs regex-extracted hrefs but Hugo HTML-escapes & -> &amp; in href attributes. Script passed the raw &amp;-encoded URL to new URL()/http.request, checking a MALFORMED URL (?cmd=show&amp;type=NOT instead of ?cmd=show&type=NOT) -> false-positive DEAD reports for any link with query params. Fixed by unescaping &amp; -> & in hostOf() and check() before URL parsing/request. Verified decode produces valid URL + correct host. Did NOT re-run full network audit (slow, non-blocking). Cleaned up local experiment artifacts (gitignored generated content + .github/reviews noise) left by probe runs."
+    },
+    {
+      "id": "T110",
+      "title": "cycle53: wire audit-internal-links.cjs into CI (was dead code)",
+      "status": "done",
+      "pr": null,
+      "note": "Discovered scripts/audit-internal-links.cjs (source-level markdown internal-link auditor) was NEVER invoked by any workflow, package.json script, or other script -- it was dead code. Its cycle-43 IGNORE list (8 mirrored awesome-lists) and 0-BROKEN result were therefore unused in CI. Wired it into .github/workflows/quality.yml as a report-only step after the built-surface check-links.cjs, giving pre-build source-level link feedback (complements Hugo alias/redirect resolution). Verified: script exits 0, 0 actionable dead links on current content. Non-blocking (no process.exit(1)), so pipeline safe. This is a workflow edit -> Quality CI needs manual dispatch on the PR."
     }
   ],
   "edges": [
@@ -1648,6 +1655,11 @@
     {
       "from": "T108",
       "to": "T109",
+      "type": "next"
+    },
+    {
+      "from": "T109",
+      "to": "T110",
       "type": "next"
     }
   ]

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -61,8 +61,14 @@ jobs:
       # test-rnd.yml workflow so a flaky R&D test cannot block the Pages deploy.
       # They are still enforced on R&D-relevant changes (src/, contracts/, tests/).
 
-      - name: 🔗 Broken internal link check
+      - name: 🔗 Broken internal link check (built surface)
         run: node scripts/check-links.cjs
+
+      - name: 🔗 Internal link audit (source markdown, pre-build)
+        # Source-level audit of content/**/*.md — complements the built-surface
+        # check above (catches dead links before Hugo resolves aliases/redirects).
+        # Report-only: always exits 0. Was previously dead code (never wired in).
+        run: node scripts/audit-internal-links.cjs
 
       - name: 🩺 HTML well-formedness (report, non-blocking)
         run: node scripts/check-html.cjs


### PR DESCRIPTION
See commit message. Source-level internal-link auditor was never invoked by any workflow/script — dead code. Wired into quality.yml as report-only step after built-surface check. 0 actionable dead links, exit 0. Edits .github/workflows/quality.yml so Quality CI needs manual dispatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added source-level Markdown link auditing to the quality workflow.
  * Link checks now distinguish between built-surface validation and source-document auditing.
* **Bug Fixes**
  * Enabled previously unused internal-link checks to provide additional link feedback during quality reviews.
* **Chores**
  * Source link auditing is report-only and does not block builds or deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->