### PR TITLE
fix(awesome): uniform /awesome/ catalog (drop inline previews)

### DIFF
--- a/layouts/awesome/list.html
+++ b/layouts/awesome/list.html
@@ -48,14 +48,6 @@
               <a class="text-neutral-500 dark:text-neutral-400 hover:underline" href="{{ $repo.gh }}/blob/main/{{ $repo.readme }}" target="_blank" rel="noopener">README ↗</a>
               {{ with $p }}<a class="text-emerald-600 dark:text-emerald-400 hover:underline" href="{{ .RelPermalink }}">Превью →</a>{{ end }}
             </div>
-            {{ with $p }}
-            <details class="mt-3 group/preview">
-              <summary class="cursor-pointer text-xs text-neutral-400 hover:text-primary-600 dark:hover:text-primary-400 select-none">показать превью списка</summary>
-              <div class="mt-2 max-h-80 overflow-auto rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 p-3 text-sm awesome-preview">
-                {{ .Content }}
-              </div>
-            </details>
-            {{ end }}
           </article>
           {{ end }}
         </div>

--- a/scripts/build-awesome.cjs
+++ b/scripts/build-awesome.cjs
@@ -133,6 +133,30 @@ function rewriteRelativeLinks(md, ghUrl, repoPath) {
   });
 }
 
+
+// Balance raw HTML tags so a malformed README (e.g. an unclosed
+// `<div align=center>` banner) can't break the page layout when inlined
+// into a Hugo preview/catalog. Void elements are ignored.
+const VOID = new Set(['area','base','br','col','embed','hr','img','input','link','meta','param','source','track','wbr']);
+function balanceHtmlTags(html) {
+  const stack = [];
+  const re = /<\/?([a-zA-Z][a-zA-Z0-9-]*)(?:\s[^>]*)?\/?>/g;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const raw = m[0];
+    const name = m[1].toLowerCase();
+    if (VOID.has(name)) continue;
+    if (raw.startsWith('</')) {
+      for (let i = stack.length - 1; i >= 0; i--) {
+        if (stack[i] === name) { stack.length = i; break; }
+      }
+    } else if (!raw.endsWith('/>')) {
+      stack.push(name);
+    }
+  }
+  return html + stack.reverse().map((n) => `</${n}>`).join('');
+}
+
 function writePreviews(entries) {
   const keep = new Set();
   for (const e of entries) {
@@ -154,6 +178,9 @@ function writePreviews(entries) {
       // sub-dirs, raw <a href> anchors) at the source repo on GitHub so they
       // don't render as broken internal links on the Hugo site.
       body = rewriteRelativeLinks(body, e.gh, path.join(ROOT, e.path));
+      // Guard against unbalanced raw HTML in the README (banners, tables, etc.)
+      // that would otherwise break the rendered preview/page layout.
+      body = balanceHtmlTags(body);
     } catch (err) {
       body = `_Не удалось прочитать ${e.readme} субмодуля._`;
     }


### PR DESCRIPTION
Makes the /awesome/ catalog uniform.

Problem: the catalog inlined every list's full README inside a per-card
<details> block (1.9 MB page, 54 inlined lists). A malformed README (e.g.
awesome-openclaw-skills has an unclosed <div align=center> banner) leaked
unbalanced HTML into the page flow, breaking the card grid -- the 'spisok,
potom vstavka OpenClaw, potom opiat spisok' reported issue.

Fix:
- layouts/awesome/list.html: remove the inline <details> full-README preview
  from each card. Cards are now a uniform grid linking to a dedicated
  /awesome/<group>/<repo>/ preview page via 'Prevyu ->'.
- scripts/build-awesome.cjs: add balanceHtmlTags() so generated preview pages
  never break from unbalanced raw HTML in a source README.

Verified locally: catalog is 116 KB (was 1.9 MB), 8 group-sections in order,
footer after all sections, zero inline previews, no leaked content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved generated README previews by ensuring HTML tags are properly balanced.
  * Simplified repository listings by removing inline expandable previews.
  * Repository links and available preview-page links remain accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->