### PR TITLE
fix: nested-submodule recursion broke checkout (exit 128)

### DIFF
--- a/.github/workflows/awesome-discover.yml
+++ b/.github/workflows/awesome-discover.yml
@@ -31,11 +31,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          submodules: true
+          submodules: false
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
+      - name: 📥 Init submodules (non-recursive)
+        # Checkout uses submodules:false so it won't recurse into nested
+        # submodules (e.g. open-source-ios-apps/ReadmeGenerator) absent from our
+        # root .gitmodules. We init only the direct submodules the job needs.
+        run: |
+          git submodule update --init --no-recurse-submodules themes/blowfish
+          git submodule update --init --no-recurse-submodules awesome
+
         uses: actions/setup-node@v7
         with:
           node-version: "24"

--- a/.github/workflows/awesome-discover.yml
+++ b/.github/workflows/awesome-discover.yml
@@ -41,8 +41,8 @@ jobs:
         # submodules (e.g. open-source-ios-apps/ReadmeGenerator) absent from our
         # root .gitmodules. We init only the direct submodules the job needs.
         run: |
-          git submodule update --init --no-recurse-submodules themes/blowfish
-          git submodule update --init --no-recurse-submodules awesome
+          git submodule update --init --no-recursive themes/blowfish
+          git submodule update --init --no-recursive awesome
 
         uses: actions/setup-node@v7
         with:

--- a/.github/workflows/awesome-discover.yml
+++ b/.github/workflows/awesome-discover.yml
@@ -41,8 +41,8 @@ jobs:
         # submodules (e.g. open-source-ios-apps/ReadmeGenerator) absent from our
         # root .gitmodules. We init only the direct submodules the job needs.
         run: |
-          git submodule update --init --no-recursive themes/blowfish
-          git submodule update --init --no-recursive awesome
+          git submodule update --init themes/blowfish
+          git submodule update --init awesome
 
         uses: actions/setup-node@v7
         with:

--- a/.github/workflows/awesome-refresh.yml
+++ b/.github/workflows/awesome-refresh.yml
@@ -21,11 +21,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          submodules: true
+          submodules: false
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
+      - name: 📥 Init awesome submodules (non-recursive)
+        run: git submodule update --init --no-recurse-submodules awesome
+
         uses: actions/setup-node@v7
         with:
           node-version: "24"

--- a/.github/workflows/awesome-refresh.yml
+++ b/.github/workflows/awesome-refresh.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Setup Node
       - name: 📥 Init awesome submodules (non-recursive)
-        run: git submodule update --init --no-recursive awesome
+        run: git submodule update --init awesome
 
         uses: actions/setup-node@v7
         with:

--- a/.github/workflows/awesome-refresh.yml
+++ b/.github/workflows/awesome-refresh.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Setup Node
       - name: 📥 Init awesome submodules (non-recursive)
-        run: git submodule update --init --no-recurse-submodules awesome
+        run: git submodule update --init --no-recursive awesome
 
         uses: actions/setup-node@v7
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,8 +29,8 @@ jobs:
 
       - name: 📥 Init submodules (non-recursive)
         run: |
-          git submodule update --init --no-recurse-submodules themes/blowfish
-          git submodule update --init --no-recurse-submodules awesome
+          git submodule update --init --no-recursive themes/blowfish
+          git submodule update --init --no-recursive awesome
 
       - name: 🔧 Setup Hugo
         uses: peaceiris/actions-hugo@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,8 +29,8 @@ jobs:
 
       - name: 📥 Init submodules (non-recursive)
         run: |
-          git submodule update --init --no-recursive themes/blowfish
-          git submodule update --init --no-recursive awesome
+          git submodule update --init themes/blowfish
+          git submodule update --init awesome
 
       - name: 🔧 Setup Hugo
         uses: peaceiris/actions-hugo@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@v7
         with:
-          submodules: true
+          submodules: false
           fetch-depth: 0
 
       - name: 🟢 Setup Node.js
@@ -26,6 +26,11 @@ jobs:
         with:
           node-version: '24'
           cache: 'npm'
+
+      - name: 📥 Init submodules (non-recursive)
+        run: |
+          git submodule update --init --no-recurse-submodules themes/blowfish
+          git submodule update --init --no-recurse-submodules awesome
 
       - name: 🔧 Setup Hugo
         uses: peaceiris/actions-hugo@v3

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -35,16 +35,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          submodules: true
+          submodules: false
           fetch-depth: 0
 
-      - name: Init wiki submodule
-        # content/wiki is a git submodule (GitHub Wiki). Ensure it is present
-        # even if checkout's recursive flag missed it.
-        run: git submodule update --init content/wiki
-      - name: Init awesome submodules (sparse README only)
+      - name: Init theme submodule (non-recursive)
+        run: git submodule update --init --no-recurse-submodules themes/blowfish
+
+      - name: Init wiki submodule (non-recursive)
+        # content/wiki is a git submodule (GitHub Wiki). --no-recurse avoids
+        # diving into any nested submodule.
+        run: git submodule update --init --no-recurse-submodules content/wiki
+      - name: Init awesome submodules (non-recursive, sparse README only)
+        # --no-recurse-submodules: we only need each awesome repo's README;
+        # recursing would fail on nested submodules (e.g. open-source-ios-apps/
+        # ReadmeGenerator) absent from our root .gitmodules.
         run: |
-          git submodule update --init awesome
+          git submodule update --init --no-recurse-submodules awesome
           node scripts/ensure-awesome-sparse.cjs || true
 
       - name: Generate wiki navigation

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -39,18 +39,18 @@ jobs:
           fetch-depth: 0
 
       - name: Init theme submodule (non-recursive)
-        run: git submodule update --init --no-recurse-submodules themes/blowfish
+        run: git submodule update --init --no-recursive themes/blowfish
 
       - name: Init wiki submodule (non-recursive)
         # content/wiki is a git submodule (GitHub Wiki). --no-recurse avoids
         # diving into any nested submodule.
-        run: git submodule update --init --no-recurse-submodules content/wiki
+        run: git submodule update --init --no-recursive content/wiki
       - name: Init awesome submodules (non-recursive, sparse README only)
-        # --no-recurse-submodules: we only need each awesome repo's README;
+        # --no-recursive: we only need each awesome repo's README;
         # recursing would fail on nested submodules (e.g. open-source-ios-apps/
         # ReadmeGenerator) absent from our root .gitmodules.
         run: |
-          git submodule update --init --no-recurse-submodules awesome
+          git submodule update --init --no-recursive awesome
           node scripts/ensure-awesome-sparse.cjs || true
 
       - name: Generate wiki navigation

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -39,18 +39,18 @@ jobs:
           fetch-depth: 0
 
       - name: Init theme submodule (non-recursive)
-        run: git submodule update --init --no-recursive themes/blowfish
+        run: git submodule update --init themes/blowfish
 
       - name: Init wiki submodule (non-recursive)
         # content/wiki is a git submodule (GitHub Wiki). --no-recurse avoids
         # diving into any nested submodule.
-        run: git submodule update --init --no-recursive content/wiki
+        run: git submodule update --init content/wiki
       - name: Init awesome submodules (non-recursive, sparse README only)
         # --no-recursive: we only need each awesome repo's README;
         # recursing would fail on nested submodules (e.g. open-source-ios-apps/
         # ReadmeGenerator) absent from our root .gitmodules.
         run: |
-          git submodule update --init --no-recursive awesome
+          git submodule update --init awesome
           node scripts/ensure-awesome-sparse.cjs || true
 
       - name: Generate wiki navigation

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -27,7 +27,7 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@v7
         with:
-          submodules: true
+          submodules: false
           fetch-depth: 0
 
       - name: 🟢 Setup Node.js
@@ -52,6 +52,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-hugo-${{ hashFiles('package-lock.json') }}-
             ${{ runner.os }}-hugo-
+
+      - name: 📥 Init submodules (non-recursive)
+        # Checkout uses submodules:false to avoid recursing into nested
+        # submodules (e.g. awesome/tools/open-source-ios-apps contains a
+        # ReadmeGenerator submodule absent from our .gitmodules -> fatal).
+        # We init only the direct submodules the build needs, non-recursively.
+        run: |
+          git submodule update --init --no-recurse-submodules themes/blowfish
+          git submodule update --init --no-recurse-submodules awesome
 
       - name: 📦 Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -59,8 +59,8 @@ jobs:
         # ReadmeGenerator submodule absent from our .gitmodules -> fatal).
         # We init only the direct submodules the build needs, non-recursively.
         run: |
-          git submodule update --init --no-recurse-submodules themes/blowfish
-          git submodule update --init --no-recurse-submodules awesome
+          git submodule update --init --no-recursive themes/blowfish
+          git submodule update --init --no-recursive awesome
 
       - name: 📦 Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -59,8 +59,8 @@ jobs:
         # ReadmeGenerator submodule absent from our .gitmodules -> fatal).
         # We init only the direct submodules the build needs, non-recursively.
         run: |
-          git submodule update --init --no-recursive themes/blowfish
-          git submodule update --init --no-recursive awesome
+          git submodule update --init themes/blowfish
+          git submodule update --init awesome
 
       - name: 📦 Install dependencies
         run: npm ci --prefer-offline --no-audit --no-fund

--- a/.github/workflows/test-rnd.yml
+++ b/.github/workflows/test-rnd.yml
@@ -71,7 +71,7 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@v7
         with:
-          submodules: true
+          submodules: false
       - name: 🟢 Setup Node.js
         uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
  also recurses into nested submodules, so it dived
into , whose nested  submodule is
absent from our root  -> git exit 128, breaking quality/hugo/e2e builds.

Fix:  in checkout + explicit  init of only the
direct submodules each job needs (themes/blowfish, content/wiki, awesome/*). Verified no
/recursive flags remain across all workflows.