### PR TITLE
fix: deploy-dao.yml skip compile/deploy without credentials

### DIFF
--- a/.github/workflows/deploy-dao.yml
+++ b/.github/workflows/deploy-dao.yml
@@ -80,9 +80,11 @@ jobs:
           fi
 
       - name: Compile
+        if: ${{ env.DEPLOY_PRIVATE_KEY != '' }}
         run: npx hardhat compile
 
       - name: Deploy to target network
+        if: ${{ env.DEPLOY_PRIVATE_KEY != '' }}
         env:
           # workflow_dispatch input is operator-controlled, not attacker PR/issue
           # content; still constrain to an allowlist for safety.


### PR DESCRIPTION
Gate compile/deploy steps on env.DEPLOY_PRIVATE_KEY. Without secrets the job succeeds (skip) instead of failing on missing Hardhat network.