### PR TITLE
fix: regenerate repositories page + wire content-sync into build

### DIFF
--- a/content/gists/453331637420dcb50d285b2de7aee442.md
+++ b/content/gists/453331637420dcb50d285b2de7aee442.md
@@ -4,7 +4,7 @@ type: gist
 gist_id: "453331637420dcb50d285b2de7aee442"
 gist_name: "UniGetUI package backups - DO NOT RENAME OR MODIFY @[UNIGETUI_BACKUP_V1] - UniGetUI Package Backups"
 gist_url: https://gist.github.com/dominicusin/453331637420dcb50d285b2de7aee442
-updated_at: "2026-07-24T06:27:15Z"
+updated_at: "2026-08-18T20:28:48Z"
 files: ["- UniGetUI Package Backups", "@[PACKAGES] HELLY\\domini"]
 ---
 _UniGetUI package backups - DO NOT RENAME OR MODIFY @[UNIGETUI_BACKUP_V1]_
@@ -30,21 +30,6 @@ Learn more about UniGetUI at https://github.com/marticliment/UniGetUI
       "Version": "26.2.0",
       "Source": "community",
       "ManagerName": "chocolatey"
-    },
-    {
-      "Id": "7zip",
-      "Name": "7zip",
-      "Version": "26.02",
-      "Source": "main",
-      "ManagerName": "scoop",
-      "InstallationOptions": {
-        "OverridesNextLevelOpts": true,
-        "SkipHashCheck": true,
-        "RunAsAdministrator": true,
-        "AutoUpdatePackage": true,
-        "Architecture": "x64",
-        "InstallationScope": "machine"
-      }
     },
     {
       "Id": "7zip.7zip",
@@ -111,7 +96,7 @@ Learn more about UniGetUI at https://github.com/marticliment/UniGetUI
     {
       "Id": "Devolutions.UniGetUI",
       "Name": "UniGetUI",
-      "Version": "2026.2.5",
+      "Version": "2026.2.7",
       "Source": "winget",
       "ManagerName": "winget"
     },
@@ -195,7 +180,7 @@ Learn more about UniGetUI at https://github.com/marticliment/UniGetUI
     {
       "Id": "Microsoft.AppInstaller",
       "Name": "ms-resource:appDisplayName",
-      "Version": "1.29.280.0",
+      "Version": "1.30.90.0",
       "Source": "winget",
       "ManagerName": "winget"
     },
@@ -209,14 +194,14 @@ Learn more about UniGetUI at https://github.com/marticliment/UniGetUI
     {
       "Id": "Microsoft.Edge",
       "Name": "Microsoft Edge",
-      "Version": "151.0.4129.35",
+      "Version": "152.0.4191.19",
       "Source": "winget",
       "ManagerName": "winget"
     },
     {
       "Id": "Microsoft.EdgeWebView2Runtime",
       "Name": "Microsoft Edge WebView2 Runtime",
-      "Version": "151.0.4129.35",
+      "Version": "152.0.4191.19",
       "Source": "winget",
       "ManagerName": "winget"
     },
@@ -340,6 +325,20 @@ Learn more about UniGetUI at https://github.com/marticliment/UniGetUI
       "ManagerName": "winget"
     },
     {
+      "Id": "Perforce.P4V",
+      "Name": "Helix Core Apps",
+      "Version": "233.249.5381",
+      "Source": "winget",
+      "ManagerName": "winget"
+    },
+    {
+      "Id": "Perforce.P4V",
+      "Name": "P4 Apps",
+      "Version": "242.62.2",
+      "Source": "winget",
+      "ManagerName": "winget"
+    },
+    {
       "Id": "Rustlang.Rustup",
       "Name": "Rustup: the Rust toolchain installer",
       "Version": "1.29.0",
@@ -354,13 +353,6 @@ Learn more about UniGetUI at https://github.com/marticliment/UniGetUI
       "ManagerName": "winget"
     },
     {
-      "Id": "Update-FarManager",
-      "Name": "Update FarManager",
-      "Version": "1.0.1",
-      "Source": "PSGallery",
-      "ManagerName": "pwsh"
-    },
-    {
       "Id": "autohotkey.portable",
       "Name": "Autohotkey",
       "Version": "2.1.0-alpha9",
@@ -373,20 +365,6 @@ Learn more about UniGetUI at https://github.com/marticliment/UniGetUI
       "Version": "1.3.14",
       "Source": "community",
       "ManagerName": "chocolatey"
-    },
-    {
-      "Id": "bzip2:x64-windows",
-      "Name": "Bzip2",
-      "Version": "1.0.8#6",
-      "Source": "x64-windows",
-      "ManagerName": "vcpkg"
-    },
-    {
-      "Id": "bzip2[tool]:x64-windows",
-      "Name": "Bzip2 [Tool]",
-      "Version": "1.0.8#6",
-      "Source": "x64-windows",
-      "ManagerName": "vcpkg"
     },
     {
       "Id": "chocolatey-compatibility.extension",
@@ -410,46 +388,11 @@ Learn more about UniGetUI at https://github.com/marticliment/UniGetUI
       "ManagerName": "chocolatey"
     },
     {
-      "Id": "curl",
-      "Name": "Curl",
-      "Version": "8.21.0_4",
-      "Source": "main",
-      "ManagerName": "scoop"
-    },
-    {
-      "Id": "dark",
-      "Name": "Dark",
-      "Version": "3.14.1",
-      "Source": "main",
-      "ManagerName": "scoop"
-    },
-    {
       "Id": "devbox-p4merge",
       "Name": "Devbox P4merge",
-      "Version": "2023.4.0",
+      "Version": "2023.3.0",
       "Source": "community",
       "ManagerName": "chocolatey"
-    },
-    {
-      "Id": "dotnet10-sdk",
-      "Name": "Dotnet10 Sdk",
-      "Version": "10.0.302",
-      "Source": "versions",
-      "ManagerName": "scoop"
-    },
-    {
-      "Id": "egl-registry:x64-windows",
-      "Name": "Egl Registry",
-      "Version": "2025-05-27",
-      "Source": "x64-windows",
-      "ManagerName": "vcpkg"
-    },
-    {
-      "Id": "git",
-      "Name": "Git",
-      "Version": "2.55.0.3",
-      "Source": "main",
-      "ManagerName": "scoop"
     },
     {
       "Id": "git",
@@ -466,39 +409,16 @@ Learn more about UniGetUI at https://github.com/marticliment/UniGetUI
       "ManagerName": "chocolatey"
     },
     {
-      "Id": "innounp",
-      "Name": "Innounp",
-      "Version": "2.70.1",
-      "Source": "main",
-      "ManagerName": "scoop"
-    },
-    {
       "Id": "p4merge",
       "Name": "P4merge",
-      "Version": "2023.4.0",
+      "Version": "2023.3.0",
       "Source": "community",
-      "ManagerName": "chocolatey"
-    },
-    {
-      "Id": "scoop-search",
-      "Name": "Scoop Search",
-      "Version": "2.1.0",
-      "Source": "main",
-      "ManagerName": "scoop"
-    },
-    {
-      "Id": "sudo",
-      "Name": "Sudo",
-      "Version": "0.2020.01.26",
-      "Source": "main",
-      "ManagerName": "scoop"
-    },
-    {
-      "Id": "tixati",
-      "Name": "Tixati",
-      "Version": "3.44",
-      "Source": "extras",
-      "ManagerName": "scoop"
+      "ManagerName": "chocolatey",
+      "InstallationOptions": {
+        "OverridesNextLevelOpts": false,
+        "RunAsAdministrator": true,
+        "PreRelease": true
+      }
     },
     {
       "Id": "tixati",
@@ -506,41 +426,6 @@ Learn more about UniGetUI at https://github.com/marticliment/UniGetUI
       "Version": "3.44.0",
       "Source": "community",
       "ManagerName": "chocolatey"
-    },
-    {
-      "Id": "vcpkg-boost:x64-windows",
-      "Name": "Vcpkg Boost",
-      "Version": "2025-03-29",
-      "Source": "x64-windows",
-      "ManagerName": "vcpkg"
-    },
-    {
-      "Id": "vcpkg-cmake-config:x64-windows",
-      "Name": "Vcpkg Cmake Config",
-      "Version": "2024-05-23",
-      "Source": "x64-windows",
-      "ManagerName": "vcpkg"
-    },
-    {
-      "Id": "vcpkg-cmake-get-vars:x64-windows",
-      "Name": "Vcpkg Cmake Get Vars",
-      "Version": "2025-05-29",
-      "Source": "x64-windows",
-      "ManagerName": "vcpkg"
-    },
-    {
-      "Id": "vcpkg-cmake:x64-windows",
-      "Name": "Vcpkg Cmake",
-      "Version": "2024-04-23",
-      "Source": "x64-windows",
-      "ManagerName": "vcpkg"
-    },
-    {
-      "Id": "vcpkg-tool-meson:x64-windows",
-      "Name": "Vcpkg Tool Meson",
-      "Version": "1.9.0#10",
-      "Source": "x64-windows",
-      "ManagerName": "vcpkg"
     },
     {
       "Id": "vcredist140",
@@ -555,20 +440,6 @@ Learn more about UniGetUI at https://github.com/marticliment/UniGetUI
       "Version": "14.16.27052",
       "Source": "community",
       "ManagerName": "chocolatey"
-    },
-    {
-      "Id": "wixtoolset",
-      "Name": "Wixtoolset",
-      "Version": "7.0.0",
-      "Source": "main",
-      "ManagerName": "scoop"
-    },
-    {
-      "Id": "zlib:x64-windows",
-      "Name": "Zlib",
-      "Version": "1.3.2#1",
-      "Source": "x64-windows",
-      "ManagerName": "vcpkg"
     }
   ],
   "incompatible_packages_info": "Incompatible packages cannot be installed from UniGetUI, either because they came from a local source (for example Local PC) or because the package manager was unavailable. Nevertheless, they have been listed here for logging purposes.",
@@ -622,9 +493,15 @@ Learn more about UniGetUI at https://github.com/marticliment/UniGetUI
       "Source": "\u042D\u0442\u043E\u0442 \u041F\u041A"
     },
     {
-      "Id": "MSIX\\Microsoft.MicrosoftEdge.Stable_151.0.4129.35_neutral__8wekyb3d8bbwe",
+      "Id": "ARP\\User\\X64\\{1f456f5f-88ad-45fd-87e0-46369153648c}",
+      "Name": "MSYS2",
+      "Version": "20260611",
+      "Source": "\u042D\u0442\u043E\u0442 \u041F\u041A"
+    },
+    {
+      "Id": "MSIX\\Microsoft.MicrosoftEdge.Stable_152.0.4191.19_neutral__8wekyb3d8bbwe",
       "Name": "Microsoft Edge",
-      "Version": "151.0.4129.35",
+      "Version": "152.0.4191.19",
       "Source": "Microsoft Store"
     },
     {
@@ -640,9 +517,9 @@ Learn more about UniGetUI at https://github.com/marticliment/UniGetUI
       "Source": "Microsoft Store"
     },
     {
-      "Id": "MSIX\\Microsoft.SecHealthUI_1000.29621.1000.0_x64__8wekyb3d8bbwe",
+      "Id": "MSIX\\Microsoft.SecHealthUI_1000.29628.1000.0_x64__8wekyb3d8bbwe",
       "Name": "ms-resource:PackageDisplayName",
-      "Version": "1000.29621.1000.0",
+      "Version": "1000.29628.1000.0",
       "Source": "Microsoft Store"
     },
     {
@@ -658,9 +535,9 @@ Learn more about UniGetUI at https://github.com/marticliment/UniGetUI
       "Source": "Microsoft Store"
     },
     {
-      "Id": "MSIX\\Microsoft.WindowsFeedbackHub_2.2606.702.0_x64__8wekyb3d8bbwe",
+      "Id": "MSIX\\Microsoft.WindowsFeedbackHub_2.2606.703.0_x64__8wekyb3d8bbwe",
       "Name": "ms-resource:AppStoreName",
-      "Version": "2.2606.702.0",
+      "Version": "2.2606.703.0",
       "Source": "Microsoft Store"
     },
     {
@@ -670,9 +547,9 @@ Learn more about UniGetUI at https://github.com/marticliment/UniGetUI
       "Source": "Microsoft Store"
     },
     {
-      "Id": "MSIX\\Microsoft.Winget.Source_2026.721.333.24_neutral__8wekyb3d8bbwe",
+      "Id": "MSIX\\Microsoft.Winget.Source_2026.818.1913.34_neutral__8wekyb3d8bbwe",
       "Name": "Windows Package Manager Source (winget) V2",
-      "Version": "2026.721.333.24",
+      "Version": "2026.818.1913.34",
       "Source": "Microsoft Store"
     },
     {
@@ -682,9 +559,9 @@ Learn more about UniGetUI at https://github.com/marticliment/UniGetUI
       "Source": "Microsoft Store"
     },
     {
-      "Id": "MSIX\\MicrosoftCorporationII.WinAppRuntime.Singleton_8002.3.0.0_x64__8wekyb3d8bbwe",
+      "Id": "MSIX\\MicrosoftCorporationII.WinAppRuntime.Singleton_8002.3.1.0_x64__8wekyb3d8bbwe",
       "Name": "WinAppRuntime.Singleton",
-      "Version": "8002.3.0.0",
+      "Version": "8002.3.1.0",
       "Source": "Microsoft Store"
     }
   ]

--- a/content/gists/a4ad9e564ff2e3216ac7fd2f5a761309.md
+++ b/content/gists/a4ad9e564ff2e3216ac7fd2f5a761309.md
@@ -399,7 +399,7 @@ function convertBBCodeToHTML($bbcode)
 	$bbcode = preg_replace('#\[b](.+)\[\/b]#', "<b>$1</b>", $bbcode);
 	$bbcode = preg_replace('#\[i](.+)\[\/i]#', "<i>$1</i>", $bbcode);
 	$bbcode = preg_replace('#\[u](.+)\[\/u]#', "<u>$1</u>", $bbcode);
-	$bbcode = preg_replace('#\[img](.+?)\[\/img]#is', "<img src='$1' alt='embedded image'\>", $bbcode);
+	$bbcode = preg_replace('#\[img](.+?)\[\/img]#is', "<img alt=" src='$1'\>", $bbcode);
 	$bbcode = preg_replace('#\[quote=(.+?)](.+?)\[\/quote]#is', "<QUOTE><i>&gt;</i>$2</QUOTE>", $bbcode);
 	$bbcode = preg_replace('#\[code:\w+](.+?)\[\/code:\w+]#is', "<CODE class='hljs'>$1<CODE>", $bbcode);
 	$bbcode = preg_replace('#\[pre](.+?)\[\/pre]#is', "<code>$1<code>", $bbcode);
@@ -426,7 +426,7 @@ function trimSmilies($postText)
 	$startStr1 = '" title';
 	$endStr1 = " -->";
 
-	$emoticonsCount = substr_count($postText, '<img src="{SMILIES_PATH}" alt=\'smiley\'');
+	$emoticonsCount = substr_count($postText, '<img alt=" src="{SMILIES_PATH}');
 
 	for ($i=0; $i < $emoticonsCount; $i++)
 	{

--- a/content/gists/b6b1dda15f789d36ea10d0139197c812.md
+++ b/content/gists/b6b1dda15f789d36ea10d0139197c812.md
@@ -50,7 +50,7 @@ copy the package to the same location where Yosemite-Zone.dmg exist
 then open the Yosemite Restore package and Install it to the 8GB/+ Pen drive
 Please view the video instructions to restore the image with Mac OS X
 
-<iframe width="830" height="497" src="https://www.youtube.com/embed/rakNhX6bz2U" frameborder="0" allowfullscreen></iframe>
+
 
 > Read also... [Installing Hackintosh Yosemite in Unsupported INtel Processors and Most AMD Processors](http://www.hackintosh.computer/?p=37)
 

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "main": "src/index.js",
   "scripts": {
-    "build": "hugo --gc --minify",
+    "build": "node scripts/sync-github.cjs && hugo --gc --minify",
     "build:css": "tailwindcss -i ./css/tailwind.src.css -o ./css/tailwind.css --minify",
     "watch:css": "tailwindcss -i ./css/tailwind.src.css -o ./css/tailwind.css --watch",
-    "build:production": "hugo --gc --minify --baseURL \"https://dominicusin.github.io/\"",
+    "build:production": "node scripts/sync-github.cjs && hugo --gc --minify --baseURL \"https://dominicusin.github.io/\"",
     "serve": "hugo server -D",
     "start": "hugo server -D --bind 0.0.0.0 --port 4000",
     "minify": "hugo --gc --minify",


### PR DESCRIPTION
## Root cause
The `/repositories/` page rendered empty ("no content extracted") because its cards are generated by `scripts/sync-github.cjs` into `content/repositories/<owner>__<repo>.md` — and **`content/repositories/` is gitignored by design** (the source repo stays clean; the build regenerates it). A bare `hugo` build without running the sync leaves the `repo-grid` empty. That's what happened during local/dev builds (including verification passes that ran `hugo` directly).

## Fix
- Regenerated the content: `sync-github.cjs` → **128 repos + 100 gists** written to `content/repositories/`, `content/gists/`, `data/github.json`.
- Wired the sync step into the default build scripts so any `hugo` build regenerates the repo/gist content:
  - `build` → `node scripts/sync-github.cjs && hugo --gc --minify`
  - `build:production` → `node scripts/sync-github.cjs && hugo --gc --minify --baseURL "https://dominicusin.github.io/"`

The sync script is graceful (per-repo try/catch, `exit 0` on partial/network failure), so builds don't break offline.

Note: CI (`hugo.yml`) already ran sync before hugo, so the **deployed** site was never actually broken — this fixes local/dev reproducibility and prevents recurrence.

## Verification
- `npm run build` (sync + hugo) regenerates pages (128 repos confirmed)
- `/repositories/` renders **128 repo cards** (768 `repo-card` class hits in the built HTML)
- `hugo --gc --minify` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
