### PR TITLE
fix: nested-submodule deploy failure + allow MPL-2.0

### DIFF
--- a/.github/workflows/awesome-discover.yml
+++ b/.github/workflows/awesome-discover.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          submodules: recursive
+          submodules: true
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/awesome-refresh.yml
+++ b/.github/workflows/awesome-refresh.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          submodules: recursive
+          submodules: true
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -35,16 +35,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          submodules: recursive
+          submodules: true
           fetch-depth: 0
 
       - name: Init wiki submodule
         # content/wiki is a git submodule (GitHub Wiki). Ensure it is present
         # even if checkout's recursive flag missed it.
-        run: git submodule update --init --recursive content/wiki
+        run: git submodule update --init content/wiki
       - name: Init awesome submodules (sparse README only)
         run: |
-          git submodule update --init --recursive awesome
+          git submodule update --init awesome
           node scripts/ensure-awesome-sparse.cjs || true
 
       - name: Generate wiki navigation

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -2,7 +2,8 @@ name: License Check
 
 # Fail the build if a dependency introduces a disallowed license
 # (copyleft / unknown). Keeps the project on permissive, audit-friendly
-# licensing for the static Hugo site and its CI tooling.
+# licensing for the static Hugo site and its CI tooling. MPL-2.0 is allowed
+# because @axe-core/playwright (E2E a11y tests only, never shipped) is MPL-2.0.
 
 on:
   pull_request:
@@ -35,6 +36,6 @@ jobs:
         run: |
           npx license-checker --summary --production \
             --excludePrivatePackages \
-            --onlyAllow "MIT;BSD-2-Clause;BSD-3-Clause;Apache-2.0;ISC;0BSD;CC0-1.0;Unlicense;WTFPL;BlueOak-1.0.0;Python-2.0;CC-BY-4.0" \
+            --onlyAllow "MIT;BSD-2-Clause;BSD-3-Clause;Apache-2.0;ISC;0BSD;CC0-1.0;Unlicense;WTFPL;BlueOak-1.0.0;Python-2.0;CC-BY-4.0;MPL-2.0" \
             || echo "::warning::License check found non-allowlisted licenses (informational; not blocking)."
         continue-on-error: true

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -27,7 +27,7 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@v7
         with:
-          submodules: recursive
+          submodules: true
           fetch-depth: 0
 
       - name: 🟢 Setup Node.js

--- a/.github/workflows/test-rnd.yml
+++ b/.github/workflows/test-rnd.yml
@@ -71,7 +71,7 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@v7
         with:
-          submodules: recursive
+          submodules: true
       - name: 🟢 Setup Node.js
         uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
Fixes two CI issues:

1. **Deploy failure (exit 128):**  + 
recursed into , whose nested 
submodule isn't in our  -> fatal. We only need each awesome repo's
README (sparse), so switched checkout  to  (no nested recursion)
and dropped  from the wiki/awesome submodule-update steps.

2. **License warning:**  (E2E a11y tests only, never shipped)
is MPL-2.0. Added MPL-2.0 to the  list (file-level
weak copyleft, acceptable for CI tooling).