### PR TITLE
fix: validated dependabot.yml (closed #280 direction)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       timezone: "UTC"
     open-pull-requests-limit: 10
     auto-merge: true
+    labels:
+      - "dependencies"
     ignore:
       # Ignore major version updates for GitHub Actions (manual review required)
       - dependency-name: "actions/*"
@@ -25,6 +27,8 @@ updates:
       timezone: "UTC"
     open-pull-requests-limit: 10
     auto-merge: true
+    labels:
+      - "dependencies"
     groups:
       production-dependencies:
         dependency-type: "production"


### PR DESCRIPTION
Replaces PR #280 (ci/dependabot-autoupdate) direction.

PR #280 stripped the schedule/timing, npm groups + commit-message, and the github-actions ignore rule from main's dependabot.yml, then added a non-functional gitsubmodule entry — and its .github/dependabot.yml check FAILED (COMPLETED/FAILURE).

This PR keeps the validated form on main intact and only adds the `labels: ["dependencies"]` to github-actions + npm (so the dependency-review/alert surface is wired). Verification: local YAML parse OK via PyYAML; ecosystems github-actions/npm/bundler present; schedule, npm groups, commit-message, github-actions ignore rule preserved.

(to-be-done after merge: enable enabled_dependabot_alerts on the repo so the Security tab dependency surface is fully on).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependency update pull requests are now automatically labeled as `dependencies`.
  * The existing limit for open Bundler update pull requests remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->