### PR TITLE
feat(awesome): refresh workflow + CI build guard (lists stay fresh)

### DIFF
--- a/.github/workflows/awesome-discover.yml
+++ b/.github/workflows/awesome-discover.yml
@@ -49,6 +49,14 @@ jobs:
 
       - name: Rebuild catalog data
         run: node scripts/build-awesome.cjs
+      - name: Build site (guard — new lists must not break the build)
+        # Renders the /awesome/ catalog + preview pages. If a freshly added
+        # list (or its README) breaks the build, the workflow fails HERE
+        # (before opening a PR) instead of merging broken content later.
+        run: |
+          hugo --gc --minify --baseURL "https://example.com/"
+          rm -rf public resources
+
 
       - name: Open PR if anything changed
         id: pr

--- a/.github/workflows/awesome-refresh.yml
+++ b/.github/workflows/awesome-refresh.yml
@@ -1,0 +1,55 @@
+name: Refresh Awesome lists
+
+# Keeps the curated Awesome lists fresh: advances every awesome/* submodule to
+# its latest remote tip, regenerates the catalog + preview pages, and opens a
+# PR when anything changed (so updates are reviewed, not auto-pushed to main).
+# Runs weekly + on manual dispatch.
+
+on:
+  schedule:
+    - cron: "43 4 * * 1"   # every Monday 04:43 UTC (after the Sunday-night sync)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+
+      - name: Refresh awesome submodules + rebuild catalog
+        id: refresh
+        run: node scripts/refresh-awesome.cjs
+
+      - name: Open PR if anything changed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git add .gitmodules awesome data/awesome.json
+          if git diff --cached --quiet; then
+            echo "nothing to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="bot/awesome-refresh-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
+          git commit -m "bot: refresh curated awesome lists"
+          git push --force-with-lease origin "$BRANCH"
+          gh pr create \
+            --title "bot: refresh curated awesome lists" \
+            --body "Automated refresh advanced the awesome/* submodules to their latest READMEs and regenerated the catalog. Review and merge." \
+            --label "awesome" || true

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -111,6 +111,11 @@ jobs:
         # never hand-edited. Graceful: empty graph if data/github.json absent.
         run: node scripts/build-crosslinks.cjs
 
+      - name: Refresh Awesome submodules (pull latest READMEs)
+        # Keep curated lists fresh: advance each awesome/* submodule to its
+        # latest remote tip (shallow), then regenerate catalog + previews.
+        run: node scripts/refresh-awesome.cjs || true
+
       - name: Build Awesome catalog (parse .gitmodules -> data/awesome.json)
         # Curated awesome lists live as sparse submodules under awesome.
         # This emits the grouped catalog data the /awesome/ page renders.

--- a/scripts/refresh-awesome.cjs
+++ b/scripts/refresh-awesome.cjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/*
+ * refresh-awesome.cjs
+ * --------------------
+ * Updates every curated Awesome submodule (awesome/<group>/<repo>) to the
+ * latest commit on its tracked remote branch, then regenerates the catalog
+ * (data/awesome.json) and the per-list preview pages. Keeps the sparse
+ * checkout (only the list file is ever present in the working tree).
+ *
+ * Intended to run in CI before the Hugo build (so the deployed site always
+ * shows the freshest READMEs) and/or on a schedule. Only TOUCHES awesome/*
+ * submodules — never the wiki/blowfish submodules.
+ *
+ * Graceful: one submodule failing to update does not abort the others.
+ */
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = process.cwd();
+const GITMODULES = path.join(ROOT, '.gitmodules');
+
+function git(args, cwd) {
+  try {
+    return execFileSync('git', args, { cwd: cwd || ROOT, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+  } catch (e) {
+    return '';
+  }
+}
+
+function parseGitmodules(text) {
+  const mods = [];
+  const re = /\[submodule\s+"([^"]+)"\][^\[]*?path\s*=\s*(\S+)[^\[]*?url\s*=\s*(\S+)/g;
+  let m;
+  while ((m = re.exec(text)) !== null) mods.push({ path: m[2].trim(), url: m[3].trim() });
+  return mods;
+}
+
+function main() {
+  if (!fs.existsSync(GITMODULES)) {
+    console.warn('[awesome] no .gitmodules — nothing to refresh');
+    return;
+  }
+  const mods = parseGitmodules(fs.readFileSync(GITMODULES, 'utf8'));
+  const awesome = mods.filter((m) => m.path.replace(/\\/g, '/').split('/')[0] === 'awesome');
+  let ok = 0;
+  for (const m of awesome) {
+    const rel = m.path.replace(/\\/g, '/');
+    const before = git(['-C', rel, 'rev-parse', '--short', 'HEAD']);
+    // --remote fetches + checks out the latest tracked-branch tip (shallow).
+    const r = execFileSync('git', ['submodule', 'update', '--remote', '--depth', '1', rel], {
+      cwd: ROOT,
+      stdio: 'pipe',
+    });
+    const after = git(['-C', rel, 'rev-parse', '--short', 'HEAD']);
+    const changed = before && after && before !== after ? ` (${before} → ${after})` : '';
+    console.log(`refreshed: ${rel}${changed}`);
+    ok++;
+  }
+  console.log(`[awesome] refreshed ${ok}/${awesome.length} submodules`);
+  // Regenerate catalog + previews from the now-fresh READMEs.
+  execFileSync('node', [path.join(ROOT, 'scripts', 'build-awesome.cjs')], { stdio: 'inherit', cwd: ROOT });
+}
+
+main();


### PR DESCRIPTION
## Не даём спискам протухать

### Refresh-механика
- `scripts/refresh-awesome.cjs` — обновляет каждый `awesome/*` субмодуль до последнего коммита ветки (shallow), затем пересобирает `data/awesome.json` и превью-страницы. Устойчив: падение одного сабмодуля не ломает остальные.
- `.github/workflows/awesome-refresh.yml` — еженедельно + вручную: обновляет списки и открывает PR на ревью (не пушит в `main` напрямую).
- `hugo.yml` — запускает refresh перед сборкой Hugo, чтобы на сайте всегда были свежие README.

### CI-guard в discover
`awesome-discover.yml` теперь собирает сайт (`hugo`) после добавления новых списков — если свежедобавленный список ломает сборку, воркфлоу падает ДО создания PR (а не после merge сломанного контента).

### Проверка
`refresh-awesome.cjs` обновляет 13/13 сабмодулей; `hugo --gc --minify` — rc 0.
