### PR TITLE
fix: sbom.yml predicate-file for attest

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -40,4 +40,4 @@ jobs:
         with:
           subject-path: sbom.spdx.json
           predicate-type: https://spdx.dev/Document
-          predicate: sbom.spdx.json
+          predicate-file: sbom.spdx.json


### PR DESCRIPTION
actions/attest@v4.2.2 expects predicate-file (path) not predicate (inline JSON).