### PR TITLE
fix: sbom.yml predicate-file for attest

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -110,6 +110,11 @@ jobs:
         with:
           path: ./public
 
+      - name: Generate Generic Attestations
+        uses: actions/attest@v4.2.2
+        with:
+          subject-path: ./public
+
   deploy:
     needs: build
     environment:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -33,3 +33,10 @@ jobs:
           name: sbom
           path: sbom.spdx.json
           retention-days: 30
+
+      - name: Generate Generic Attestations
+        uses: actions/attest@v4.2.2
+        with:
+          subject-path: sbom.spdx.json
+          predicate-type: https://spdx.dev/Document
+          predicate: sbom.spdx.json

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   sbom:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -40,4 +40,4 @@ jobs:
         with:
           subject-path: sbom.spdx.json
           predicate-type: https://spdx.dev/Document
-          predicate: sbom.spdx.json
+          predicate-file: sbom.spdx.json


### PR DESCRIPTION
actions/attest@v4.2.2 expects `predicate-file` (path) not `predicate` (inline JSON). Fixes '\'sbom.spdx.json\' is not valid JSON'.