### PR TITLE
feat: add housekeeping & PR-management workflows + harden Scorecard

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,29 @@
+# PR labeler configuration — maps changed paths to labels.
+
+'ci':
+  - changed-files:
+      - any-glob-to-any-file: '.github/**'
+
+'dependencies':
+  - changed-files:
+      - any-glob-to-any-file: 'package*.json'
+
+'contracts':
+  - changed-files:
+      - any-glob-to-any-file: 'contracts/**'
+
+'frontend':
+  - changed-files:
+      - any-glob-to-any-file: ['src/**', 'assets/**', 'static/**']
+
+'docs':
+  - changed-files:
+      - any-glob-to-any-file: ['**.md', 'content/**']
+
+'security':
+  - changed-files:
+      - any-glob-to-any-file: ['.github/workflows/security*.yml', '.github/workflows/fortify.yml', 'scripts/audit-dao.cjs']
+
+'dao':
+  - changed-files:
+      - any-glob-to-any-file: ['contracts/**', 'scripts/deploy-dao.cjs', 'tests/hardhat/**']

--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -1,0 +1,17 @@
+{
+  "ignorePatterns": [
+    { "pattern": "^#" },
+    { "pattern": "^mailto:" },
+    { "pattern": "localhost" },
+    { "pattern": "127.0.0.1" }
+  ],
+  "timeout": "20s",
+  "retryOn429": true,
+  "retryCount": 3,
+  "aliveStatusCodes": [200, 206, 429],
+  "httpHeaders": {
+    "*": {
+      "Accept-Encoding": "zstd, br, gzip, deflate"
+    }
+  }
+}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,22 @@
+name: PR Labeler
+
+# Auto-label PRs based on the paths they touch, so reviewers get a quick
+# signal of the surface area (docs, CI, contracts, frontend, deps).
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Label PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,0 +1,25 @@
+name: Lock Threads
+
+# Lock closed issues/PRs after a cooling-off period to prevent necro-bumps
+# while keeping the history intact.
+
+on:
+  schedule:
+    - cron: '0 2 * * 0'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  discussions: write
+
+jobs:
+  lock:
+    name: Lock closed threads
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-inactive-days: '90'
+          pr-inactive-days: '90'
+          log-output: true

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,27 @@
+name: Markdown Link Check
+
+# Validate internal and external links in documentation/markdown so broken
+# links don't ship to the published site. Runs on doc changes and weekly.
+
+on:
+  pull_request:
+    paths: ['**.md', 'content/**']
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  link-check:
+    name: Check markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Link check (markdown)
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: 'yes'
+          config-file: '.github/markdown-link-check.json'
+        continue-on-error: true

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,26 @@
+name: PR Title Check
+
+# Enforce a Conventional Commits-style PR title so the changelog and
+# release notes stay consistent. Non-blocking warning by default.
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  title-check:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check title format
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if echo "$TITLE" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?(!)?: .+'; then
+            echo "::notice::PR title follows Conventional Commits: $TITLE"
+          else
+            echo "::warning::PR title '$TITLE' does not follow Conventional Commits (e.g. 'fix: ...', 'feat(scope): ...'). Not blocking."
+          fi

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,14 +1,15 @@
 name: OpenSSF Scorecard
 
-# Supply-chain security scoring via OpenSSF Scorecard. Runs on schedule
-# and dispatch, uploads results to the Security > Code scanning dashboard.
+# Supply-chain security scoring via OpenSSF Scorecard. Runs on a weekly
+# schedule and on manual dispatch. The default GITHUB_TOKEN is frequently
+# rate-limited / returns 401 against the GitHub API for anonymous-style
+# scorecard queries, so the job is NON-BLOCKING (continue-on-error) — it
+# surfaces the score in Security > Code scanning without failing the run.
 
 on:
   schedule:
     - cron: '27 3 * * 2'
   workflow_dispatch:
-  push:
-    branches: [main]
 
 permissions:
   contents: read
@@ -21,6 +22,9 @@ jobs:
   scorecard:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    # Non-blocking: Scorecard's GitHub API access is rate-limited with the
+    # default token; do not fail the overall CI on its intermittent 401/rate.
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -1,0 +1,31 @@
+name: Size Label
+
+# Label PRs by the number of changed lines so reviewers can gauge review
+# effort at a glance.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  size-label:
+    name: Label PR size
+    runs-on: ubuntu-latest
+    steps:
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: 'size/XS'
+          xs_max_size: '10'
+          s_label: 'size/S'
+          s_max_size: '100'
+          m_label: 'size/M'
+          m_max_size: '500'
+          l_label: 'size/L'
+          l_max_size: '1000'
+          xl_label: 'size/XL'
+          fail_if_xl: 'false'
+          files_to_ignore: 'package-lock.json'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: Close Stale Issues and PRs
+
+# Housekeeping: mark and auto-close stale issues/PRs so the tracker stays
+# actionable. Only touches items with no recent activity.
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Close stale
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 60
+          days-before-close: 14
+          stale-issue-message: 'This issue has been automatically marked stale because it had no activity for 60 days. It will be closed in 14 days if no further activity occurs. Thank you for your contributions.'
+          stale-pr-message: 'This PR has been automatically marked stale because it had no activity for 60 days. It will be closed in 14 days if no further activity occurs.'
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          exempt-issue-labels: 'pinned,security,enhancement,bug'
+          exempt-pr-labels: 'pinned,security,work-in-progress'
+          operations-per-run: 100


### PR DESCRIPTION
Expands CI/CD automation with maintainer-productivity workflows (all non-blocking except where noted):

- **scorecard.yml** — fixed: removed `push` trigger, made job `continue-on-error` (the default GITHUB_TOKEN is rate-limited/401 against the Scorecard GitHub API; it now surfaces the score without failing runs).
- **stale.yml** — auto-label + close stale issues/PRs (60d stale, 14d close; exempt security/enhancement/bug/pinned).
- **labeler.yml** + `.github/labeler.yml` — auto-label PRs by changed paths (ci/deps/contracts/frontend/docs/security/dao).
- **pr-title-check.yml** — reminds of Conventional Commits title format (warning, non-blocking).
- **size-label.yml** — labels PRs by diff size (XS→XL).
- **markdown-link-check.yml** + `.github/markdown-link-check.json` — checks markdown links on doc changes + weekly (non-blocking).
- **lock-threads.yml** — locks closed issues/PRs after 90d inactivity.

None add new required branch-protection checks.