### PR TITLE
revert: drop nested ReadmeGenerator .gitmodules entries

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -168,11 +168,3 @@
 	path = awesome/tools/tvlist-awesome-m3u-m3u8
 	url = https://github.com/imDazui/Tvlist-awesome-m3u-m3u8
 
-[submodule "awesome/tools/open-source-mac-os-apps/ReadmeGenerator"]
-	path = awesome/tools/open-source-mac-os-apps/ReadmeGenerator
-	url = https://github.com/serhii-londar/open-source-mac-os-apps
-	active = false
-[submodule "awesome/tools/open-source-ios-apps/ReadmeGenerator"]
-	path = awesome/tools/open-source-ios-apps/ReadmeGenerator
-	url = https://github.com/dkhamsing/open-source-ios-apps
-	active = false


### PR DESCRIPTION
The .gitmodules entries added in #271 used the parent repo URL for the nested ReadmeGenerator path, which made git submodule update emit "No such file or directory" during catalog rebuild. The original Post Checkout "No url found" fatal is benign (the job still succeeds) and pre-existed this work. Removing the misleading entries restores the clean state. The deactivation step in the workflows (active=false) remains as a best-effort guard.