### PR TITLE
fix: lock-threads token length bug

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -19,7 +19,6 @@ jobs:
     steps:
       - uses: dessant/lock-threads@v5
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-inactive-days: '90'
           pr-inactive-days: '90'
           log-output: true


### PR DESCRIPTION
dessant/lock-threads@v5 rejects an explicit github-token input (length <= 100 bug). Removing it lets the action use the default GITHUB_TOKEN.