### PR TITLE
feat: customize Sitemap + RSS (per-section priority, blog-scoped feed)

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -40,6 +40,12 @@ canonifyURLs = false
 [outputFormats.RSS]
   baseName = "feed"
 
+# Native Hugo RSS cap: keep the home feed to the N most-recent blog posts
+# (the full site has 295+ regular pages incl. gists/repos — far too noisy for
+# a subscription feed). The feed template further scopes to the blog section.
+[services.rss]
+  limit = 50
+
 # Lightweight [{slug,url,title,section}] index powering the 404 smart-redirect
 # (broken URL -> fuzzy slug match -> closest existing page). Deliberately small
 # (no content) so it loads instantly on a 404; distinct from the 4.4MB search index.

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,0 +1,50 @@
+{{- /* Custom RSS feed: scope to the blog section, cap to the N most-recent
+       posts (services.rss.limit), and enrich each item with category tags
+       and full content. Overrides the Blowfish/stock feed which pulled every
+       regular page (gists, repo subpages, wiki) into a 295-item, 4MB feed. */}}
+{{- $pages := slice -}}
+{{- if .IsHome -}}
+  {{- /* Editorial content only: the blog section (posts). */ -}}
+  {{- $pages = where site.RegularPages "Section" "blog" -}}
+  {{- $limit := .Site.Config.Services.RSS.Limit -}}
+  {{- if ge $limit 1 -}}{{- $pages = $pages | first $limit -}}{{- end -}}
+{{- else -}}
+  {{- $pages = .Pages -}}
+{{- end -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} на {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Новые записи{{ if ne .Title .Site.Title }} в «{{ .Title }}»{{ end }} на {{ .Site.Title }}</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>{{ site.Language.Locale }}</language>
+    {{- with .Site.Params.Author.email }}<managingEditor>{{ . }}{{ with $.Site.Params.Author.name }} ({{ . }}){{ end }}</managingEditor>{{ end }}
+    {{- with .Site.Params.Author.email }}<webMaster>{{ . }}{{ with $.Site.Params.Author.name }} ({{ . }}){{ end }}</webMaster>{{ end }}
+    {{- if .Site.Params.footer.showCopyright | default true }}
+    <copyright>{{ with replace .Site.Params.copyright "{ year }" now.Year }}{{ . }}{{ else }}© {{ now.Format "2006" }} {{ .Site.Params.Author.name }}{{ end }}</copyright>
+    {{- end }}
+    {{- with .OutputFormats.Get "RSS" }}<atom:link href="{{ .Permalink }}" rel="self" type="{{ .MediaType }}"/>{{ end }}
+    {{- /* Channel image (OG image) for richer feed cards in readers. */ -}}
+    {{- with .Site.Params.defaultSocialImage }}<image>
+      <url>{{ . | absURL }}</url>
+      <title>{{ $.Site.Title }}</title>
+      <link>{{ $.Permalink }}</link>
+    </image>{{ end }}
+    {{- range $pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      <dc:creator>{{ with .Site.Params.Author.name }}{{ . }}{{ end }}</dc:creator>
+      <guid isPermaLink="true">{{ .Permalink }}</guid>
+      <description>{{ .Summary | transform.XMLEscape | safeHTML }}</description>
+      <content:encoded>{{ .Content | transform.XMLEscape | safeHTML }}</content:encoded>
+      {{- /* Category tags: both tags and categories for better aggregation. */ -}}
+      {{- range .Params.tags }}<category>{{ . }}</category>{{ end }}
+      {{- range .Params.categories }}<category>{{ . }}</category>{{ end }}
+      {{- with .Params.featuredimage }}<enclosure url="{{ . | absURL }}" type="image/jpeg"/>{{ end }}
+    </item>
+    {{- end }}
+  </channel>
+</rss>

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,0 +1,36 @@
+{{- /* Custom sitemap: per-section priority + changefreq, lastmod on every
+       URL, and the 404 page excluded. Overrides the stock template that
+       assigned a flat 0.5/monthly to all 488 pages. */}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml"
+  xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+{{- range .Data.Pages }}
+  {{- if and (not .Sitemap.Disable) (not (in ($.Site.Params.sitemap.excludedKinds | default slice) .Kind)) }}
+    {{- if and (.Param "xml" | default true) (not .Params.excludeFromSearch) (not (eq .RelPermalink "/404.html")) }}
+      {{- $prio := 0.3 -}}
+      {{- $freq := "yearly" -}}
+      {{- if .IsHome }}{{- $prio = 1.0 }}{{- $freq = "weekly" }}{{- end -}}
+      {{- if eq .Kind "section" }}{{- $prio = 0.6 }}{{- $freq = "monthly" }}{{- end -}}
+      {{- if eq .Kind "taxonomy" }}{{- $prio = 0.4 }}{{- $freq = "monthly" }}{{- end -}}
+      {{- if eq .Kind "term" }}{{- $prio = 0.4 }}{{- $freq = "monthly" }}{{- end -}}
+      {{- if eq .Section "blog" }}{{- $prio = 0.8 }}{{- $freq = "monthly" }}{{- end -}}
+      {{- /* Front-matter overrides win (only when explicitly >= 0). */ -}}
+      {{- with .Sitemap.Priority }}{{ if ge . 0.0 }}{{ $prio = . }}{{ end }}{{ end -}}
+      {{- with .Sitemap.ChangeFreq }}{{ $freq = . }}{{ end -}}
+      {{- if .Permalink }}
+  <url>
+    <loc>{{ .Permalink }}</loc>
+        {{- if not .Lastmod.IsZero }}<lastmod>{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" }}</lastmod>{{ end }}
+    <changefreq>{{ $freq }}</changefreq>
+    <priority>{{ $prio }}</priority>
+        {{- /* Featured image as sitemap image extension for image SEO. */ -}}
+        {{- with .Params.featuredimage }}<image:image><image:loc>{{ . | absURL }}</image:loc></image:image>{{ end -}}
+        {{- if .IsTranslated }}{{ range .Translations }}
+    <xhtml:link rel="alternate" hreflang="{{ .Language.Locale }}" href="{{ .Permalink }}"/>{{ end }}{{ end }}
+  </url>
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+</urlset>


### PR DESCRIPTION
## Sitemap — `layouts/sitemap.xml` (override)
- **Per-section priority + changefreq**: home `1.0`/weekly, blog posts `0.8`/monthly, sections `0.6`/monthly, taxonomies `0.4`/monthly, other pages (repos/gists) `0.3`/yearly — replaces the stock flat `0.5`/monthly on all 488 pages.
- **Fixed a `-1` priority bug**: Hugo's `.Sitemap.Priority` defaults to `-1` (the "unset" sentinel) and was clobbering computed values via `with`. Now only overrides when explicitly `>= 0`.
- **Excludes `/404.html`**; emits `lastmod` on every dated URL.

## RSS — `layouts/_default/rss.xml` (override) + `services.rss.limit = 50`
- **Scoped to the blog section only** — the previous feed pulled 295 regular pages (107 gists + 129 repo subpages) into a 4.2 MB noise feed. Now **50 most-recent blog posts**.
- **Enriched items**: `<category>` tags (tags + categories), full `<content:encoded>`, channel `<image>` (OG image), `dc:creator` hook (activates when `[params.author]` is set).

## Leveraged Hugo/Blowfish capabilities
`services.rss.limit` (native cap), custom `OutputFormats`, per-page `.Sitemap.Priority`/`.Sitemap.ChangeFreq` (front-matter overridable), RSS `<content:encoded>` + `<image>` + `<category>` extensions, sitemap image-extension namespace.

## Verification (real builds)
- `hugo --gc --minify`: OK
- `feed.xml`: well-formed XML, **50 items**, 206 `<category>`, `content:encoded` present, channel `<image>` present
- `sitemap.xml`: well-formed XML, **301 URLs**, priority dist `{1.0:1, 0.8:59, 0.6:5, 0.3:236}`, **0** `<priority>-1</priority>`, 404 excluded
- `npm run test` (jest): ALL TESTS PASSED · `npm run lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
