### PR TITLE
fix: malformed YAML in awesome-discover/refresh workflows

### DIFF
--- a/.github/workflows/awesome-discover.yml
+++ b/.github/workflows/awesome-discover.yml
@@ -36,6 +36,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+
       - name: 📥 Init submodules (non-recursive)
         # Checkout uses submodules:false so it won't recurse into nested
         # submodules (e.g. open-source-ios-apps/ReadmeGenerator) absent from our
@@ -43,10 +47,6 @@ jobs:
         run: |
           git submodule update --init themes/blowfish
           git submodule update --init awesome
-
-        uses: actions/setup-node@v7
-        with:
-          node-version: "24"
 
       - name: Discover and add new awesome lists
         env:

--- a/.github/workflows/awesome-refresh.yml
+++ b/.github/workflows/awesome-refresh.yml
@@ -26,12 +26,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
-      - name: 📥 Init awesome submodules (non-recursive)
-        run: git submodule update --init awesome
-
         uses: actions/setup-node@v7
         with:
           node-version: "24"
+
+      - name: 📥 Init awesome submodules (non-recursive)
+        run: git submodule update --init awesome
 
       - name: Refresh awesome submodules + rebuild catalog
         id: refresh


### PR DESCRIPTION
My earlier submodule-init insert accidentally split the  step, orphaning its . That malformed YAML made awesome-discover/refresh fail to run. Restored correct step structure. Quality CI (same submodule+build steps) already passes, so this is purely the workflow shape fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows to use Node.js 24.
  * Improved workflow setup order for more reliable submodule initialization.
  * Removed duplicate Node.js configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->