### PR TITLE
fix(ci): deactivate nested ReadmeGenerator submodules (silence recursive fatal)

### DIFF
--- a/.github/workflows/awesome-discover.yml
+++ b/.github/workflows/awesome-discover.yml
@@ -32,6 +32,10 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: false
+      - name: 🛡️ Ignore nested submodules (avoid recursive fatal)
+        run: |
+          git config --global submodule."awesome/tools/open-source-ios-apps/ReadmeGenerator".active false
+          git config --global submodule."awesome/tools/open-source-mac-os-apps/ReadmeGenerator".active false
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/awesome-refresh.yml
+++ b/.github/workflows/awesome-refresh.yml
@@ -22,6 +22,10 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: false
+      - name: 🛡️ Ignore nested submodules (avoid recursive fatal)
+        run: |
+          git config --global submodule."awesome/tools/open-source-ios-apps/ReadmeGenerator".active false
+          git config --global submodule."awesome/tools/open-source-mac-os-apps/ReadmeGenerator".active false
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,6 +20,10 @@ jobs:
         with:
           submodules: false
           fetch-depth: 0
+      - name: 🛡️ Ignore nested submodules (avoid recursive fatal)
+        run: |
+          git config --global submodule."awesome/tools/open-source-ios-apps/ReadmeGenerator".active false
+          git config --global submodule."awesome/tools/open-source-mac-os-apps/ReadmeGenerator".active false
 
       - name: 🟢 Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -36,6 +36,10 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: false
+      - name: 🛡️ Ignore nested submodules (avoid recursive fatal)
+        run: |
+          git config --global submodule."awesome/tools/open-source-ios-apps/ReadmeGenerator".active false
+          git config --global submodule."awesome/tools/open-source-mac-os-apps/ReadmeGenerator".active false
           fetch-depth: 0
 
       - name: Init theme submodule (non-recursive)

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -29,6 +29,10 @@ jobs:
         with:
           submodules: false
           fetch-depth: 0
+      - name: 🛡️ Ignore nested submodules (avoid recursive fatal)
+        run: |
+          git config --global submodule."awesome/tools/open-source-ios-apps/ReadmeGenerator".active false
+          git config --global submodule."awesome/tools/open-source-mac-os-apps/ReadmeGenerator".active false
 
       - name: 🔎 actionlint (workflow YAML structural check)
         run: |


### PR DESCRIPTION
actions/checkout Post Checkout cleanup recurses into the nested ReadmeGenerator submodule present in awesome/tools/open-source-ios-apps and open-source-mac-os-apps (absent from our root .gitmodules), emitting "fatal: No url found ... ReadmeGenerator". The job still succeeds, but it is noisy and a regression of the #261 bug class. Deactivate both nested submodules via git config so any recursive git op (including Post Checkout) skips them. Applied to discover/refresh/e2e/hugo/quality workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated workflow reliability by preventing failures caused by unsupported nested submodules.
  * Updated discovery, refresh, end-to-end, publishing, and quality checks to complete submodule setup more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->