### PR TITLE
chore: autopilot — self-merging awesome + dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
       time: "09:00"
       timezone: "UTC"
     open-pull-requests-limit: 10
+    auto-merge: true
     ignore:
       # Ignore major version updates for GitHub Actions (manual review required)
       - dependency-name: "actions/*"
@@ -23,6 +24,7 @@ updates:
       time: "10:00"
       timezone: "UTC"
     open-pull-requests-limit: 10
+    auto-merge: true
     groups:
       production-dependencies:
         dependency-type: "production"

--- a/.github/workflows/awesome-discover.yml
+++ b/.github/workflows/awesome-discover.yml
@@ -93,5 +93,5 @@ jobs:
           gh pr create \
             --title "bot: discover new curated awesome lists" \
             --body "Automated discovery added new awesome lists as sparse submodules under content/awesome/. Review and merge." \
-            --label "awesome" || true
+            --label "awesome" --auto || true
           echo "changed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/awesome-refresh.yml
+++ b/.github/workflows/awesome-refresh.yml
@@ -55,4 +55,4 @@ jobs:
           gh pr create \
             --title "bot: refresh curated awesome lists" \
             --body "Automated refresh advanced the awesome/* submodules to their latest READMEs and regenerated the catalog. Review and merge." \
-            --label "awesome" || true
+            --label "awesome" --auto || true


### PR DESCRIPTION
Enables true autopilot: awesome-discover/refresh PRs self-merge via  once the
required Quality CI passes, and Dependabot version-update PRs auto-merge (major Actions
versions still ignored for manual review). All gated by the existing branch protection +
enforce_admins + required Quality CI, so autonomy never bypasses CI.