### PR TITLE
feat: mirror GitHub Wiki into published site (submodule + nav ADR-0003)

### DIFF
--- a/.beads/beads.json
+++ b/.beads/beads.json
@@ -1378,6 +1378,22 @@
       "status": "done",
       "pr": null,
       "note": "User requested: categories quick-nav on top of every page (after menu), tags quick-nav in footer of every page. Added reusable layouts/partials/taxonomy-bar.html (renders .Site.GetPage 'taxonomy' <name> .Data.Terms with i18n nav_<tax> heading; uses urlize $term in GetPage because raw term name returned nil). Wired into layouts/partials/header/basic.html override (categories, right after .main-menu) and layouts/partials/footer.html override (tags, top of footer). Verified on built public/: categories bar at byte 30662 < main 33496 (after menu, before content); tags bar at 82468 > footer 79734 (inside footer); real links /categories/{ai,career,dao,links}/ and /tags/{awesome-list,media,piracy}/; i18n headings Категории/Теги (RU) + Categories/Tags (EN). Full gate: lint clean, jest 277/21, hugo build 0. Key gotcha fixed: $.Site.GetPage 'taxonomy' $taxonomy $term returned nil until wrapped with (urlize $term); relLangURL . broke because . is WeightedPages inside range."
+    },
+    {
+      "id": "T113",
+      "kind": "task",
+      "title": "Mirror GitHub Wiki into published site as /wiki/ section",
+      "status": "done",
+      "deps": [],
+      "artifacts": [
+        ".gitmodules",
+        "content/wiki (submodule)",
+        "content/wiki-build (generated, git-ignored)",
+        "scripts/generate-wiki-nav.py",
+        "docs/adr/0003-wiki-submodule-sync.md",
+        ".github/workflows/hugo.yml"
+      ],
+      "pr": 214
     }
   ],
   "edges": [

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -38,6 +38,17 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Init wiki submodule
+        # content/wiki is a git submodule (GitHub Wiki). Ensure it is present
+        # even if checkout's recursive flag missed it.
+        run: git submodule update --init --recursive content/wiki
+
+      - name: Generate wiki navigation
+        # Blowfish has no built-in docs-tree sidebar; this pre-build script
+        # copies content/wiki/*.md into content/wiki-build/ with menu.main
+        # front matter (submodule stays read-only). See ADR for the design.
+        run: python3 scripts/generate-wiki-nav.py
+
       - name: Setup Node (for content-contract validation)
         uses: actions/setup-node@v7
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ Thumbs.db
 # Generated CI report artifacts (e.g. external-links-report.json from
 # scripts/check-external-links.cjs). Regenerated per run; never commit.
 .ci/
+
+# Generated wiki nav (built from content/wiki submodule)
+content/wiki-build/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "themes/blowfish"]
 	path = themes/blowfish
 	url = https://github.com/nunocoracao/blowfish.git
+[submodule "content/wiki"]
+	path = content/wiki
+	url = https://github.com/dominicusin/dominicusin.github.io.wiki.git

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -56,3 +56,17 @@ canonifyURLs = false
   [[related.indices]]
     name = "categories"
     weight = 50
+
+# The GitHub Wiki is mirrored as a git submodule at content/wiki/ (read-only
+# source). Its pages are copied + front-matter-injected into content/wiki-build/
+# by scripts/generate-wiki-nav.py at build time. Exclude the raw submodule from
+# the build so we don't publish duplicate un-menu'd pages. See ADR-0003.
+ignoreFiles = ["content/wiki/**"]
+
+# Also exclude the wiki submodule from the content mount so Hugo does not
+# publish the raw (front-matter-less) submodule pages alongside wiki-build/.
+[module]
+  [[module.mounts]]
+    source = "content"
+    target = "content"
+    excludeFiles = ["wiki/**"]

--- a/docs/adr/0003-wiki-submodule-sync.md
+++ b/docs/adr/0003-wiki-submodule-sync.md
@@ -1,0 +1,51 @@
+# ADR 0003 — Mirroring the GitHub Wiki into the published site
+
+- **Status:** Accepted (verified 2026-08-20, after submodule + pre-build nav script)
+- **Context:** The repository's operational/security documentation lives in the
+  GitHub Wiki (`dominicusin.github.io.wiki`). We want that content surfaced on the
+  published site as a documentation section, kept in sync automatically. Two
+  constraints shape the design:
+  1. **Blowfish (v2.105.0, submodule) has no built-in hierarchical docs-tree
+     sidebar.** Verified in `themes/blowfish/layouts/`: navigation is built
+     exclusively from `.Site.Menus.main` (flat list via `menu:` front matter or
+     `hugo.toml [menu]`. There is no Docsy/hugo-book style auto-tree, no
+     `hasChildren`/`Parent` support, no sidebar partial. This was confirmed by
+     code inspection, not assumed.
+  2. The wiki is a separate git repository. Embedding it via `<iframe>` is
+     impossible — GitHub Wiki sends `X-Frame-Options: DENY` / CSP, so no
+     in-page embedding. Content must be built into the static site.
+- **Decision:** Mirror the wiki as a **git submodule** at `content/wiki/`
+  (read-only during build) and generate navigation with a **pre-build Python
+  script** (`scripts/generate-wiki-nav.py`):
+  - The submodule is never written to. The script reads `content/wiki/*.md`
+    and copies each page into `content/wiki-build/` (git-ignored intermediate
+    dir) with injected `menu.main` front matter (title from H1, stable weight,
+    `identifier`).
+  - `content/wiki-build/_index.md` defines the "Wiki" section in `menu.main`
+    (weight 110; child pages 111..). This gives a flat but correct nav that
+    Blowfish can render.
+  - `hugo.yml` runs `git submodule update --init --recursive content/wiki` then
+    the script, then the normal build. No new workflow is added (avoids the
+    existing 13-workflow sprawl).
+- **Sync trigger:** The wiki submodule is refreshed on every `hugo.yml` run.
+  `hugo.yml` already triggers on a `*/30 * * * *` cron (repo/gist sync) and on
+  `push`/`repository_dispatch`/`workflow_dispatch`. The submodule update rides
+  those triggers, so wiki edits land on the site within ≤30 min with no extra
+  workflow. (A `repository_dispatch` webhook from the wiki repo would make this
+  near-instant but requires config in the wiki repo — out of scope here.)
+- **Source of truth:** the wiki repo remains authoritative for that content.
+  The site is a read-only mirror; there is **no reverse sync** (site edits do
+  not write back to the wiki).
+- **Limitations (explicit):**
+  - One-directional sync (wiki → site). No site→wiki path.
+  - Up to ~30 min latency between a wiki edit and its appearance on the site.
+  - Flat navigation (no nested sidebar) — a consequence of Blowfish, not a bug.
+  - Wiki structure must stay shallow (single level of `.md` files) for the
+    script's flat-weight scheme to remain sensible; nested folders would need
+    cascade/section-weight extensions.
+- **Alternatives considered:**
+  - `hugo-book` / `docsy` themes — rejected: would replace Blowfish, a much
+    larger change than the doc requirement justifies.
+  - Manual copy of wiki into `content/` — rejected: drift-prone, no automation.
+  - `{{< readfile >}}` / iframe embeds — rejected: iframe blocked by GitHub
+    Wiki CSP; readfile still requires the content to live in the repo.

--- a/scripts/generate-wiki-nav.py
+++ b/scripts/generate-wiki-nav.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Generate Hugo navigation front matter for the GitHub Wiki section.
+
+The wiki lives in `content/wiki/` as a git *submodule* (read-only during
+build). Blowfish does NOT ship a hierarchical docs-tree sidebar — it only
+renders a flat `menu.main` built from front matter. This script therefore:
+
+  1. Reads the wiki submodule files (never writes to them).
+  2. Copies each page into `content/wiki-build/` (git-ignored intermediate
+     dir) and injects front matter: title (from the first H1), a stable
+     `weight`, and a `menu.main` entry so the page appears in the nav.
+  3. Writes `content/wiki-build/_index.md` for the "Wiki" section itself.
+
+Run this BEFORE `hugo` in CI (and locally). See ADR-00XX (wiki sync).
+"""
+import os
+import re
+import shutil
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+WIKI_SRC = os.path.join(ROOT, "content", "wiki")          # submodule (read-only)
+WIKI_BUILD = os.path.join(ROOT, "content", "wiki-build")  # generated, git-ignored
+
+# Section landing weight is lower so "Wiki" sits above its child pages.
+SECTION_WEIGHT = 110
+# Child pages get weights 111..; order by filename for determinism.
+CHILD_BASE = 111
+
+
+def extract_title(md_text: str, fallback: str) -> str:
+    """Use the first Markdown H1 as the title, else the file stem."""
+    m = re.search(r"^#\s+(.+?)\s*$", md_text, re.MULTILINE)
+    if m:
+        return m.group(1).strip()
+    return fallback
+
+
+def split_front_matter(md_text: str):
+    """Return (front_matter_dict_lines, body) — body starts after '---' pair."""
+    if md_text.startswith("---"):
+        end = md_text.find("\n---", 3)
+        if end != -1:
+            fm = md_text[3:end].strip()
+            body = md_text[end + 4:].lstrip("\n")
+            return fm, body
+    return "", md_text
+
+
+def build_page(src_path: str, out_path: str, weight: int, title: str):
+    raw = open(src_path, encoding="utf-8").read()
+    _, body = split_front_matter(raw)
+    # Keep the original H1 in the body (don't duplicate it as a title heading
+    # clash — Hugo still renders the heading, that's fine for a wiki page).
+    fm = [
+        "---",
+        f"title: {title!r}",
+        "description: Documentation mirrored from the repository GitHub Wiki.",
+        "type: wiki",
+        f"weight: {weight}",
+        "menu:",
+        "  main:",
+        f"    name: {title!r}",
+        f"    weight: {weight}",
+        f"    identifier: wiki-{weight}",
+        "---",
+        "",
+    ]
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(fm) + "\n" + body)
+
+
+def main():
+    if not os.path.isdir(WIKI_SRC):
+        raise SystemExit(f"Wiki submodule not found at {WIKI_SRC}. "
+                         "Run `git submodule update --init --recursive` first.")
+
+    shutil.rmtree(WIKI_BUILD, ignore_errors=True)
+    os.makedirs(WIKI_BUILD, exist_ok=True)
+
+    md_files = sorted(
+        f for f in os.listdir(WIKI_SRC)
+        if f.endswith(".md") and f.lower() != "_index.md"
+    )
+
+    index_fm = [
+        "---",
+        "title: Wiki",
+        "description: Operational & security documentation mirrored from the GitHub Wiki.",
+        f"weight: {SECTION_WEIGHT}",
+        "menu:",
+        "  main:",
+        "    name: Wiki",
+        f"    weight: {SECTION_WEIGHT}",
+        "    identifier: wiki-section",
+        "---",
+        "",
+        "This section mirrors the [repository GitHub Wiki](https://github.com/"
+        "dominicusin/dominicusin.github.io/wiki). It is regenerated automatically "
+        "during the CI build from the `content/wiki` submodule.",
+        "",
+    ]
+    with open(os.path.join(WIKI_BUILD, "_index.md"), "w", encoding="utf-8") as f:
+        f.write("\n".join(index_fm) + "\n")
+
+    for i, fname in enumerate(md_files):
+        src = os.path.join(WIKI_SRC, fname)
+        out = os.path.join(WIKI_BUILD, fname)
+        weight = CHILD_BASE + i
+        title = extract_title(open(src, encoding="utf-8").read(),
+                              os.path.splitext(fname)[0])
+        build_page(src, out, weight, title)
+        print(f"  generated {out} (weight={weight}, title={title!r})")
+
+    print(f"Wiki nav generated: {len(md_files)} pages -> {WIKI_BUILD}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Integrates the GitHub Wiki into the published Hugo+Blowfish site, analogous to how giscus mirrors Discussions — but statically at build time (no client JS, no iframe; GitHub Wiki blocks X-Frame-Options).

## What & why (Step 0 confirmed)
- Blowfish v2.105.0 (submodule) has **no built-in hierarchical docs-tree sidebar**. Navigation is built solely from `.Site.Menus.main` (flat list via `menu:` front matter). Confirmed by inspecting `themes/blowfish/layouts/` — zero `docs`/`sidebar`/`tree`/`hasChildren` references. Therefore Step 2b path was taken.

## Changes
- `content/wiki` = git submodule of the wiki repo (read-only in build).
- `scripts/generate-wiki-nav.py` — copies each wiki page into `content/wiki-build/` with injected `menu.main` front matter (title from H1, weight, identifier). Submodule files are never modified.
- `.github/workflows/hugo.yml` — adds `git submodule update --init --recursive content/wiki` + `python3 scripts/generate-wiki-nav.py` before the build. No new workflow added (project already has 13+).
- `config/_default/hugo.toml` — `ignoreFiles` + module mount `excludeFiles: ["wiki/**"]` so the raw submodule is not double-published.
- `.gitignore` — `content/wiki-build/`.
- `docs/adr/0003-wiki-submodule-sync.md`, Beads T113.

## Sync trigger
Rides existing `hugo.yml` triggers (push + `*/30 * * * *` cron + repository_dispatch). Wiki edits land on site within ~30 min, no extra workflow.

## Verification
- `hugo --gc --minify` → exit 0.
- `public/wiki-build/{index,ci-cd,security,home}` all resolve; "Wiki" present in `public/index.html` nav.
- No `<iframe>` anywhere in the implementation.