### PR TITLE
fix: resolve 7 Dependabot vulns via npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8220,13 +8220,13 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
-      "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=0.3.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/aes-js": {
@@ -9924,9 +9924,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.0.tgz",
+      "integrity": "sha512-qCf+V4dtlNhSRXGAZatc1TasyFO6GjohcOul807YOb5ik3+kQSnb4d7iajeCL8QHaJ4uZEjCgiCJerKXwdRVlQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10486,9 +10486,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -12189,14 +12189,17 @@
       }
     },
     "node_modules/hardhat/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/hardhat/node_modules/ws": {
@@ -15021,6 +15024,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jest-junit/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/jest-leak-detector": {
@@ -18321,16 +18338,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-limit": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.1.tgz",
@@ -19729,13 +19736,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-function-length": {
@@ -20513,16 +20520,13 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {
@@ -20862,20 +20866,6 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -479,5 +479,13 @@
     "yargs": "^18.1.0",
     "yargs-parser": "^22.0.0",
     "yocto-queue": "^1.2.2"
+  },
+  "overrides": {
+    "adm-zip": "0.6.0",
+    "tmp": "0.2.7",
+    "serialize-javascript": "7.0.5",
+    "uuid": "11.1.1",
+    "cookie": "0.7.0",
+    "diff": "9.0.0"
   }
 }


### PR DESCRIPTION
## What
The 16 Dependabot alerts were all in `package-lock.json`, pulled transitively by `hardhat@2.29.1` (engineering/DAO plane) and `jsdom`. `npm audit fix --force` wants to install `hardhat@3.14.0` — a breaking major upgrade of the DAO contract config that must not be applied silently.

Instead, this PR pins the fixable transitive deps via npm `overrides` and regenerates the lockfile:

| Package | Before → After | Severity | Alert |
|---|---|---|---|
| adm-zip | 0.4.16 → 0.6.0 | high | #35 |
| tmp | 0.0.33 → 0.2.7 | high/low | #30, #19 |
| serialize-javascript | 6.0.2 → 7.0.5 | med/high | #29, #23 |
| uuid (hardhat + jest-junit) | → 11.1.1 | med | #28 |
| cookie | 0.4.2 → 0.7.0 | low | #16 |
| diff (jsdiff DoS) | 7.0.0 → 9.0.0 | audit hygiene | — |

`npm audit` drops **23 → 14** vulnerabilities.

## Verification
- `npm audit`: 23 → 14 vulns
- `npm run test` (jest): ALL TESTS PASSED (Unit/Accessibility/Performance)
- `npm run lint`: clean
- `hugo --gc --minify`: OK
- `hardhat --version` (via node, shim broken): **2.29.1** still loads → DAO plane not broken by overrides

## Not fixable here (documented, left open)
- **undici ×8** (#38/#37/#36/#34/#33/#31/#25/#24): hardhat 2.x pins `undici@5.29.0`; the only fix is **hardhat@3** (breaking DAO config migration + plugin API change). Requires separate, validated migration before applying.
- **elliptic #20**: vulnerable range `<=6.6.1` and **6.6.1 is the latest published version** — no upstream fix exists yet. Dependabot will auto-close once upstream patches.
- **html-minifier@4.0.0** (npm-audit only, not a Dependabot alert): 4.0.0 is the final release (2019, unmaintained); no fix available. Could be swapped for `html-minifier-terser` as a follow-up code change.

Once this merges, GitHub re-scans the new lockfile and the 7 resolved Dependabot alerts auto-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version overrides to ensure consistent, secure dependency versions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->