### PR TITLE
fix: sbom.yml predicate-path for attest

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -40,4 +40,4 @@ jobs:
         with:
           subject-path: sbom.spdx.json
           predicate-type: https://spdx.dev/Document
-          predicate-file: sbom.spdx.json
+          predicate-path: sbom.spdx.json

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -40,4 +40,4 @@ jobs:
         with:
           subject-path: sbom.spdx.json
           predicate-type: https://spdx.dev/Document
-          predicate: sbom.spdx.json
+          predicate-file: sbom.spdx.json


### PR DESCRIPTION
Correct input is `predicate-path` (not predicate-file/predicate). Verified inputs list from action.