### PR TITLE
fix: ergonomics pass (nav clutter, loading counters, readability)

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -185,6 +185,53 @@ html { scroll-behavior: smooth; }
 /* ---------- Selection ---------- */
 ::selection { background: rgb(var(--ring) / .35); color: #fff; }
 
+/* ============================================================
+   Ergonomics pass — readability & scanning improvements
+   ============================================================ */
+
+.article-list .article-list-item .article-time,
+.article-header .article-time,
+.article-meta,
+.article-list-item .text-sm,
+.text-sm.text-neutral-500,
+.text-neutral-500 {
+  font-size: .82rem !important;
+  color: rgb(var(--color-neutral-400)) !important;
+}
+.dark .article-meta,
+.dark .article-time {
+  color: rgb(var(--color-neutral-300)) !important;
+}
+
+#top-app-bar nav a,
+.header nav a,
+.desktop-menu a {
+  padding-inline: .55rem !important;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+.kg-search:focus-visible {
+  outline: 2px solid rgb(var(--ring) / .9);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.article-content,
+.prose {
+  line-height: 1.75;
+}
+
+@media (max-width: 640px) {
+  .footer .flex.flex-wrap,
+  #site-footer .tagcloud,
+  .footer-tags {
+    gap: .35rem !important;
+    font-size: .8rem !important;
+  }
+}
+
 /* ---------- Scrollbar polish ---------- */
 * { scrollbar-width: thin; scrollbar-color: rgb(var(--color-neutral-700)) transparent; }
 *::-webkit-scrollbar { width: 10px; height: 10px; }

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -61,12 +61,6 @@ canonifyURLs = false
 # source). Its pages are copied + front-matter-injected into content/wiki-build/
 # by scripts/generate-wiki-nav.py at build time. Exclude the raw submodule from
 # the build so we don't publish duplicate un-menu'd pages. See ADR-0003.
-ignoreFiles = ["content/wiki/**"]
-
-# Also exclude the wiki submodule from the content mount so Hugo does not
-# publish the raw (front-matter-less) submodule pages alongside wiki-build/.
-[module]
-  [[module.mounts]]
-    source = "content"
-    target = "content"
-    excludeFiles = ["wiki/**"]
+# NOTE: ignoreFiles uses Go regexp (not glob), so `content/wiki/.*\.md$` matches
+# only files directly under content/wiki/ — NOT content/wiki-build/.
+ignoreFiles = ["content/wiki/.*\\.md$"]

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -78,8 +78,11 @@ externalSubscriptionURL = "https://buttondown.email/api/emails/embed-subscribe/d
   editURL = "https://github.com/dominicusin/dominicusin.github.io/edit/main/content"
   editAppendPath = true
   sharingLinks = ["linkedin", "twitter", "bluesky", "reddit", "telegram", "email"]
-  showViews = true
-  showLikes = true
+  # showViews/showLikes disabled: the Firebase backend is deny-all (403), so the
+  # counters render a permanent "loading" placeholder — bad UX. Re-enable once
+  # Firestore rules permit reads/increments.
+  # showViews = true
+  # showLikes = true
 
 # --- List / section pages ---
 [list]
@@ -88,7 +91,8 @@ externalSubscriptionURL = "https://buttondown.email/api/emails/embed-subscribe/d
   showReadingTime = true
   showCards = true
   cardView = true
-  showViews = true
+  # showViews disabled (Firebase backend deny-all → permanent "loading")
+  # showViews = true
 
 # --- Sitemap ---
 [sitemap]
@@ -120,7 +124,9 @@ externalSubscriptionURL = "https://buttondown.email/api/emails/embed-subscribe/d
   measurementId = "G-4QCLTEKK18"
 
 [taxonomy]
-  showViews = true
+  # showViews disabled (Firebase backend deny-all → permanent "loading")
+  # showViews = true
 
 [term]
-  showViews = true
+  # showViews disabled (Firebase backend deny-all → permanent "loading")
+  # showViews = true

--- a/scripts/generate-wiki-nav.py
+++ b/scripts/generate-wiki-nav.py
@@ -50,19 +50,15 @@ def split_front_matter(md_text: str):
 def build_page(src_path: str, out_path: str, weight: int, title: str):
     raw = open(src_path, encoding="utf-8").read()
     _, body = split_front_matter(raw)
-    # Keep the original H1 in the body (don't duplicate it as a title heading
-    # clash — Hugo still renders the heading, that's fine for a wiki page).
+    # Children contribute ONLY to the /wiki/ section page (parent _index.md),
+    # NOT to the global header menu. Adding them to menu.main clutters the
+    # nav with one flat link per wiki file. See ADR-0003.
     fm = [
         "---",
         f"title: {title!r}",
         "description: Documentation mirrored from the repository GitHub Wiki.",
         "type: wiki",
         f"weight: {weight}",
-        "menu:",
-        "  main:",
-        f"    name: {title!r}",
-        f"    weight: {weight}",
-        f"    identifier: wiki-{weight}",
         "---",
         "",
     ]


### PR DESCRIPTION
Ergonomic fixes for the published site.

## 1. Wiki nav clutter
Wiki child pages no longer inject menu.main — only the /wiki/ section appears in the global header; children live under /wiki/. Removes 3 spurious top-level links (CI/CD, Security, Engineering Blog — Wiki).

## 2. Permanent 'loading' counters
showViews/showLikes disabled in all scopes. Firebase backend is deny-all (403) so counters rendered a permanent 'loading' placeholder on every card. Re-enable when Firestore rules permit reads/increments.

## 3. Readability
- Article metadata bumped to .82rem with higher contrast.
- Roomier header nav spacing.
- :focus-visible rings for keyboard a11y.
- 1.75 line-height for long-form reading.
- Tighter mobile tag footer.

## Verification (clean build: rm -rf public resources)
- exit 0; no '>loading<' anywhere in public/.
- Rendered home nav shows only the Wiki section link (no wiki children).
- public/wiki/{index,ci-cd,security,home} all build; raw submodule not leaked.