### PR TITLE
fix: clear remaining 8 undici Dependabot alerts via undici override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4719,16 +4719,6 @@
         }
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@formatjs/ecma402-abstract": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
@@ -16736,15 +16726,6 @@
         "node": "^22.13.0 || >=24.0.0"
       }
     },
-    "node_modules/jsdom/node_modules/undici": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "license": "MIT",
@@ -20683,16 +20664,12 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "dev": true,
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -486,6 +486,7 @@
     "serialize-javascript": "7.0.5",
     "uuid": "11.1.1",
     "cookie": "0.7.0",
-    "diff": "9.0.0"
+    "diff": "9.0.0",
+    "undici": "8.10.0"
   }
 }


### PR DESCRIPTION
## Context — why not a "real" hardhat 3 migration
The 8 remaining undici alerts come from hardhat 2.x's nominal pin of `undici@5.29.0`. `npm audit fix --force` proposes `hardhat@3.14.0`, but a genuine hardhat 3 migration is **currently impossible** on this plugin set:

- `@nomicfoundation/hardhat-chai-matchers@3.0.0` metadata explicitly states it *"does not work with Hardhat 2 nor 3"*; there is **no `hh3` dist-tag** (only `hh2` 2.1.2).
- Verified empirically: `npm install hardhat@3.14.0 @nomicfoundation/hardhat-ethers@4 @nomicfoundation/hardhat-chai-matchers@3.0.0` fails to load with `MODULE_NOT_FOUND`. `npx hardhat test` would be left broken with no compatible fix.

## The actual fix (achieves the goal, no breaking change)
`hardhat` core **does not import undici at runtime** (grep of `hardhat/dist` for `require('undici')` is empty). The only real consumer is `jsdom@30`, already at `undici@8.10.0` (≥ 6.28, patched). So overriding `undici` to `8.10.0` clears all 8 undici alerts **without** touching hardhat — verified safe.

## Verification (real runs)
- `npm audit`: **23 → 13** vulnerabilities; all 8 undici alerts gone
- `npx hardhat test` (via node, shim broken): **9 passing** (DAO — SoulboundToken + ProposalEngine)
- `hardhat --version` → **2.29.1** (unchanged, DAO plane intact)
- `npm run test` (jest): ALL TESTS PASSED (Unit/Accessibility/Performance)
- `npm run lint`: clean
- `hugo --gc --minify`: OK

## Residual (genuinely unfixable, not hardhat-gated)
- **elliptic** (1 high): vulnerable range `<=6.6.1` and 6.6.1 IS the latest published version — no upstream patch exists. Dependabot auto-closes when upstream releases a fix.
- **html-minifier@4.0.0** (npm-audit only, NOT a Dependabot alert): final 2019 release, unmaintained; no fix. Could be swapped for `html-minifier-terser` as a follow-up code change.

Once merged, GitHub re-scans the lockfile and the 8 undici Dependabot alerts auto-close — leaving only the elliptic one open (upstream-blocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)