### PR TITLE
feat: add actions/attest@v4.2.2 generic attestations

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -110,6 +110,11 @@ jobs:
         with:
           path: ./public
 
+      - name: Generate Generic Attestations
+        uses: actions/attest@v4.2.2
+        with:
+          subject-path: ./public
+
   deploy:
     needs: build
     environment:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -33,3 +33,10 @@ jobs:
           name: sbom
           path: sbom.spdx.json
           retention-days: 30
+
+      - name: Generate Generic Attestations
+        uses: actions/attest@v4.2.2
+        with:
+          subject-path: sbom.spdx.json
+          predicate-type: https://spdx.dev/Document
+          predicate: sbom.spdx.json


### PR DESCRIPTION
Adds `actions/attest@v4.2.2` (Generate Generic Attestations) to:\n- `sbom.yml`: attests the generated `sbom.spdx.json`\n- `hugo.yml`: attests the built site artifact (`./public`)\n\nProvides SLSA-style provenance for build outputs.