### PR TITLE
fix: add missing content/wiki-build/_index.md

### DIFF
--- a/content/wiki-build/_index.md
+++ b/content/wiki-build/_index.md
@@ -1,0 +1,11 @@
+---
+title: "Wiki"
+slug: "wiki-build"
+description: "A wiki-style view of the site — notes, gists and posts grouped as interlinked articles."
+layout: "wiki-build"
+---
+
+This is a **wiki** view of the site: long-form notes, gists and posts are
+presented as interlinked articles rather than a chronological feed. Use the
+year/section groupings below to browse, or the search page to jump straight
+to a topic.


### PR DESCRIPTION
The wiki-build layout merged in #293 but the content file was never committed, so /wiki-build/ produced no page. This adds content/wiki-build/_index.md (layout: wiki-build) so the wiki page generates.