### PR TITLE
fix(ci): clean nested-submodule deactivation step (remove leaked lines)

### DIFF
--- a/.github/workflows/awesome-discover.yml
+++ b/.github/workflows/awesome-discover.yml
@@ -36,8 +36,6 @@ jobs:
         run: |
           git config --global submodule."awesome/tools/open-source-ios-apps/ReadmeGenerator".active false
           git config --global submodule."awesome/tools/open-source-mac-os-apps/ReadmeGenerator".active false
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
         uses: actions/setup-node@v7

--- a/.github/workflows/awesome-refresh.yml
+++ b/.github/workflows/awesome-refresh.yml
@@ -26,8 +26,6 @@ jobs:
         run: |
           git config --global submodule."awesome/tools/open-source-ios-apps/ReadmeGenerator".active false
           git config --global submodule."awesome/tools/open-source-mac-os-apps/ReadmeGenerator".active false
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
         uses: actions/setup-node@v7

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -40,7 +40,6 @@ jobs:
         run: |
           git config --global submodule."awesome/tools/open-source-ios-apps/ReadmeGenerator".active false
           git config --global submodule."awesome/tools/open-source-mac-os-apps/ReadmeGenerator".active false
-          fetch-depth: 0
 
       - name: Init theme submodule (non-recursive)
         run: git submodule update --init themes/blowfish


### PR DESCRIPTION
The deactivation step for nested ReadmeGenerator submodules had fetch-depth: 0 / token lines leaked into its run: script (corruption from the insertion point inside the Checkout with: block). Restored the run: block to exactly the two git config commands. Validated via YAML parse: all 5 workflows now have 2 clean run lines. Prevents exit-code-127 failures in awesome-discover/refresh/hugo.