### PR TITLE
feat: separable presentation layer (themes, category menu, tag-cloud footer, settings)

### DIFF
--- a/assets/css/neo.css
+++ b/assets/css/neo.css
@@ -1,10 +1,13 @@
 /* ===========================================================================
-   Neo Design System — single source of truth for the full-site redesign.
-   Dark by default via :root; light via [data-theme="light"] on <html>.
-   Namespaced under .neo-* so it never collides with Blowfish / movie-grid.
+   Neo Design System — presentation layer (fully separable from content).
+   Themes are pure CSS custom properties keyed by [data-theme] on <html>;
+   accents by [data-accent]. Switching is a runtime attribute change with
+   zero content edits. Components are namespaced under .neo-*.
    =========================================================================== */
 
-:root{
+/* ---------- THEME TOKENS ---------- */
+:root,
+[data-theme="dark"]{
   --bg:#0b0e14; --bg-2:#10141d; --panel:#151a26; --panel-2:#1b2231;
   --line:#232c3d; --line-2:#2c374c;
   --text:#e6eaf2; --muted:#93a0b5; --faint:#5d6a80;
@@ -12,6 +15,8 @@
   --mono:"JetBrains Mono","SF Mono",ui-monospace,Menlo,Consolas,monospace;
   --sans:"Inter",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
   --radius:14px; --shadow:0 20px 50px -20px rgba(0,0,0,.6);
+  --grid:rgba(255,255,255,.025);
+  color-scheme: dark;
 }
 [data-theme="light"]{
   --bg:#f6f8fb; --bg-2:#eef1f6; --panel:#ffffff; --panel-2:#f1f4f9;
@@ -19,89 +24,118 @@
   --text:#0f172a; --muted:#475569; --faint:#94a3b8;
   --accent:#0d9488; --accent-2:#0284c7; --violet:#7c3aed;
   --shadow:0 20px 50px -20px rgba(15,23,42,.15);
+  --grid:rgba(15,23,42,.03);
+  color-scheme: light;
 }
+[data-theme="solar"]{
+  --bg:#1c1917; --bg-2:#292524; --panel:#292524; --panel-2:#3a3531;
+  --line:#44403c; --line-2:#57534e;
+  --text:#fef3c7; --muted:#d6c3a3; --faint:#a89167;
+  --accent:#fbbf24; --accent-2:#fb923c; --violet:#c084fc;
+  --shadow:0 20px 50px -20px rgba(0,0,0,.6);
+  --grid:rgba(251,191,36,.04);
+  color-scheme: dark;
+}
+[data-theme="mono"]{
+  --bg:#0a0a0a; --bg-2:#111; --panel:#141414; --panel-2:#1c1c1c;
+  --line:#262626; --line-2:#333;
+  --text:#e5e5e5; --muted:#a3a3a3; --faint:#666;
+  --accent:#e5e5e5; --accent-2:#bdbdbd; --violet:#d4d4d4;
+  --shadow:0 20px 50px -20px rgba(0,0,0,.8);
+  --grid:rgba(255,255,255,.03);
+  color-scheme: dark;
+}
+/* Accents */
+[data-accent="teal"]{--accent:#4fd1c5;--accent-2:#7dd3fc;--violet:#a78bfa}
+[data-accent="violet"]{--accent:#a78bfa;--accent-2:#c4b5fd}
+[data-accent="amber"]{--accent:#fbbf24;--accent-2:#fcd34d}
+[data-accent="emerald"]{--accent:#34d399;--accent-2:#6ee7b7}
+[data-accent="rose"]{--accent:#fb7185;--accent-2:#fda4af}
 
-.neo{
-  color:var(--text); font-family:var(--sans); line-height:1.65;
-  -webkit-font-smoothing:antialiased; overflow-x:hidden;
-}
-.neo *{box-sizing:border-box;margin:0;padding:0}
-.neo a{color:inherit;text-decoration:none}
+/* Font scale (accessibility) */
+:root{--fs:1}
+html[data-fscale="large"]{--fs:1.12}
+html[data-fscale="xlarge"]{--fs:1.25}
+
+/* ---------- BASE ---------- */
+* { box-sizing:border-box; margin:0; padding:0; }
 body{
   background:var(--bg); color:var(--text); font-family:var(--sans);
-  line-height:1.65; -webkit-font-smoothing:antialiased; overflow-x:hidden;
-  transition:background .3s,color .3s;
+  font-size:calc(16px * var(--fs)); line-height:1.65;
+  -webkit-font-smoothing:antialiased; overflow-x:hidden;
+  transition:background .3s, color .3s;
 }
 a{color:inherit;text-decoration:none}
 body::before{
   content:"";position:fixed;inset:0;z-index:-2;
   background:
-    radial-gradient(900px 500px at 85% -10%,rgba(79,209,197,.10),transparent 60%),
-    radial-gradient(700px 500px at 0% 10%,rgba(167,139,250,.08),transparent 55%),
+    radial-gradient(900px 500px at 85% -10%,color-mix(in srgb,var(--accent) 12%,transparent),transparent 60%),
+    radial-gradient(700px 500px at 0% 10%,color-mix(in srgb,var(--violet) 9%,transparent),transparent 55%),
     var(--bg);
 }
 body::after{
   content:"";position:fixed;inset:0;z-index:-1;pointer-events:none;
-  background-image:linear-gradient(rgba(255,255,255,.025) 1px,transparent 1px),
-                   linear-gradient(90deg,rgba(255,255,255,.025) 1px,transparent 1px);
+  background-image:linear-gradient(var(--grid) 1px,transparent 1px),
+                   linear-gradient(90deg,var(--grid) 1px,transparent 1px);
   background-size:44px 44px;
   -webkit-mask-image:radial-gradient(ellipse at 50% 0%,#000 30%,transparent 75%);
           mask-image:radial-gradient(ellipse at 50% 0%,#000 30%,transparent 75%);
 }
-[data-theme="light"] body::before{
-  background:
-    radial-gradient(900px 500px at 85% -10%,rgba(13,148,136,.10),transparent 60%),
-    radial-gradient(700px 500px at 0% 10%,rgba(124,58,237,.07),transparent 55%),
-    var(--bg);
+@media (prefers-reduced-motion: reduce){
+  *{animation:none !important; transition:none !important; scroll-behavior:auto !important}
 }
-[data-theme="light"] body::after{
-  background-image:linear-gradient(rgba(15,23,42,.03) 1px,transparent 1px),
-                   linear-gradient(90deg,rgba(15,23,42,.03) 1px,transparent 1px);
-}
+html[data-reduce-motion="true"] *{animation:none !important; transition:none !important; scroll-behavior:auto !important}
 
-/* Accent variants */
-.neo[data-accent="violet"]{--accent:#a78bfa;--accent-2:#c4b5fd}
-.neo[data-accent="amber"]{--accent:#fbbf24;--accent-2:#fcd34d}
-.neo[data-accent="emerald"]{--accent:#34d399;--accent-2:#6ee7b7}
-
-/* Header */
+/* ---------- HEADER + MENU (categories from data) ---------- */
 .neo-header{position:sticky;top:0;z-index:50;backdrop-filter:blur(12px);
-  background:rgba(11,14,20,.72);border-bottom:1px solid var(--line)}
-[data-theme="light"] .neo-header{background:rgba(246,248,251,.78)}
+  background:color-mix(in srgb,var(--bg) 72%,transparent);border-bottom:1px solid var(--line)}
 .neo-nav{max-width:1180px;margin:0 auto;padding:0 24px;height:64px;
-  display:flex;align-items:center;justify-content:space-between}
-.neo-brand{display:flex;align-items:center;gap:12px;font-weight:700;letter-spacing:.3px}
+  display:flex;align-items:center;justify-content:space-between;gap:16px}
+.neo-brand{display:flex;align-items:center;gap:12px;font-weight:700;letter-spacing:.3px;white-space:nowrap}
 .neo-brand .mark{width:34px;height:34px;border-radius:9px;display:grid;place-items:center;
   background:linear-gradient(135deg,var(--accent),var(--accent-2));color:#07121a;
-  font-family:var(--mono);font-weight:700;font-size:15px;
-  box-shadow:0 6px 18px -6px color-mix(in srgb,var(--accent) 60%,transparent)}
+  font-family:var(--mono);font-weight:700;font-size:15px}
 .neo-brand small{display:block;font-weight:500;color:var(--muted);font-size:11px;letter-spacing:.5px}
-.neo-links{display:flex;align-items:center;gap:26px;font-size:14px;color:var(--muted)}
-.neo-links a{transition:color .2s}.neo-links a:hover{color:var(--text)}
-.neo-nav-actions{display:flex;align-items:center;gap:12px}
-.neo-theme,.neo-icon-btn{background:var(--panel);border:1px solid var(--line-2);border-radius:8px;
-  width:34px;height:34px;cursor:pointer;font-size:15px;transition:transform .2s,color .2s;color:var(--text)}
-.neo-theme:hover,.neo-icon-btn:hover{transform:scale(1.08);color:var(--accent)}
+.neo-menu{display:flex;align-items:center;gap:4px;overflow-x:auto;flex:1}
+.neo-menu a{padding:7px 12px;border-radius:8px;font-size:14px;color:var(--muted);white-space:nowrap;transition:color .2s,background .2s}
+.neo-menu a:hover{color:var(--text);background:var(--panel)}
+.neo-nav-actions{display:flex;align-items:center;gap:8px}
+.neo-icon-btn{background:var(--panel);border:1px solid var(--line-2);border-radius:8px;width:36px;height:36px;
+  cursor:pointer;font-size:15px;color:var(--text);transition:transform .2s,color .2s,background .2s}
+.neo-icon-btn:hover{transform:scale(1.06);color:var(--accent)}
 
-/* Hero */
-.neo-hero{max-width:1180px;margin:0 auto;padding:88px 24px 40px;
-  display:grid;grid-template-columns:1.2fr .8fr;gap:48px;align-items:center}
-.neo-eyebrow{font-family:var(--mono);font-size:12.5px;color:var(--accent);
-  display:inline-flex;align-items:center;gap:9px;margin-bottom:20px}
+/* Settings drawer */
+.neo-settings{position:relative}
+.neo-drawer{position:absolute;right:0;top:48px;width:280px;background:var(--panel);border:1px solid var(--line-2);
+  border-radius:var(--radius);box-shadow:var(--shadow);padding:18px;display:none;z-index:60;font-size:14px}
+.neo-drawer.open{display:block}
+.neo-drawer h5{font-family:var(--mono);font-size:11px;color:var(--accent);letter-spacing:1px;text-transform:uppercase;margin:14px 0 8px}
+.neo-drawer h5:first-child{margin-top:0}
+.neo-theme-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:8px}
+.neo-theme-opt,.neo-accent-opt{display:flex;align-items:center;gap:8px;padding:8px 10px;border:1px solid var(--line-2);
+  border-radius:8px;cursor:pointer;color:var(--muted);transition:border-color .2s,color .2s}
+.neo-theme-opt.active,.neo-accent-opt.active{border-color:var(--accent);color:var(--text)}
+.neo-sw{width:16px;height:16px;border-radius:4px;border:1px solid var(--line-2)}
+.neo-accent-grid{display:flex;gap:8px;flex-wrap:wrap}
+.neo-accent-opt{width:32px;height:32px;padding:0;justify-content:center}
+.neo-row-opt{display:flex;align-items:center;justify-content:space-between;padding:6px 0;color:var(--muted)}
+.neo-seg{display:flex;border:1px solid var(--line-2);border-radius:8px;overflow:hidden}
+.neo-seg button{background:var(--panel);border:none;color:var(--muted);padding:6px 10px;cursor:pointer;font-size:12px;font-family:var(--mono)}
+.neo-seg button.active{background:var(--accent);color:#07121a}
+
+/* ---------- HERO ---------- */
+.neo-hero{max-width:1180px;margin:0 auto;padding:88px 24px 40px;display:grid;grid-template-columns:1.2fr .8fr;gap:48px;align-items:center}
+.neo-eyebrow{font-family:var(--mono);font-size:12.5px;color:var(--accent);display:inline-flex;align-items:center;gap:9px;margin-bottom:20px}
 .neo-eyebrow::before{content:"";width:26px;height:1px;background:var(--accent);opacity:.6}
 .neo-hero h1{font-size:clamp(34px,5vw,58px);line-height:1.05;font-weight:800;letter-spacing:-1.5px;margin-bottom:22px}
-.neo-hero h1 .grad{background:linear-gradient(100deg,var(--accent) 10%,var(--accent-2) 50%,var(--violet) 90%);
-  -webkit-background-clip:text;background-clip:text;color:transparent}
+.neo-hero h1 .grad{background:linear-gradient(100deg,var(--accent) 10%,var(--accent-2) 50%,var(--violet) 90%);-webkit-background-clip:text;background-clip:text;color:transparent}
 .neo-hero p.lead{color:var(--muted);font-size:17.5px;max-width:56ch}
 .neo-tags{display:flex;flex-wrap:wrap;gap:8px;margin-top:26px}
-.neo-chip{font-family:var(--mono);font-size:12px;color:var(--muted);
-  border:1px solid var(--line-2);padding:5px 12px;border-radius:999px;background:var(--panel)}
+.neo-chip{font-family:var(--mono);font-size:12px;color:var(--muted);border:1px solid var(--line-2);padding:5px 12px;border-radius:999px;background:var(--panel)}
 .neo-chip b{color:var(--accent);font-weight:600}
 
-.neo-term{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);
-  box-shadow:var(--shadow);overflow:hidden}
-.neo-term-bar{display:flex;align-items:center;gap:8px;padding:12px 16px;
-  background:var(--panel-2);border-bottom:1px solid var(--line)}
+.neo-term{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);overflow:hidden}
+.neo-term-bar{display:flex;align-items:center;gap:8px;padding:12px 16px;background:var(--panel-2);border-bottom:1px solid var(--line)}
 .neo-dot{width:11px;height:11px;border-radius:50%}
 .neo-term-bar .path{font-family:var(--mono);font-size:12px;color:var(--faint);margin-left:8px}
 .neo-term-body{padding:22px;font-family:var(--mono);font-size:13.5px;color:var(--muted)}
@@ -111,19 +145,18 @@ body::after{
 .neo-cursor{display:inline-block;width:8px;height:15px;background:var(--accent);vertical-align:-2px;animation:neo-blink 1s steps(1) infinite}
 @keyframes neo-blink{50%{opacity:0}}
 
-/* Sections */
+/* ---------- SECTIONS ---------- */
 .neo-wrap{max-width:1180px;margin:0 auto;padding:56px 24px}
-.neo-sec-head{display:flex;align-items:baseline;justify-content:space-between;margin-bottom:28px}
+.neo-sec-head{display:flex;align-items:baseline;justify-content:space-between;margin-bottom:28px;gap:12px;flex-wrap:wrap}
 .neo-sec-head h2{font-size:22px;font-weight:700;letter-spacing:-.3px;display:flex;align-items:center;gap:12px}
 .neo-sec-head h2::before{content:"//";font-family:var(--mono);color:var(--accent);font-size:18px}
 .neo-sec-head .more{font-family:var(--mono);font-size:13px;color:var(--muted);transition:color .2s}
 .neo-sec-head .more:hover{color:var(--accent)}
 
-/* Featured */
+/* Featured cards */
 .neo-featured{display:grid;grid-template-columns:repeat(3,1fr);gap:20px}
-.neo-card{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);
-  padding:24px;display:flex;flex-direction:column;gap:14px;
-  transition:transform .25s,border-color .25s,background .25s}
+.neo-card{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);padding:24px;
+  display:flex;flex-direction:column;gap:14px;transition:transform .25s,border-color .25s,background .25s}
 .neo-card:hover{transform:translateY(-5px);border-color:var(--line-2);background:var(--panel-2)}
 .neo-card .meta{font-family:var(--mono);font-size:12px;color:var(--faint);display:flex;gap:10px;align-items:center}
 .neo-card .meta .cat{color:var(--accent)}
@@ -135,40 +168,33 @@ body::after{
 
 /* Rows */
 .neo-rows{display:flex;flex-direction:column;border-top:1px solid var(--line)}
-.neo-row{display:grid;grid-template-columns:150px 1fr auto;gap:24px;align-items:center;
-  padding:18px 6px;border-bottom:1px solid var(--line);transition:background .2s;text-decoration:none}
-.neo-row:hover{background:rgba(255,255,255,.02)}
-[data-theme="light"] .neo-row:hover{background:rgba(15,23,42,.02)}
+.neo-row{display:grid;grid-template-columns:150px 1fr auto;gap:24px;align-items:center;padding:18px 6px;
+  border-bottom:1px solid var(--line);transition:background .2s;text-decoration:none}
+.neo-row:hover{background:color-mix(in srgb,var(--accent) 6%,transparent)}
 .neo-row .date{font-family:var(--mono);font-size:12.5px;color:var(--faint)}
 .neo-row .title{font-weight:600;font-size:15.5px;transition:color .2s}
 .neo-row:hover .title{color:var(--accent)}
 .neo-row .tag{font-family:var(--mono);font-size:11.5px;color:var(--muted);border:1px solid var(--line-2);padding:3px 10px;border-radius:999px;white-space:nowrap}
 
-/* Categories */
+/* Categories grid */
 .neo-cats{display:grid;grid-template-columns:repeat(4,1fr);gap:16px}
-.neo-cat{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);
-  padding:20px;transition:transform .2s,border-color .2s;text-decoration:none;display:block}
+.neo-cat{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);padding:20px;transition:transform .2s,border-color .2s;text-decoration:none;display:block}
 .neo-cat:hover{transform:translateY(-4px);border-color:var(--accent)}
 .neo-cat .ico{font-size:22px;margin-bottom:12px}
 .neo-cat h4{font-size:15px;font-weight:700;margin-bottom:4px}
 .neo-cat span{font-family:var(--mono);font-size:12px;color:var(--faint)}
 
 /* Newsletter */
-.neo-news{background:linear-gradient(135deg,var(--panel-2),var(--panel));
-  border:1px solid var(--line-2);border-radius:var(--radius);
-  padding:44px;display:grid;grid-template-columns:1.2fr .8fr;gap:32px;align-items:center}
+.neo-news{background:linear-gradient(135deg,var(--panel-2),var(--panel));border:1px solid var(--line-2);border-radius:var(--radius);padding:44px;display:grid;grid-template-columns:1.2fr .8fr;gap:32px;align-items:center}
 .neo-news h3{font-size:24px;letter-spacing:-.4px;margin-bottom:10px}
 .neo-news p{color:var(--muted);font-size:14.5px}
 .neo-news form{display:flex;gap:10px}
-.neo-news input{flex:1;background:var(--bg);border:1px solid var(--line-2);border-radius:10px;
-  padding:13px 16px;color:var(--text);font-family:var(--mono);font-size:13.5px;outline:none;transition:border-color .2s}
+.neo-news input{flex:1;background:var(--bg);border:1px solid var(--line-2);border-radius:10px;padding:13px 16px;color:var(--text);font-family:var(--mono);font-size:13.5px;outline:none;transition:border-color .2s}
 .neo-news input:focus{border-color:var(--accent)}
-.neo-news button{background:linear-gradient(135deg,var(--accent),var(--accent-2));color:#07121a;
-  border:none;border-radius:10px;padding:13px 22px;font-weight:700;cursor:pointer;
-  font-family:var(--mono);font-size:13.5px;transition:filter .2s,transform .2s}
+.neo-news button{background:linear-gradient(135deg,var(--accent),var(--accent-2));color:#07121a;border:none;border-radius:10px;padding:13px 22px;font-weight:700;cursor:pointer;font-family:var(--mono);font-size:13.5px;transition:filter .2s,transform .2s}
 .neo-news button:hover{filter:brightness(1.08);transform:translateY(-1px)}
 
-/* Post page */
+/* ---------- POST ---------- */
 .neo-post{max-width:1180px;margin:0 auto;padding:56px 24px}
 .neo-post-head{margin-bottom:36px}
 .neo-post-head h1{font-size:clamp(28px,4vw,44px);letter-spacing:-1px}
@@ -182,88 +208,77 @@ body::after{
 .neo-post-body a:hover{border-color:var(--accent)}
 .neo-post-body ul,.neo-post-body ol{margin:16px 0;padding-left:24px}
 .neo-post-body li{margin:6px 0}
-.neo-post-body pre{background:var(--bg-2);border:1px solid var(--line);border-radius:10px;
-  padding:18px;overflow-x:auto;font-family:var(--mono);font-size:13.5px;margin:20px 0}
+.neo-post-body pre{background:var(--bg-2);border:1px solid var(--line);border-radius:10px;padding:18px;overflow-x:auto;font-family:var(--mono);font-size:13.5px;margin:20px 0}
 .neo-post-body code{font-family:var(--mono);font-size:.9em;background:var(--panel-2);padding:2px 6px;border-radius:5px}
 .neo-post-body pre code{background:none;padding:0}
-.neo-post-body blockquote{border-left:3px solid var(--accent);padding:4px 0 4px 20px;
-  color:var(--muted);margin:20px 0;font-style:italic}
+.neo-post-body blockquote{border-left:3px solid var(--accent);padding:4px 0 4px 20px;color:var(--muted);margin:20px 0;font-style:italic}
 .neo-post-body img{max-width:100%;border-radius:10px;border:1px solid var(--line);margin:20px 0}
 .neo-post-body hr{border:none;border-top:1px solid var(--line);margin:32px 0}
 
-/* Breadcrumbs */
+/* Crumbs / meta / TOC / share / related / pager (existing) */
 .neo-crumbs{font-family:var(--mono);font-size:12.5px;color:var(--faint);margin-bottom:20px;display:flex;gap:8px;flex-wrap:wrap}
 .neo-crumbs a:hover{color:var(--accent)}
-
-/* Post meta */
 .neo-post-meta{font-family:var(--mono);font-size:12.5px;color:var(--faint);margin-top:14px}
-
-/* TOC */
 .neo-toc-wrap{margin:28px 0}
 .neo-toc{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);padding:18px 22px;max-width:760px}
 .neo-toc h4{font-family:var(--mono);font-size:12px;color:var(--accent);letter-spacing:1px;margin-bottom:10px;text-transform:uppercase}
-.neo-toc ul{list-style:none;padding-left:0}
-.neo-toc li{margin:4px 0}
-.neo-toc a{color:var(--muted);font-size:14px}
-.neo-toc a:hover{color:var(--accent)}
-.neo-toc ul ul{padding-left:18px}
-
-/* Share */
+.neo-toc ul{list-style:none;padding-left:0}.neo-toc li{margin:4px 0}.neo-toc a{color:var(--muted);font-size:14px}.neo-toc a:hover{color:var(--accent)}.neo-toc ul ul{padding-left:18px}
 .neo-share{display:flex;align-items:center;gap:10px;margin:36px 0;flex-wrap:wrap;font-family:var(--mono);font-size:13px}
 .neo-share span{color:var(--faint)}
 .neo-share a{border:1px solid var(--line-2);border-radius:8px;padding:6px 12px;color:var(--muted);transition:color .2s,border-color .2s}
 .neo-share a:hover{color:var(--accent);border-color:var(--accent)}
-
-/* Related */
 .neo-related{margin-top:44px}
-
-/* Pagination */
 .neo-pager{display:flex;align-items:center;justify-content:center;gap:8px;margin:40px 0 8px;flex-wrap:wrap}
-.neo-pager a,.neo-pager span{font-family:var(--mono);font-size:13px;padding:8px 14px;
-  border:1px solid var(--line-2);border-radius:8px;color:var(--muted);text-decoration:none}
+.neo-pager a,.neo-pager span{font-family:var(--mono);font-size:13px;padding:8px 14px;border:1px solid var(--line-2);border-radius:8px;color:var(--muted);text-decoration:none}
 .neo-pager a:hover{border-color:var(--accent);color:var(--accent)}
 .neo-pager .current{background:var(--accent);color:#07121a;border-color:var(--accent);font-weight:700}
 
-/* Tag cloud */
-.neo-tagcloud{display:flex;flex-wrap:wrap;gap:10px;align-items:center}
-.neo-tagcloud .neo-chip{font-size:13px}
-.neo-tagcloud .count{color:var(--accent);font-weight:600}
+/* View counter + giscus wrapper */
+.neo-views{font-family:var(--mono);font-size:12.5px;color:var(--faint);margin-top:6px}
+.neo-giscus{margin-top:40px}
+
+/* Year archive / wiki / sitemap (existing) */
+.neo-year{font-family:var(--mono);font-size:20px;color:var(--accent);margin:32px 0 8px;letter-spacing:1px}
+.neo-wiki{display:grid;grid-template-columns:220px 1fr;gap:32px;align-items:start}
+.neo-wiki-side{position:sticky;top:84px;display:flex;flex-direction:column;gap:8px;border:1px solid var(--line);border-radius:var(--radius);padding:18px;background:var(--panel)}
+.neo-wiki-side h4{font-family:var(--mono);font-size:12px;color:var(--accent);letter-spacing:1px;text-transform:uppercase;margin-bottom:6px}
+.neo-wiki-side a{font-size:14px;color:var(--muted);padding:4px 0}.neo-wiki-side a:hover{color:var(--accent)}
+.neo-sitemap{display:grid;grid-template-columns:repeat(2,1fr);gap:28px;margin-top:20px}
+.neo-sitemap .col h4{font-family:var(--mono);font-size:12px;color:var(--accent);letter-spacing:1px;text-transform:uppercase;margin-bottom:12px}
+.neo-sitemap .col a{display:block;color:var(--muted);font-size:14px;padding:5px 0;border-bottom:1px solid var(--line)}.neo-sitemap .col a:hover{color:var(--accent)}
 
 /* Search */
-.neo-search-input{width:100%;background:var(--bg);border:1px solid var(--line-2);border-radius:10px;
-  padding:14px 18px;color:var(--text);font-family:var(--mono);font-size:15px;outline:none;margin-bottom:24px}
+.neo-search-input{width:100%;background:var(--bg);border:1px solid var(--line-2);border-radius:10px;padding:14px 18px;color:var(--text);font-family:var(--mono);font-size:15px;outline:none;margin-bottom:24px}
 .neo-search-input:focus{border-color:var(--accent)}
 .neo-search-empty{color:var(--faint);font-size:14px}
 
 /* 404 */
-.neo-notfound{text-align:center;padding-top:80px}
-.neo-notfound h1{font-size:clamp(40px,7vw,72px)}
-.neo-nf-suggestion{margin:18px 0;font-size:16px;color:var(--muted)}
-.neo-nf-suggestion a{color:var(--accent-2);border-bottom:1px solid var(--line-2)}
+.neo-notfound{text-align:center;padding-top:80px}.neo-notfound h1{font-size:clamp(40px,7vw,72px)}
+.neo-nf-suggestion{margin:18px 0;font-size:16px;color:var(--muted)}.neo-nf-suggestion a{color:var(--accent-2);border-bottom:1px solid var(--line-2)}
 
 /* Back to top */
-#neo-backtotop{position:fixed;right:24px;bottom:24px;z-index:60;width:46px;height:46px;border-radius:12px;
-  border:1px solid var(--line-2);background:var(--panel);color:var(--accent);font-size:20px;cursor:pointer;
-  opacity:0;pointer-events:none;transform:translateY(10px);transition:opacity .25s,transform .25s}
-#neo-backtotop.show{opacity:1;pointer-events:auto;transform:translateY(0)}
-#neo-backtotop:hover{background:var(--panel-2)}
+#neo-backtotop{position:fixed;right:24px;bottom:24px;z-index:60;width:46px;height:46px;border-radius:12px;border:1px solid var(--line-2);background:var(--panel);color:var(--accent);font-size:20px;cursor:pointer;opacity:0;pointer-events:none;transform:translateY(10px);transition:opacity .25s,transform .25s}
+#neo-backtotop.show{opacity:1;pointer-events:auto;transform:translateY(0)}#neo-backtotop:hover{background:var(--panel-2)}
 
-/* Footer */
+/* ---------- FOOTER (tag cloud from data) ---------- */
 .neo-footer{border-top:1px solid var(--line);margin-top:40px}
 .neo-foot{max-width:1180px;margin:0 auto;padding:40px 24px;display:flex;justify-content:space-between;gap:24px;flex-wrap:wrap}
 .neo-foot p{color:var(--faint);font-size:13px}
 .neo-foot-cols{display:flex;gap:48px}
 .neo-foot-col{display:flex;flex-direction:column;gap:8px}
 .neo-foot-col h5{font-family:var(--mono);font-size:12px;color:var(--accent);letter-spacing:1px;text-transform:uppercase;margin-bottom:4px}
-.neo-foot-col a{font-size:13.5px;color:var(--muted)}
-.neo-foot-col a:hover{color:var(--accent)}
+.neo-foot-col a{font-size:13.5px;color:var(--muted)}.neo-foot-col a:hover{color:var(--accent)}
+.neo-tagcloud-foot{max-width:1180px;margin:0 auto;padding:0 24px 40px;display:flex;flex-wrap:wrap;gap:10px;align-items:center}
+.neo-tagcloud-foot .neo-tc{color:var(--muted);border:1px solid var(--line-2);border-radius:999px;padding:4px 12px;transition:color .2s,border-color .2s}
+.neo-tagcloud-foot .neo-tc:hover{color:var(--accent);border-color:var(--accent)}
 
+/* ---------- RESPONSIVE ---------- */
 @media(max-width:900px){
   .neo-hero{grid-template-columns:1fr;padding-top:56px}
   .neo-featured{grid-template-columns:1fr}
   .neo-cats{grid-template-columns:repeat(2,1fr)}
   .neo-news{grid-template-columns:1fr;padding:30px}
-  .neo-links{display:none}
+  .neo-menu{display:none}
   .neo-foot-cols{gap:24px}
 }
 @media(max-width:600px){
@@ -271,31 +286,13 @@ body::after{
   .neo-cats{grid-template-columns:1fr}
   .neo-news form{flex-direction:column}
   .neo-foot{flex-direction:column}
+  .neo-wiki{grid-template-columns:1fr}
+  .neo-sitemap{grid-template-columns:1fr}
 }
 
-/* Print */
+/* ---------- PRINT ---------- */
 @media print{
-  .neo-header,.neo-footer,#neo-backtotop,.neo-share,.neo-related,.neo-toc-wrap,.neo-news{display:none!important}
-  body{background:#fff;color:#000}
-  body::before,body::after{display:none}
-  .neo-post{max-width:100%;padding:0}
-  .neo-post-body{color:#000;font-size:12pt}
+  .neo-header,.neo-footer,#neo-backtotop,.neo-share,.neo-related,.neo-toc-wrap,.neo-news,.neo-settings{display:none !important}
+  body{background:#fff;color:#000}body::before,body::after{display:none}
+  .neo-post{max-width:100%;padding:0}.neo-post-body{color:#000;font-size:12pt}
 }
-
-/* ===== Year archive ===== */
-.neo-year{font-family:var(--mono);font-size:20px;color:var(--accent);margin:32px 0 8px;letter-spacing:1px}
-
-/* ===== Wiki ===== */
-.neo-wiki{display:grid;grid-template-columns:220px 1fr;gap:32px;align-items:start}
-.neo-wiki-side{position:sticky;top:84px;display:flex;flex-direction:column;gap:8px;border:1px solid var(--line);border-radius:var(--radius);padding:18px;background:var(--panel)}
-.neo-wiki-side h4{font-family:var(--mono);font-size:12px;color:var(--accent);letter-spacing:1px;text-transform:uppercase;margin-bottom:6px}
-.neo-wiki-side a{font-size:14px;color:var(--muted);padding:4px 0}
-.neo-wiki-side a:hover{color:var(--accent)}
-@media(max-width:900px){.neo-wiki{grid-template-columns:1fr}.neo-wiki-side{position:static}}
-
-/* ===== Sitemap page ===== */
-.neo-sitemap{display:grid;grid-template-columns:repeat(2,1fr);gap:28px;margin-top:20px}
-.neo-sitemap .col h4{font-family:var(--mono);font-size:12px;color:var(--accent);letter-spacing:1px;text-transform:uppercase;margin-bottom:12px}
-.neo-sitemap .col a{display:block;color:var(--muted);font-size:14px;padding:5px 0;border-bottom:1px solid var(--line)}
-.neo-sitemap .col a:hover{color:var(--accent)}
-@media(max-width:700px){.neo-sitemap{grid-template-columns:1fr}}

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,30 +1,98 @@
-/* Neo design-system JS — theme toggle, back-to-top, share copy, smooth anchors.
-   No external dependencies. Loaded deferred from head.html. */
+/* Neo presentation-layer JS — theme/appearance, settings drawer, a11y.
+   Pure presentation control: reads/writes data-theme / data-accent /
+   data-fscale / data-reduce-motion on <html>. Content is untouched.
+   No external dependencies. */
 (function(){
   "use strict";
   var root = document.documentElement;
-  var saved = null;
-  try { saved = localStorage.getItem('theme'); } catch(e){}
-  if (saved === 'light' || saved === 'dark') {
-    root.setAttribute('data-theme', saved);
-  } else {
-    root.setAttribute('data-theme', 'dark');
+  function ls(k){ try { return localStorage.getItem(k); } catch(e){ return null; } }
+  function ss(k,v){ try { localStorage.setItem(k,v); } catch(e){} }
+
+  // Apply persisted appearance
+  var theme = ls('neo-theme') || 'dark';
+  var accent = ls('neo-accent') || 'teal';
+  var fscale = ls('neo-fscale') || 'normal';
+  var motion = ls('neo-motion') || 'on';
+  root.setAttribute('data-theme', theme);
+  root.setAttribute('data-accent', accent);
+  if (fscale !== 'normal') root.setAttribute('data-fscale', fscale);
+  if (motion === 'off') root.setAttribute('data-reduce-motion', 'true');
+
+  function markActive(){
+    document.querySelectorAll('#neo-theme-grid .neo-theme-opt').forEach(function(el){
+      el.classList.toggle('active', el.getAttribute('data-theme') === root.getAttribute('data-theme'));
+    });
+    document.querySelectorAll('#neo-accent-grid .neo-accent-opt').forEach(function(el){
+      el.classList.toggle('active', el.getAttribute('data-accent') === root.getAttribute('data-accent'));
+    });
+    document.querySelectorAll('#neo-fscale button').forEach(function(el){
+      el.classList.toggle('active', el.getAttribute('data-fs') === (root.getAttribute('data-fscale')||'normal'));
+    });
+    document.querySelectorAll('#neo-motion button').forEach(function(el){
+      el.classList.toggle('active', el.getAttribute('data-motion') === (root.getAttribute('data-reduce-motion')==='true'?'off':'on'));
+    });
+  }
+  markActive();
+
+  // Theme picker
+  document.querySelectorAll('#neo-theme-grid .neo-theme-opt').forEach(function(el){
+    el.addEventListener('click', function(){
+      var t = el.getAttribute('data-theme');
+      root.setAttribute('data-theme', t); ss('neo-theme', t); markActive();
+    });
+  });
+  // Accent picker
+  document.querySelectorAll('#neo-accent-grid .neo-accent-opt').forEach(function(el){
+    el.addEventListener('click', function(){
+      var a = el.getAttribute('data-accent');
+      root.setAttribute('data-accent', a); ss('neo-accent', a); markActive();
+    });
+  });
+  // Font scale
+  document.querySelectorAll('#neo-fscale button').forEach(function(el){
+    el.addEventListener('click', function(){
+      var f = el.getAttribute('data-fs');
+      if (f === 'normal') root.removeAttribute('data-fscale'); else root.setAttribute('data-fscale', f);
+      ss('neo-fscale', f); markActive();
+    });
+  });
+  // Motion
+  document.querySelectorAll('#neo-motion button').forEach(function(el){
+    el.addEventListener('click', function(){
+      var m = el.getAttribute('data-motion');
+      if (m === 'off') root.setAttribute('data-reduce-motion','true'); else root.removeAttribute('data-reduce-motion');
+      ss('neo-motion', m); markActive();
+    });
+  });
+
+  // Settings drawer toggle
+  var btn = document.getElementById('neo-settings-btn');
+  var drawer = document.getElementById('neo-drawer');
+  if (btn && drawer){
+    btn.addEventListener('click', function(e){ e.stopPropagation(); drawer.classList.toggle('open'); });
+    document.addEventListener('click', function(e){
+      if (!drawer.contains(e.target) && e.target !== btn) drawer.classList.remove('open');
+    });
   }
 
-  function toggleTheme(){
-    var cur = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
-    root.setAttribute('data-theme', cur);
-    try { localStorage.setItem('theme', cur); } catch(e){}
+  // Quick light/dark toggle
+  var tog = document.getElementById('neo-theme-toggle');
+  if (tog){
+    tog.addEventListener('click', function(){
+      var cur = root.getAttribute('data-theme');
+      var next = (cur === 'light') ? 'dark' : 'light';
+      root.setAttribute('data-theme', next); ss('neo-theme', next); markActive();
+    });
   }
-  var btns = document.querySelectorAll('#neo-theme-toggle, .neo-theme');
-  btns.forEach(function(b){ b.addEventListener('click', toggleTheme); });
+
+  // Search open -> go to /search/
+  var so = document.getElementById('neo-search-open');
+  if (so){ so.addEventListener('click', function(){ window.location.href = so.getAttribute('data-href') || '/search/'; }); }
 
   // Back to top
   var b = document.getElementById('neo-backtotop');
-  if (b) {
-    window.addEventListener('scroll', function(){
-      b.classList.toggle('show', window.scrollY > 600);
-    }, {passive:true});
+  if (b){
+    window.addEventListener('scroll', function(){ b.classList.toggle('show', window.scrollY > 600); }, {passive:true});
     b.addEventListener('click', function(){ window.scrollTo({top:0, behavior:'smooth'}); });
   }
 })();

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -26,7 +26,7 @@
   <div class="neo-post-body">{{ .Content }}</div>
   {{ partial "share.html" . }}
   {{ partial "related.html" . }}
-  {{ if .Params.comments }}{{ partial "comments.html" . }}{{ end }}
+  {{ if or .Params.comments .Site.Params.article.showComments }}{{ partial "comments.html" . }}{{ end }}
 </article>
 </main>
 {{ partial "neo-footer.html" . }}

--- a/layouts/partials/neo-footer.html
+++ b/layouts/partials/neo-footer.html
@@ -1,7 +1,7 @@
 {{/*
-  Neo footer — sections + links (GitHub/RSS/Search). Reuses the existing
-  subscription.html partial (Buttondown) for the newsletter block so the
-  configured externalSubscriptionURL keeps working.
+  Neo footer — presentation layer. The primary footer content is the tag
+  cloud, auto-generated from the tags taxonomy with font-size scaled by
+  mention count (raw data -> tag cloud). Reuses subscription.html (Buttondown).
 */}}
 <footer class="neo-footer">
   <div class="neo-foot">
@@ -12,15 +12,27 @@
     <div class="neo-foot-cols">
       <div class="neo-foot-col">
         <h5>Разделы</h5>
-        {{ range site.Menus.main }}{{ if not .Parent }}<a href="{{ .URL }}">{{ .Name }}</a>{{ end }}{{ end }}
+        {{ range first 6 site.Taxonomies.categories.ByCount }}<a href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a>{{ end }}
       </div>
       <div class="neo-foot-col">
         <h5>Ссылки</h5>
         <a href="https://github.com/dominicusin">GitHub</a>
         <a href="{{ "feed.xml" | relURL }}">RSS</a>
         <a href="{{ "search/" | relURL }}">Поиск</a>
+        <a href="{{ "sitemap/" | relURL }}">Карта сайта</a>
       </div>
     </div>
   </div>
+
+  {{/* Tag cloud from data, sized by count */}}
+  <nav class="neo-tagcloud-foot" aria-label="Облако тегов">
+    {{ $max := 0 }}{{ range site.Taxonomies.tags.Alphabetical }}{{ if gt .Count $max }}{{ $max = .Count }}{{ end }}{{ end }}
+    {{ range site.Taxonomies.tags.Alphabetical }}
+      {{ $size := 12 }}
+      {{ if gt $max 1 }}{{ $size = add 12 (mul 16 (div (sub .Count 1.0) (sub $max 1.0))) }}{{ end }}
+      <a class="neo-tc" style="font-size:{{ $size | lang.FormatNumber 0 }}px" href="{{ .Page.RelPermalink }}">#{{ .Page.Title }}</a>
+    {{ end }}
+  </nav>
+
   {{ partial "subscription.html" . }}
 </footer>

--- a/layouts/partials/neo-header.html
+++ b/layouts/partials/neo-header.html
@@ -1,7 +1,8 @@
 {{/*
-  Neo header — reads site.Menus.main. EN is disabled on this site, so no
-  RU/EN switcher. Includes Search link + theme toggle (no JS dep; wired in
-  custom.js via #neo-theme-toggle).
+  Neo header — presentation layer. The primary navigation is auto-generated
+  from the site's categories taxonomy (raw data -> categories -> common menu),
+  so adding a category needs no menu edit. A settings drawer (theme/appearance/
+  accessibility/search) is wired by custom.js. EN is disabled, so no RU/EN.
 */}}
 <header class="neo-header">
   <div class="neo-nav">
@@ -9,14 +10,60 @@
       <span class="mark">D</span>
       <span>Dominicus&nbsp;In<small>engineering · systems · data</small></span>
     </a>
-    <nav class="neo-links">
-      {{ range site.Menus.main }}
-        {{ if not .Parent }}<a href="{{ .URL }}">{{ .Name }}</a>{{ end }}
+
+    {{/* Common menu derived from categories (data-driven) */}}
+    <nav class="neo-menu" aria-label="Разделы">
+      {{ range first 8 site.Taxonomies.categories.ByCount }}
+        <a href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a>
       {{ end }}
-      <a href="{{ "search/" | relURL }}">Поиск</a>
+      <a href="{{ "blog/" | relURL }}">Блог</a>
+      <a href="{{ "knowledge-graph/" | relURL }}">Graph</a>
+      <a href="{{ "wiki-build/" | relURL }}">Wiki</a>
     </nav>
+
     <div class="neo-nav-actions">
-      <button id="neo-theme-toggle" class="neo-theme" aria-label="Переключить тему">◐</button>
+      <button class="neo-icon-btn" id="neo-search-open" aria-label="Поиск" title="Поиск">⌕</button>
+      <div class="neo-settings">
+        <button class="neo-icon-btn" id="neo-settings-btn" aria-label="Настройки" title="Настройки">⚙</button>
+        <div class="neo-drawer" id="neo-drawer" role="dialog" aria-label="Настройки оформления">
+          <h5>Тема оформления</h5>
+          <div class="neo-theme-grid" id="neo-theme-grid">
+            <div class="neo-theme-opt" data-theme="dark"><span class="neo-sw" style="background:#0b0e14"></span>Тёмная</div>
+            <div class="neo-theme-opt" data-theme="light"><span class="neo-sw" style="background:#f6f8fb"></span>Светлая</div>
+            <div class="neo-theme-opt" data-theme="solar"><span class="neo-sw" style="background:#1c1917"></span>Solar</div>
+            <div class="neo-theme-opt" data-theme="mono"><span class="neo-sw" style="background:#0a0a0a"></span>Mono</div>
+          </div>
+          <h5>Акцент</h5>
+          <div class="neo-accent-grid" id="neo-accent-grid">
+            <div class="neo-accent-opt" data-accent="teal" style="background:#4fd1c5" title="Teal"></div>
+            <div class="neo-accent-opt" data-accent="violet" style="background:#a78bfa" title="Violet"></div>
+            <div class="neo-accent-opt" data-accent="amber" style="background:#fbbf24" title="Amber"></div>
+            <div class="neo-accent-opt" data-accent="emerald" style="background:#34d399" title="Emerald"></div>
+            <div class="neo-accent-opt" data-accent="rose" style="background:#fb7185" title="Rose"></div>
+          </div>
+          <h5>Доступность</h5>
+          <div class="neo-row-opt">
+            <span>Размер шрифта</span>
+            <div class="neo-seg" id="neo-fscale">
+              <button data-fs="normal">A</button>
+              <button data-fs="large">A+</button>
+              <button data-fs="xlarge">A++</button>
+            </div>
+          </div>
+          <div class="neo-row-opt">
+            <span>Анимация</span>
+            <div class="neo-seg" id="neo-motion">
+              <button data-motion="on">Вкл</button>
+              <button data-motion="off">Выкл</button>
+            </div>
+          </div>
+          <h5>Навигация</h5>
+          <a class="neo-theme-opt" href="{{ "search/" | relURL }}" style="margin-top:4px">⌕ Поиск по сайту</a>
+          <a class="neo-theme-opt" href="{{ "sitemap/" | relURL }}" style="margin-top:4px">🗺 Карта сайта</a>
+          <a class="neo-theme-opt" href="{{ "archives/" | relURL }}" style="margin-top:4px">🗓 Архив по годам</a>
+        </div>
+      </div>
+      <button class="neo-icon-btn" id="neo-theme-toggle" aria-label="Светлая/тёмная" title="Светлая/тёмная">◐</button>
     </div>
   </div>
 </header>


### PR DESCRIPTION
Implements the requested architecture: presentation fully separated from content, swappable themes, data-driven menu/footer.

What changed:
- Presentation layer = neo.css (themes/accents as CSS tokens) + neo-header/neo-footer partials + custom.js. Every Neo page includes these, so the look is DRY and theme-switchable with zero content edits.
- Themes: dark / light / solar / mono, each a [data-theme] token set. Accents: teal/violet/amber/emerald/rose via [data-accent]. Switched at runtime, persisted in localStorage.
- Header menu is auto-generated from the categories taxonomy (raw data -> categories -> common menu) — no hand-edited menu needed for sections.
- Footer shows the tag cloud auto-generated from the tags taxonomy, font-size scaled by mention count.
- Settings drawer (in header) exposes: theme picker, accent picker, font-size (a11y), reduce-motion (a11y), and quick links to search/sitemap/archives.
- giscus (comments + reactions/likes + comment counts) now renders on all posts via article.showComments=true (already enabled in params).

Verified: local build Hugo 0.164.0 (same as CI) succeeds, 367 pages. <head> present (perf check passes). Category menu + settings drawer + tag-cloud footer on home/post/gallery. giscus client.js present on posts. film-collection (82 posters) untouched.

Untouched & still working: repositories/gists/awesome (Blowfish baseof), knowledge-graph D3, RSS, XML sitemap, search, 404 redirect, subscription.