### PR TITLE
fix: declare nested ReadmeGenerator submodules inactive (silence recursive fatal)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -167,3 +167,12 @@
 [submodule "awesome/tools/tvlist-awesome-m3u-m3u8"]
 	path = awesome/tools/tvlist-awesome-m3u-m3u8
 	url = https://github.com/imDazui/Tvlist-awesome-m3u-m3u8
+
+[submodule "awesome/tools/open-source-mac-os-apps/ReadmeGenerator"]
+	path = awesome/tools/open-source-mac-os-apps/ReadmeGenerator
+	url = https://github.com/serhii-londar/open-source-mac-os-apps
+	active = false
+[submodule "awesome/tools/open-source-ios-apps/ReadmeGenerator"]
+	path = awesome/tools/open-source-ios-apps/ReadmeGenerator
+	url = https://github.com/dkhamsing/open-source-ios-apps
+	active = false


### PR DESCRIPTION
Post Checkout cleanup in actions/checkout recurses into the nested ReadmeGenerator submodule present inside awesome/tools/open-source-mac-os-apps and open-source-ios-apps. Since that nested path is absent from our root .gitmodules, git emits "fatal: No url found ... ReadmeGenerator". Declare both nested paths in .gitmodules with active=false so recursive ops skip them. Non-blocking (job still succeeds) but silences the warning and hardens the autopilot.