### PR TITLE
fix: repair about.md corrupted by N| line-number prefixes

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -1,116 +1,116 @@
-1|---
-2|title: About
-3|slug: "about"
-4|draft: false
-5|description: "Dominicus In — industrial & systems engineer; this site is an engineering notebook on optimization, automation, and decentralized systems."
-6|---
-7|
-8|<div class="about-container">
-9|<div class="about-hero">
-10|<div class="about-avatar">
-11|<img src="/images/avatar.svg" alt="Dominicus In" class="avatar-image" />
-12|<div class="avatar-placeholder"><span class="avatar-initials">DI</span></div>
-13|</div>
-14|<div class="about-header-content">
-15|<h1 class="about-title">Dominicus In</h1>
-16|<p class="about-subtitle">Industrial &amp; Systems Engineer</p>
-17|<p class="about-description">Passionate about optimizing complex systems, data-driven decision making, and building scalable engineering solutions. Specializing in industrial automation, process optimization, and systems integration.</p>
-18|<div class="about-social">
+---
+title: About
+slug: "about"
+draft: false
+date: 2024-01-01
+description: "Dominicus In — industrial & systems engineer; this site is an engineering notebook on optimization, automation, and decentralized systems."
+---
+
+<div class="about-container">
+<div class="about-hero">
+<div class="about-avatar">
+<img src="/images/avatar.svg" alt="Dominicus In" class="avatar-image" />
+<div class="avatar-placeholder"><span class="avatar-initials">DI</span></div>
+</div>
+<div class="about-header-content">
+<h1 class="about-title">Dominicus In</h1>
+<p class="about-subtitle">Industrial &amp; Systems Engineer</p>
+<p class="about-description">Passionate about optimizing complex systems, data-driven decision making, and building scalable engineering solutions. Specializing in industrial automation, process optimization, and systems integration.</p>
+<div class="about-social">
 <a href="https://github.com/dominicusin" class="social-link" target="_blank" rel="noopener"><span class="social-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M12 .5C5.73.5.5 5.74.5 12.02c0 5.1 3.29 9.41 7.86 10.94.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.53-1.35-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.78 1.2 1.78 1.2 1.04 1.79 2.73 1.27 3.4.97.1-.76.4-1.27.73-1.56-2.56-.29-5.26-1.28-5.26-5.71 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.1 11.1 0 0 1 2.9-.39c.98 0 1.97.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.44-2.7 5.41-5.27 5.7.41.36.78 1.07.78 2.16v3.2c0 .31.21.67.8.56A11.52 11.52 0 0 0 23.5 12.02C23.5 5.74 18.27.5 12 .5z"/></svg></span><span class="social-text">GitHub</span></a>
 <a href="https://linkedin.com/in/dominicusin" class="social-link" target="_blank" rel="noopener"><span class="social-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M20.45 20.45h-3.56v-5.57c0-1.33-.02-3.04-1.85-3.04-1.85 0-2.14 1.45-2.14 2.94v5.67H9.35V9h3.42v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.45v6.29zM5.34 7.43a2.07 2.07 0 1 1 0-4.14 2.07 2.07 0 0 1 0 4.14zM7.12 20.45H3.55V9h3.57v11.45zM22.22 0H1.77C.79 0 0 .77 0 1.73v20.54C0 23.23.79 24 1.77 24h20.45c.98 0 1.78-.77 1.78-1.73V1.73C24 .77 23.2 0 22.22 0z"/></svg></span><span class="social-text">LinkedIn</span></a>
-21|<a href="https://twitter.com/dominicusin" class="social-link" target="_blank" rel="noopener"><span class...[truncated]
-22|</div>
-23|</div>
-24|</div>
-25|
-26|<div class="about-content">
-27|<section class="about-section">
-28|<h2 class="section-title">Professional Background</h2>
-29|<div class="experience-timeline">
-30|<div class="timeline-item"><div class="timeline-date">2022 - Present</div><div class="timeline-content"><h3>Senior Systems Engineer</h3><p>Leading complex industrial automation projects and implementing cutting-edge optimization strategies for manufacturing processes.</p></div></div>
-31|<div class="timeline-item"><div class="timeline-date">2019 - 2022</div><div class="timeline-content"><h3>Industrial Engineer</h3><p>Designed and implemented process improvements resulting in 25% efficiency gains and 30% cost reduction.</p></div></div>
-32|<div class="timeline-item"><div class="timeline-date">2017 - 2019</div><div class="timeline-content"><h3>Systems Analyst</h3><p>Analyzed complex manufacturing systems and developed data-driven solutions for operational challenges.</p></div></div>
-33|</div>
-34|</section>
-35|
-36|<section class="about-section">
-37|<h2 class="section-title">Core Competencies</h2>
-38|<div class="skills-grid">
-39|<div class="skill-category"><h3 class="skill-title">Industrial Engineering</h3><ul class="skill-list"><li class="skill-item">Process Optimization</li><li class="skill-item">Quality Management</li><li class="skill-item">Lean Manufacturing</li><li class="skill-item">Six Sigma</li></ul></div>
-40|<div class="skill-category"><h3 class="skill-title">Systems Engineering</h3><ul class="skill-list"><li class="skill-item">System Integration</li><li class="skill-item">Automation Design</li><li class="skill-item">Control Systems</li><li class="skill-item">IoT Implementation</li></ul></div>
-41|<div class="skill-category"><h3 class="skill-title">Data Science</h3><ul class="skill-list"><li class="skill-item">Statistical Analysis</li><li class="skill-item">Machine Learning</li><li class="skill-item">Data Visualization</li><li class="skill-item">Predictive Modeling</li></ul></div>
-42|<div class="skill-category"><h3 class="skill-title">Technical Tools</h3><ul class="skill-list"><li class="skill-item">Python / R</li><li class="skill-item">MATLAB / Simulink</li><li class="skill-item">SQL / NoSQL</li><li class="skill-item">Cloud Platforms</li></ul></div>
-43|</div>
-44|</section>
-45|
-46|<section class="about-section">
-47|<h2 class="section-title">Featured Projects</h2>
-48|<div class="projects-grid">
-49|<div class="project-card"><div class="project-header"><h3 class="project-title">Smart Manufacturing System</h3><span class="project-status">Completed</span></div><p class="project-description">Implemented IoT-based monitoring and optimization system for large-scale manufacturing facility, resulting in 40% efficiency improvement and real-time predictive maintenance capabilities.</p><div class="project-tags"><span class="project-tag">IoT</span><span class="project-tag">Automation</span><span class="project-tag">Machine Learning</span></div></div>
-50|<div class="project-card"><div class="project-header"><h3 class="project-title">Supply Chain Optimization</h3><span class="project-status">In Progress</span></div><p class="project-description">Developing AI-powered supply chain optimization platform using advanced algorithms and real-time data analysis to minimize costs and maximize efficiency.</p><div class="project-tags"><span class="project-tag">AI/ML</span><span class="project-tag">Optimization</span><span class="project-tag">Data Science</span></div></div>
-51|<div class="project-card"><div class="project-header"><h3 class="project-title">Quality Management System</h3><span class="project-status">Completed</span></div><p class="project-description">Designed comprehensive quality management system with automated inspection, statistical process control, and continuous improvement methodologies.</p><div class="project-tags"><span class="project-tag">Quality</span><span class="project-tag">Statistics</span><span class="project-tag">Process Control</span></div></div>
-52|</div>
-53|</section>
-54|
-55|<section class="about-section">
-56|<h2 class="section-title">Education &amp; Certifications</h2>
-57|<div class="education-grid">
-58|<div class="education-item"><h3 class="education-title">M.S. Industrial Engineering</h3><p class="education-institution">Technical University</p><p class="education-period">2015 - 2017</p><p class="education-details">Focus on Systems Optimization and Data Analytics</p></div>
-59|<div class="education-item"><h3 class="education-title">B.S. Industrial Engineering</h3><p class="education-institution">Engineering Institute</p><p class="education-period">2011 - 2015</p><p class="education-details">Graduated Magna Cum Laude</p></div>
-60|</div>
-61|<div class="certifications"><h3 class="certifications-title">Professional Certifications</h3><ul class="certification-list"><li class="certification-item">Certified Six Sigma Black Belt</li><li class="certification-item">AWS Solutions Architect</li><li class="certification-item">PMP Project Management</li><li class="certification-item">Lean Manufacturing Expert</li></ul></div>
-62|</section>
-63|
-64|<section class="about-section">
-65|<h2 class="section-title">Blog Focus Areas</h2>
-66|<div class="blog-areas">
-67|<div class="area-card"><div class="area-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></div><h3 class="area-title">Industrial Engineering</h3><p class="area-description">Process optimization, quality management, lean principles, and manufacturing excellence.</p></div>
-68|<div class="area-card"><div class="area-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg></div><h3 class="area-title">Systems Integration</h3><p class="area-description">Complex system design, automation, IoT implementation, and cross-platform integration.</p></div>
-69|<div class="area-card"><div class="area-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M7 14l3-3 3 3 5-5"/></svg></div><h3 class="area-title">Data Science</h3><p class="area-description">Statistical analysis, machine learning, data visualization, and predictive modeling.</p></div>
-70|<div class="area-card"><div class="area-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/><path d="M12 15l-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/><path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/><path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/></svg></div><h3 class="area-title">Technology Trends</h3><p class="area-description">Emerging technologies, industry 4.0, digital transformation, and innovation.</p></div>
-71|</div>
-72|</section>
-73|
-74|<section class="about-section">
-75|<h2 class="section-title">Get In Touch</h2>
-76|<div class="contact-section">
-77|<p class="contact-text">I'm always interested in collaborating on challenging projects, sharing knowledge, or discussing the latest developments in engineering and technology. Feel free to reach out!</p>
-78|<div class="contact-methods">
-79|<a href="mailto:contact@dominicu_sin.io" class="contact-method"><span class="contact-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-10 6L2 7"/></svg></span><div class="contact-info"><h4>Email</h4><p>contact@dominicu_sin.io</p></div></a>
-80|<a href="https://linkedin.com/in/dominicusin" class="contact-method" target="_blank" rel="noopener"><span class="contact-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path d="M20.45 20.45h-3.56v-5.57c0-1.33-.02-3.04-1.85-3.04-1.85 0-2.14 1.45-2.14 2.94v5.67H9.35V9h3.42v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.45v6.29zM5.34 7.43a2.07 2.07 0 1 1 0-4.14 2.07 2.07 0 0 1 0 4.14zM7.12 20.45H3.55V9h3.57v11.45zM22.22 0H1.77C.79 0 0 .77 0 1.73v20.54C0 23.23.79 24 1.77 24h20.45c.98 0 1.78-.77 1.78-1.73V1.73C24 .77 23.2 0 22.22 0z"/></svg></span><div class="contact-info"><h4>LinkedIn</h4><p>/in/dominicusin</p></div></a>
-81|<a href="https://github.com/dominicusin" class="contact-method" target="_blank" rel="noopener"><span class="contact-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path d="M12 .5C5.73.5.5 5.74.5 12.02c0 5.1 3.29 9.41 7.86 10.94.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.53-1.35-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.78 1.2 1.78 1.2 1.04 1.79 2.73 1.27 3.4.97.1-.76.4-1.27.73-1.56-2.56-.29-5.26-1.28-5.26-5.71 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.1 11.1 0 0 1 2.9-.39c.98 0 1.97.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.44-2.7 5.41-5.27 5.7.41.36.78 1.07.78 2.16v3.2c0 .31.21.67.8.56A11.52 11.52 0 0 0 23.5 12.02C23.5 5.74 18.27.5 12 .5z"/></svg></span><div class="contact-info"><h4>GitHub</h4><p>/dominicusin</p></div></a>
-82|<a href="https://twitter.com/dominicusin" class="contact-method" target="_blank" rel="noopener"><span class="contact-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path d="M18.24 2.25h3.31l-7.23 8.26 8.5 11.24h-6.66l-5.22-6.82-5.97 6.82H1.66l7.73-8.84L1.24 2.25h6.83l4.71 6.23 5.46-6.23zm-1.16 17.52h1.83L7.01 4.13H5.05L17.08 19.77z"/></svg></span><div class="contact-info"><h4>Twitter</h4><p>@dominicusin</p></div></a>
-83|</div>
-84|</div>
-85|</section>
-86|
-87|<section class="about-section" id="domini">
-88|<h2 class="section-title"><span class="section-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg></span> Избранное чтение</h2>
-89|<p class="section-intro">Курируемый список книг и руководств по инженерии, программированию и анализу данных — ранее в разделе <em>Domini</em>.</p>
-90|<div class="book-list">
-91|<div class="book-group"><h3 class="book-group-title">Language Agnostic</h3><ul class="book-items"><li><a href="http://scrum.org.ua/wp-content/uploads/2008/12/scrum_xp-from-the-trenches-rus-final.pdf" target="_blank" rel="noopener">Scrum и XP: заметки с передовой</a></li></ul></div>
-92|<div class="book-group"><h3 class="book-group-title">Bash</h3><ul class="book-items"><li><a href="http://rus-linux.net/MyLDP/BOOKS/abs-guide/flat/abs-book.html" target="_blank" rel="noopener">Advanced Bash-Scripting Guide</a></li></ul></div>
-93|<div class="book-group"><h3 class="book-group-title">CoffeeScript</h3><ul class="book-items"><li><a href="http://cidocs.ru/coffeescript/" target="_blank" rel="noopener">Документация CoffeeScript</a></li></ul></div>
-94|<div class="book-group"><h3 class="book-group-title">Git</h3><ul class="book-items"><li><a href="http://www-cs-students.stanford.edu/~blynn/gitmagic/intl/ru/" target="_blank" rel="noopener">Волшебство Git</a></li><li><a href="http://git-scm.com/book/ru" target="_blank" rel="noopener">Pro Git</a></li></ul></div>
-95|<div class="book-group"><h3 class="book-group-title">JavaScript</h3><ul class="book-items"><li><a href="http://learn.javascript.ru/" target="_blank" rel="noopener">Современный учебник JavaScript</a></li><li><a href="http://bonsaiden.github.io/JavaScript-Garden/ru/" target="_blank" rel="noopener">JavaScript Garden</a></li></ul></div>
-96|<div class="book-group"><h3 class="book-group-title">LaTeX</h3><ul class="book-items"><li><a href="http://www.inp.nsk.su/~baldin/LaTeX/index.html" target="_blank" rel="noopener">LaTeX, GNU/Linux и русский стиль</a></li></ul></div>
-97|<div class="book-group"><h3 class="book-group-title">Lisp</h3><ul class="book-items"><li><a href="https://github.com/ilammy/lisp" target="_blank" rel="noopener">Lisp In Small Pieces (перевод)</a></li></ul></div>
-98|<div class="book-group"><h3 class="book-group-title">MetaPost</h3><ul class="book-items"><li><a href="http://www.inp.nsk.su/~baldin/mpost/index.html" target="_blank" rel="noopener">Создание иллюстраций в MetaPost</a></li></ul></div>
-99|<div class="book-group"><h3 class="book-group-title">Node.js</h3><ul class="book-items"><li><a href="http://nodebeginner.ru" target="_blank" rel="noopener">Node.js для начинающих</a></li></ul></div>
-100|<div class="book-group"><h3 class="book-group-title">NoSQL</h3><ul class="book-items"><li><a href="http://jsman.ru/mongo-book/index.html" target="_blank" rel="noopener">Маленькая книга о MongoDB</a></li><li><a href="https://github.com/kondratovich/the-little-redis-book/blob/master/ru/redis.md" target="_blank" rel="noopener">Маленькая книга о Redis</a></li></ul></div>
-101|<div class="book-group"><h3 class="book-group-title">Perl</h3><ul class="book-items"><li><a href="http://pragmaticperl.com/" target="_blank" rel="noopener">Pragmatic Perl (журнал)</a></li></ul></div>
-102|<div class="book-group"><h3 class="book-group-title">R</h3><ul class="book-items"><li><a href="http://www.inp.nsk.su/~baldin/DataAnalysis/index.html" target="_blank" rel="noopener">Анализ данных с R</a></li></ul></div>
-103|<div class="book-group"><h3 class="book-group-title">Ruby</h3><ul class="book-items"><li><a href="https://github.com/Krugloff/rus_ruby_book" target="_blank" rel="noopener">Круглов А. — Ruby</a></li><li><a href="http://betterspecs.org/ru" target="_blank" rel="noopener">Better Specs (RSpec)</a></li><li><a href="http://rusrails.ru" target="_blank" rel="noopener">Ruby on Rails Guides</a></li><li><a href="http://railtutorial.ru/" target="_blank" rel="noopener">Ruby on Rails Tutorial</a></li></ul></div>
-104|<div class="book-group"><h3 class="book-group-title">Scilab</h3><ul class="book-items"><li><a href="http://forge.scilab.org/index.php/p/docintrotoscilab/downloads/" target="_blank" rel="noopener">Введение в Scilab</a></li><li><a href="http://forge.scilab.org/index.php/p/docprogscilab/downloads/" target="_blank" rel="noopener">Программирование в Scilab</a></li></ul></div>
-105|<div class="book-group"><h3 class="book-group-title">SQL</h3><ul class="book-items"><li><a href="http://postgresql.leopard.in.ua/" target="_blank" rel="noopener">Работа с PostgreSQL</a></li><li><a href="http://www.inp.nsk.su/~baldin/PostgreSQL/index.html" target="_blank" rel="noopener">История о PostgreSQL</a></li></ul></div>
-106|<div class="book-group"><h3 class="book-group-title">Параллельные технологии</h3><ul class="book-items"><li><a href="http://www.inp.nsk.su/~baldin/Parallel/index.html" target="_blank" rel="noopener">Параллельные технологии</a></li></ul></div>
-107|</div>
-108|</section>
-109|
-110|<section class="about-section" id="people">
-111|<h2 class="section-title">👥 Люди</h2>
-112|<p class="section-intro">Автор и редактор проекта — <strong>Dominicus In</strong>. Над материалами также работали соавторы и рецензенты сообщества Domini. Полный список участников ведётся в репозитории проекта.</p>
-113|</section>
-114|</div>
-115|</div>
-116|
+<a href="https://twitter.com/dominicusin" class="social-link" target="_blank" rel="noopener"><span class...[truncated]
+</div>
+</div>
+</div>
+
+<div class="about-content">
+<section class="about-section">
+<h2 class="section-title">Professional Background</h2>
+<div class="experience-timeline">
+<div class="timeline-item"><div class="timeline-date">2022 - Present</div><div class="timeline-content"><h3>Senior Systems Engineer</h3><p>Leading complex industrial automation projects and implementing cutting-edge optimization strategies for manufacturing processes.</p></div></div>
+<div class="timeline-item"><div class="timeline-date">2019 - 2022</div><div class="timeline-content"><h3>Industrial Engineer</h3><p>Designed and implemented process improvements resulting in 25% efficiency gains and 30% cost reduction.</p></div></div>
+<div class="timeline-item"><div class="timeline-date">2017 - 2019</div><div class="timeline-content"><h3>Systems Analyst</h3><p>Analyzed complex manufacturing systems and developed data-driven solutions for operational challenges.</p></div></div>
+</div>
+</section>
+
+<section class="about-section">
+<h2 class="section-title">Core Competencies</h2>
+<div class="skills-grid">
+<div class="skill-category"><h3 class="skill-title">Industrial Engineering</h3><ul class="skill-list"><li class="skill-item">Process Optimization</li><li class="skill-item">Quality Management</li><li class="skill-item">Lean Manufacturing</li><li class="skill-item">Six Sigma</li></ul></div>
+<div class="skill-category"><h3 class="skill-title">Systems Engineering</h3><ul class="skill-list"><li class="skill-item">System Integration</li><li class="skill-item">Automation Design</li><li class="skill-item">Control Systems</li><li class="skill-item">IoT Implementation</li></ul></div>
+<div class="skill-category"><h3 class="skill-title">Data Science</h3><ul class="skill-list"><li class="skill-item">Statistical Analysis</li><li class="skill-item">Machine Learning</li><li class="skill-item">Data Visualization</li><li class="skill-item">Predictive Modeling</li></ul></div>
+<div class="skill-category"><h3 class="skill-title">Technical Tools</h3><ul class="skill-list"><li class="skill-item">Python / R</li><li class="skill-item">MATLAB / Simulink</li><li class="skill-item">SQL / NoSQL</li><li class="skill-item">Cloud Platforms</li></ul></div>
+</div>
+</section>
+
+<section class="about-section">
+<h2 class="section-title">Featured Projects</h2>
+<div class="projects-grid">
+<div class="project-card"><div class="project-header"><h3 class="project-title">Smart Manufacturing System</h3><span class="project-status">Completed</span></div><p class="project-description">Implemented IoT-based monitoring and optimization system for large-scale manufacturing facility, resulting in 40% efficiency improvement and real-time predictive maintenance capabilities.</p><div class="project-tags"><span class="project-tag">IoT</span><span class="project-tag">Automation</span><span class="project-tag">Machine Learning</span></div></div>
+<div class="project-card"><div class="project-header"><h3 class="project-title">Supply Chain Optimization</h3><span class="project-status">In Progress</span></div><p class="project-description">Developing AI-powered supply chain optimization platform using advanced algorithms and real-time data analysis to minimize costs and maximize efficiency.</p><div class="project-tags"><span class="project-tag">AI/ML</span><span class="project-tag">Optimization</span><span class="project-tag">Data Science</span></div></div>
+<div class="project-card"><div class="project-header"><h3 class="project-title">Quality Management System</h3><span class="project-status">Completed</span></div><p class="project-description">Designed comprehensive quality management system with automated inspection, statistical process control, and continuous improvement methodologies.</p><div class="project-tags"><span class="project-tag">Quality</span><span class="project-tag">Statistics</span><span class="project-tag">Process Control</span></div></div>
+</div>
+</section>
+
+<section class="about-section">
+<h2 class="section-title">Education &amp; Certifications</h2>
+<div class="education-grid">
+<div class="education-item"><h3 class="education-title">M.S. Industrial Engineering</h3><p class="education-institution">Technical University</p><p class="education-period">2015 - 2017</p><p class="education-details">Focus on Systems Optimization and Data Analytics</p></div>
+<div class="education-item"><h3 class="education-title">B.S. Industrial Engineering</h3><p class="education-institution">Engineering Institute</p><p class="education-period">2011 - 2015</p><p class="education-details">Graduated Magna Cum Laude</p></div>
+</div>
+<div class="certifications"><h3 class="certifications-title">Professional Certifications</h3><ul class="certification-list"><li class="certification-item">Certified Six Sigma Black Belt</li><li class="certification-item">AWS Solutions Architect</li><li class="certification-item">PMP Project Management</li><li class="certification-item">Lean Manufacturing Expert</li></ul></div>
+</section>
+
+<section class="about-section">
+<h2 class="section-title">Blog Focus Areas</h2>
+<div class="blog-areas">
+<div class="area-card"><div class="area-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></div><h3 class="area-title">Industrial Engineering</h3><p class="area-description">Process optimization, quality management, lean principles, and manufacturing excellence.</p></div>
+<div class="area-card"><div class="area-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg></div><h3 class="area-title">Systems Integration</h3><p class="area-description">Complex system design, automation, IoT implementation, and cross-platform integration.</p></div>
+<div class="area-card"><div class="area-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M7 14l3-3 3 3 5-5"/></svg></div><h3 class="area-title">Data Science</h3><p class="area-description">Statistical analysis, machine learning, data visualization, and predictive modeling.</p></div>
+<div class="area-card"><div class="area-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/><path d="M12 15l-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/><path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/><path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/></svg></div><h3 class="area-title">Technology Trends</h3><p class="area-description">Emerging technologies, industry 4.0, digital transformation, and innovation.</p></div>
+</div>
+</section>
+
+<section class="about-section">
+<h2 class="section-title">Get In Touch</h2>
+<div class="contact-section">
+<p class="contact-text">I'm always interested in collaborating on challenging projects, sharing knowledge, or discussing the latest developments in engineering and technology. Feel free to reach out!</p>
+<div class="contact-methods">
+<a href="mailto:contact@dominicu_sin.io" class="contact-method"><span class="contact-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-10 6L2 7"/></svg></span><div class="contact-info"><h4>Email</h4><p>contact@dominicu_sin.io</p></div></a>
+<a href="https://linkedin.com/in/dominicusin" class="contact-method" target="_blank" rel="noopener"><span class="contact-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path d="M20.45 20.45h-3.56v-5.57c0-1.33-.02-3.04-1.85-3.04-1.85 0-2.14 1.45-2.14 2.94v5.67H9.35V9h3.42v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.45v6.29zM5.34 7.43a2.07 2.07 0 1 1 0-4.14 2.07 2.07 0 0 1 0 4.14zM7.12 20.45H3.55V9h3.57v11.45zM22.22 0H1.77C.79 0 0 .77 0 1.73v20.54C0 23.23.79 24 1.77 24h20.45c.98 0 1.78-.77 1.78-1.73V1.73C24 .77 23.2 0 22.22 0z"/></svg></span><div class="contact-info"><h4>LinkedIn</h4><p>/in/dominicusin</p></div></a>
+<a href="https://github.com/dominicusin" class="contact-method" target="_blank" rel="noopener"><span class="contact-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path d="M12 .5C5.73.5.5 5.74.5 12.02c0 5.1 3.29 9.41 7.86 10.94.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.53-1.35-1.3-1.7-1.3-1.7-1.06-.72.08-.71.08-.71 1.17.08 1.78 1.2 1.78 1.2 1.04 1.79 2.73 1.27 3.4.97.1-.76.4-1.27.73-1.56-2.56-.29-5.26-1.28-5.26-5.71 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.1 11.1 0 0 1 2.9-.39c.98 0 1.97.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.44-2.7 5.41-5.27 5.7.41.36.78 1.07.78 2.16v3.2c0 .31.21.67.8.56A11.52 11.52 0 0 0 23.5 12.02C23.5 5.74 18.27.5 12 .5z"/></svg></span><div class="contact-info"><h4>GitHub</h4><p>/dominicusin</p></div></a>
+<a href="https://twitter.com/dominicusin" class="contact-method" target="_blank" rel="noopener"><span class="contact-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor"><path d="M18.24 2.25h3.31l-7.23 8.26 8.5 11.24h-6.66l-5.22-6.82-5.97 6.82H1.66l7.73-8.84L1.24 2.25h6.83l4.71 6.23 5.46-6.23zm-1.16 17.52h1.83L7.01 4.13H5.05L17.08 19.77z"/></svg></span><div class="contact-info"><h4>Twitter</h4><p>@dominicusin</p></div></a>
+</div>
+</div>
+</section>
+
+<section class="about-section" id="domini">
+<h2 class="section-title"><span class="section-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg></span> Избранное чтение</h2>
+<p class="section-intro">Курируемый список книг и руководств по инженерии, программированию и анализу данных — ранее в разделе <em>Domini</em>.</p>
+<div class="book-list">
+<div class="book-group"><h3 class="book-group-title">Language Agnostic</h3><ul class="book-items"><li><a href="http://scrum.org.ua/wp-content/uploads/2008/12/scrum_xp-from-the-trenches-rus-final.pdf" target="_blank" rel="noopener">Scrum и XP: заметки с передовой</a></li></ul></div>
+<div class="book-group"><h3 class="book-group-title">Bash</h3><ul class="book-items"><li><a href="http://rus-linux.net/MyLDP/BOOKS/abs-guide/flat/abs-book.html" target="_blank" rel="noopener">Advanced Bash-Scripting Guide</a></li></ul></div>
+<div class="book-group"><h3 class="book-group-title">CoffeeScript</h3><ul class="book-items"><li><a href="http://cidocs.ru/coffeescript/" target="_blank" rel="noopener">Документация CoffeeScript</a></li></ul></div>
+<div class="book-group"><h3 class="book-group-title">Git</h3><ul class="book-items"><li><a href="http://www-cs-students.stanford.edu/~blynn/gitmagic/intl/ru/" target="_blank" rel="noopener">Волшебство Git</a></li><li><a href="http://git-scm.com/book/ru" target="_blank" rel="noopener">Pro Git</a></li></ul></div>
+<div class="book-group"><h3 class="book-group-title">JavaScript</h3><ul class="book-items"><li><a href="http://learn.javascript.ru/" target="_blank" rel="noopener">Современный учебник JavaScript</a></li><li><a href="http://bonsaiden.github.io/JavaScript-Garden/ru/" target="_blank" rel="noopener">JavaScript Garden</a></li></ul></div>
+<div class="book-group"><h3 class="book-group-title">LaTeX</h3><ul class="book-items"><li><a href="http://www.inp.nsk.su/~baldin/LaTeX/index.html" target="_blank" rel="noopener">LaTeX, GNU/Linux и русский стиль</a></li></ul></div>
+<div class="book-group"><h3 class="book-group-title">Lisp</h3><ul class="book-items"><li><a href="https://github.com/ilammy/lisp" target="_blank" rel="noopener">Lisp In Small Pieces (перевод)</a></li></ul></div>
+<div class="book-group"><h3 class="book-group-title">MetaPost</h3><ul class="book-items"><li><a href="http://www.inp.nsk.su/~baldin/mpost/index.html" target="_blank" rel="noopener">Создание иллюстраций в MetaPost</a></li></ul></div>
+<div class="book-group"><h3 class="book-group-title">Node.js</h3><ul class="book-items"><li><a href="http://nodebeginner.ru" target="_blank" rel="noopener">Node.js для начинающих</a></li></ul></div>
+<div class="book-group"><h3 class="book-group-title">NoSQL</h3><ul class="book-items"><li><a href="http://jsman.ru/mongo-book/index.html" target="_blank" rel="noopener">Маленькая книга о MongoDB</a></li><li><a href="https://github.com/kondratovich/the-little-redis-book/blob/master/ru/redis.md" target="_blank" rel="noopener">Маленькая книга о Redis</a></li></ul></div>
+<div class="book-group"><h3 class="book-group-title">Perl</h3><ul class="book-items"><li><a href="http://pragmaticperl.com/" target="_blank" rel="noopener">Pragmatic Perl (журнал)</a></li></ul></div>
+<div class="book-group"><h3 class="book-group-title">R</h3><ul class="book-items"><li><a href="http://www.inp.nsk.su/~baldin/DataAnalysis/index.html" target="_blank" rel="noopener">Анализ данных с R</a></li></ul></div>
+<div class="book-group"><h3 class="book-group-title">Ruby</h3><ul class="book-items"><li><a href="https://github.com/Krugloff/rus_ruby_book" target="_blank" rel="noopener">Круглов А. — Ruby</a></li><li><a href="http://betterspecs.org/ru" target="_blank" rel="noopener">Better Specs (RSpec)</a></li><li><a href="http://rusrails.ru" target="_blank" rel="noopener">Ruby on Rails Guides</a></li><li><a href="http://railtutorial.ru/" target="_blank" rel="noopener">Ruby on Rails Tutorial</a></li></ul></div>
+<div class="book-group"><h3 class="book-group-title">Scilab</h3><ul class="book-items"><li><a href="http://forge.scilab.org/index.php/p/docintrotoscilab/downloads/" target="_blank" rel="noopener">Введение в Scilab</a></li><li><a href="http://forge.scilab.org/index.php/p/docprogscilab/downloads/" target="_blank" rel="noopener">Программирование в Scilab</a></li></ul></div>
+<div class="book-group"><h3 class="book-group-title">SQL</h3><ul class="book-items"><li><a href="http://postgresql.leopard.in.ua/" target="_blank" rel="noopener">Работа с PostgreSQL</a></li><li><a href="http://www.inp.nsk.su/~baldin/PostgreSQL/index.html" target="_blank" rel="noopener">История о PostgreSQL</a></li></ul></div>
+<div class="book-group"><h3 class="book-group-title">Параллельные технологии</h3><ul class="book-items"><li><a href="http://www.inp.nsk.su/~baldin/Parallel/index.html" target="_blank" rel="noopener">Параллельные технологии</a></li></ul></div>
+</div>
+</section>
+
+<section class="about-section" id="people">
+<h2 class="section-title">👥 Люди</h2>
+<p class="section-intro">Автор и редактор проекта — <strong>Dominicus In</strong>. Над материалами также работали соавторы и рецензенты сообщества Domini. Полный список участников ведётся в репозитории проекта.</p>
+</section>
+</div>
+</div>


### PR DESCRIPTION
## Root cause
`content/about.md` had every line prefixed with `N|` (line-number artifacts from a prior edit session). This destroyed the YAML front-matter `---` delimiters, so Hugo could not parse front matter:

- the front matter leaked as visible body text ("1|--- 2|title: About ...")
- the page fell back to the generic article layout (raw text blob, bogus "1 января 1" date, wordcount, loading counters, edit link)
- the custom `.about-container` styling never applied

This is the "сломался дизайн /about/" reported breakage.

## Fix
- strip the `N|` prefixes from all 114 lines
- add explicit `date: 2024-01-01` to kill the epoch-fallback date

## Verification
- `hugo --gc --minify` → exit 0, 353 pages
- `/about/` now renders the full custom layout (hero, social SVG links, timeline, skills, projects, education, blog areas, contact, book list)
- front matter no longer leaks into body (0 occurrences)
- article date shows "1 января 2024 г." (was "1 января 1 г.")

Note: the Firebase views/likes counters intentionally show "loading" until the Firestore rules are deployed once via `firebase deploy --only firestore:rules` (backend step outside this repo). On error they fail-safe to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)