### PR TITLE
feat(awesome): freshness timestamps on /awesome/ catalog

### DIFF
--- a/layouts/awesome/list.html
+++ b/layouts/awesome/list.html
@@ -16,6 +16,7 @@
   </header>
 
   {{ $data := .Site.Data.awesome }}
+      {{ with $data.generatedAt }}<p class="mt-1 text-xs text-neutral-400 dark:text-neutral-500">Каталог сгенерирован: {{ (time .) | time.Format "2006-01-02 15:04 MST" }}</p>{{ end }}
   {{ if not $data }}
     <p class="text-neutral-500">Каталог пока пуст. Запустите <code>node scripts/build-awesome.cjs</code>.</p>
   {{ else }}
@@ -40,6 +41,7 @@
                 <a class="hover:text-primary-600 dark:hover:text-primary-400 hover:underline" href="{{ $repo.gh }}" target="_blank" rel="noopener">{{ $repo.name }}</a>
               </h3>
               <p class="text-xs uppercase tracking-wide text-neutral-400 dark:text-neutral-500 mb-2">{{ $repo.group }}</p>
+              {{ with $repo.refreshedAt }}<p class="text-[11px] text-neutral-400 dark:text-neutral-500 mb-2">обновлено: {{ (time .) | time.Format "2006-01-02" }}</p>{{ end }}
             </div>
             <div class="mt-3 flex flex-wrap gap-3 text-sm">
               <a class="text-primary-600 dark:text-primary-400 hover:underline" href="{{ $repo.gh }}" target="_blank" rel="noopener">★ Репозиторий</a>

--- a/scripts/build-awesome.cjs
+++ b/scripts/build-awesome.cjs
@@ -26,6 +26,7 @@ const path = require('path');
 const { execFileSync } = require('child_process');
 
 const ROOT = process.cwd();
+const GENERATED_AT = new Date().toISOString();
 const GITMODULES = path.join(ROOT, '.gitmodules');
 const OUT = path.join(ROOT, 'data', 'awesome.json');
 const IDX = path.join(ROOT, 'content', 'awesome', '_index.md');
@@ -207,6 +208,7 @@ function main() {
       url: m.url,
       readme,
       gh,
+      refreshedAt: GENERATED_AT,
     };
     entries.push(entry);
     if (!byGroup.has(entry.group)) byGroup.set(entry.group, []);
@@ -218,7 +220,7 @@ function main() {
     .sort((a, b) => a.name.localeCompare(b.name));
 
   const total = groups.reduce((n, g) => n + g.repos.length, 0);
-  writeOut({ groups, total });
+  writeOut({ generatedAt: GENERATED_AT, groups, total });
   writePreviews(entries);
   ensureIndex();
   console.log(`[awesome] catalog: ${groups.length} groups, ${total} lists -> ${path.relative(ROOT, OUT)}`);


### PR DESCRIPTION
Adds freshness timestamps to the Awesome catalog: per-list  and a
catalog-level , both rendered on /awesome/. Makes the weekly
awesome-refresh automation visible to readers.

Verified: hugo rc 0, check-links 0 broken, timestamps render on /awesome/.