### PR TITLE
fix: attestations:write perm for actions/attest

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -15,6 +15,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  attestations: write
 
 concurrency:
   group: pages

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -40,4 +40,4 @@ jobs:
         with:
           subject-path: sbom.spdx.json
           predicate-type: https://spdx.dev/Document
-          predicate-file: sbom.spdx.json
+          predicate-path: sbom.spdx.json

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  attestations: write
 
 jobs:
   sbom:


### PR DESCRIPTION
actions/attest@v4.2.2 needs `attestations: write` to persist attestations. Add to sbom.yml and hugo.yml.