### PR TITLE
fix: replace unsupported coalesce() with || in vr-export/link-repair

### DIFF
--- a/.github/workflows/link-repair.yml
+++ b/.github/workflows/link-repair.yml
@@ -47,8 +47,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
-          DRY_RUN: ${{ coalesce(github.event.inputs.dry_run, 'false') }}
-          MIN_CONFIDENCE: ${{ coalesce(github.event.inputs.min_confidence, '0.6') }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          MIN_CONFIDENCE: ${{ github.event.inputs.min_confidence || '0.6' }}
         run: |
           node src/agents/link-repair-agent.js ${DRY_RUN == 'true' && '--dry-run' || ''}
       

--- a/.github/workflows/vr-export.yml
+++ b/.github/workflows/vr-export.yml
@@ -43,8 +43,8 @@ jobs:
       
       - name: Generate VR Scene
         env:
-          EXPORT_QUALITY: ${{ coalesce(github.event.inputs.quality, 'medium') }}
-          EXPORT_FORMAT: ${{ coalesce(github.event.inputs.format, 'glb') }}
+          EXPORT_QUALITY: ${{ github.event.inputs.quality || 'medium' }}
+          EXPORT_FORMAT: ${{ github.event.inputs.format || 'glb' }}
         run: |
           node scripts/generate-vr-scene.js
       
@@ -106,8 +106,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const quality = '${{ coalesce(github.event.inputs.quality, 'medium') }}';
-            const format = '${{ coalesce(github.event.inputs.format, 'glb') }}';
+            const quality = '${{ github.event.inputs.quality || 'medium' }}';
+            const format = '${{ github.event.inputs.format || 'glb' }}';
             
             await github.rest.repos.createCommitComment({
               owner: context.repo.owner,


### PR DESCRIPTION
GitHub Actions expressions do NOT support `coalesce()`. Both `vr-export.yml` and `link-repair.yml` used `coalesce(github.event.inputs.x, 'default')`, which made GitHub reject the workflow at parse time (0-second failures shown as the filename in run list).

Replaced all 6 occurrences with the supported `github.event.inputs.x || 'default'` form.

Verified: `gh workflow run vr-export.yml` no longer returns "Unrecognized function: 'coalesce'".