### PR TITLE
fix(ci): update=none + recurse=false for nested ReadmeGenerator submodules

### DIFF
--- a/.github/workflows/awesome-discover.yml
+++ b/.github/workflows/awesome-discover.yml
@@ -36,6 +36,9 @@ jobs:
         run: |
           git config --global submodule."awesome/tools/open-source-ios-apps/ReadmeGenerator".active false
           git config --global submodule."awesome/tools/open-source-mac-os-apps/ReadmeGenerator".active false
+          git config --global submodule."awesome/tools/open-source-ios-apps/ReadmeGenerator".update none
+          git config --global submodule."awesome/tools/open-source-mac-os-apps/ReadmeGenerator".update none
+          git config --global submodule.recurse false
 
       - name: Setup Node
         uses: actions/setup-node@v7

--- a/.github/workflows/awesome-refresh.yml
+++ b/.github/workflows/awesome-refresh.yml
@@ -26,6 +26,9 @@ jobs:
         run: |
           git config --global submodule."awesome/tools/open-source-ios-apps/ReadmeGenerator".active false
           git config --global submodule."awesome/tools/open-source-mac-os-apps/ReadmeGenerator".active false
+          git config --global submodule."awesome/tools/open-source-ios-apps/ReadmeGenerator".update none
+          git config --global submodule."awesome/tools/open-source-mac-os-apps/ReadmeGenerator".update none
+          git config --global submodule.recurse false
 
       - name: Setup Node
         uses: actions/setup-node@v7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,6 +24,9 @@ jobs:
         run: |
           git config --global submodule."awesome/tools/open-source-ios-apps/ReadmeGenerator".active false
           git config --global submodule."awesome/tools/open-source-mac-os-apps/ReadmeGenerator".active false
+          git config --global submodule."awesome/tools/open-source-ios-apps/ReadmeGenerator".update none
+          git config --global submodule."awesome/tools/open-source-mac-os-apps/ReadmeGenerator".update none
+          git config --global submodule.recurse false
 
       - name: 🟢 Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -40,6 +40,9 @@ jobs:
         run: |
           git config --global submodule."awesome/tools/open-source-ios-apps/ReadmeGenerator".active false
           git config --global submodule."awesome/tools/open-source-mac-os-apps/ReadmeGenerator".active false
+          git config --global submodule."awesome/tools/open-source-ios-apps/ReadmeGenerator".update none
+          git config --global submodule."awesome/tools/open-source-mac-os-apps/ReadmeGenerator".update none
+          git config --global submodule.recurse false
 
       - name: Init theme submodule (non-recursive)
         run: git submodule update --init themes/blowfish

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -33,6 +33,9 @@ jobs:
         run: |
           git config --global submodule."awesome/tools/open-source-ios-apps/ReadmeGenerator".active false
           git config --global submodule."awesome/tools/open-source-mac-os-apps/ReadmeGenerator".active false
+          git config --global submodule."awesome/tools/open-source-ios-apps/ReadmeGenerator".update none
+          git config --global submodule."awesome/tools/open-source-mac-os-apps/ReadmeGenerator".update none
+          git config --global submodule.recurse false
 
       - name: 🔎 actionlint (workflow YAML structural check)
         run: |


### PR DESCRIPTION
Expands the nested-submodule guard: in addition to active=false, set update=none (git will not try to fetch/update the nested ReadmeGenerator path during recursive ops) and submodule.recurse=false (no implicit recursion). Targets the benign "fatal: No url found ... ReadmeGenerator" emitted by actions/checkout Post Checkout cleanup. Job still succeeds either way; this just silences the warning.