### PR TITLE
fix(awesome): remove stray async token breaking catalog build

### DIFF
--- a/scripts/build-awesome.cjs
+++ b/scripts/build-awesome.cjs
@@ -225,7 +225,6 @@ async function fetchRepoMeta(gh) {
     cache[full] = meta; saveMetaCache(cache); return { stars: meta.stars, description: meta.description };
   } catch { return null; }
 }
-async 
 function countCJK(text){const m=(text||'').match(/[\u3400-\u9fff\uf900-\ufaff]/g);return m?m.length:0;}
 function isChineseDominant(text){const cjk=countCJK(text||'');if(cjk<120)return false;const nonWs=(text||'').replace(/\s+/g,'').length||1;return cjk/nonWs>0.05||cjk>300;}
 const LANG_REPLACE={};


### PR DESCRIPTION
The committed build-awesome.cjs contained a stray standalone "async" token (introduced while converting main() to async), causing `ReferenceError: async is not defined` and a failed catalog build/deploy (PR #267). Removed it; node --check passes and the Chinese-list filter works (54 -> 51 lists).