### PR TITLE
fix: deploy-dao skip when secrets absent (non-blocking)

### DIFF
--- a/.github/workflows/deploy-dao.yml
+++ b/.github/workflows/deploy-dao.yml
@@ -45,14 +45,17 @@ jobs:
   deploy:
     name: Deploy DAO contracts
     runs-on: ubuntu-latest
-    # Tests must pass before we even consider deploying.
-    needs: test
-    # Only deploy from main via workflow_dispatch or a direct push with secrets;
-    # never from a PR (PRs only run the test job above).
+    # Deploy only from main/dispatch when credentials exist; otherwise skip
+    # (don't fail) so the check stays non-blocking. Tests (above) always run.
+    # Never from a PR.
     if: >-
+      secrets.DEPLOY_PRIVATE_KEY != '' &&
+      secrets.SEPOLIA_RPC_URL != '' &&
       github.event_name != 'pull_request' &&
       (github.event_name == 'workflow_dispatch' ||
        (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+    # Tests must pass before we even consider deploying.
+    needs: test
     # Hard requirement: a funded wallet private key must be supplied as a
     # repository secret. Without it we fail loudly rather than fake a deploy.
     env:


### PR DESCRIPTION
Deploy DAO contracts job now skips (instead of failing) when DEPLOY_PRIVATE_KEY/SEPOLIA_RPC_URL secrets are absent, keeping the check non-blocking. Tests always run.