### PR TITLE
fix: sbom.yml id-token permission for attest

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -110,6 +110,11 @@ jobs:
         with:
           path: ./public
 
+      - name: Generate Generic Attestations
+        uses: actions/attest@v4.2.2
+        with:
+          subject-path: ./public
+
   deploy:
     needs: build
     environment:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -33,3 +33,10 @@ jobs:
           name: sbom
           path: sbom.spdx.json
           retention-days: 30
+
+      - name: Generate Generic Attestations
+        uses: actions/attest@v4.2.2
+        with:
+          subject-path: sbom.spdx.json
+          predicate-type: https://spdx.dev/Document
+          predicate: sbom.spdx.json

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   sbom:


### PR DESCRIPTION
actions/attest@v4.2.2 requires `permissions: id-token: write` (OIDC). Add it to the SBOM job.