### PR TITLE
fix(css): reserve avatar box (aspect-ratio) to eliminate CLS on /about/

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -254,6 +254,14 @@ input:focus-visible,
 }
 .about-avatar { position: relative; width: 112px; height: 112px; flex: 0 0 auto; }
 .about-avatar .avatar-image { width: 100%; height: 100%; object-fit: cover; border-radius: 50%;
+
+/* CLS fix (Performance Monitoring regression): reserve avatar box before the
+   SVG loads so the image doesn't shift layout. See .about-avatar (112x112). */
+.about-avatar { aspect-ratio: 1 / 1; }
+.about-avatar .avatar-image { width: 100%; height: 100%; aspect-ratio: 1 / 1; object-fit: cover; }
+/* global safety: never let an unsized image collapse its container */
+img { height: auto; }
+
   border: 2px solid rgba(var(--ring), .6); box-shadow: 0 0 0 4px rgba(var(--ring), .12); }
 .about-avatar .avatar-placeholder { display: none; }
 .about-header-content { flex: 1 1 16rem; min-width: 0; }


### PR DESCRIPTION
Performance Monitoring (Lighthouse) fails on main: /about/ CLS=0.123 (budget <=0.1, hard error). Root cause: <img src=/images/avatar.svg> has no width/height, so the 112x112 .about-avatar container collapses until the SVG loads, shifting layout. Fix reserves the box via aspect-ratio:1/1 on .avatar-image (plus global img{height:auto} safety). Pure CSS in custom.css — no theme submodule changes. Expects CLS -> ~0 on /about/.