### PR TITLE
fix: unify Neo presentation — wiki-build in menu + repositories/gists/awesome as standalone docs

### DIFF
--- a/layouts/awesome/list.html
+++ b/layouts/awesome/list.html
@@ -1,22 +1,17 @@
-{{ define "main" }}
-<section class="prose dark:prose-invert max-w-none mb-10">
-  <header class="mb-8">
-    <h1 class="text-4xl font-bold tracking-tight text-neutral-900 dark:text-neutral mb-3">
-      {{ .Title | default "Awesome" }}
-    </h1>
-    <p class="text-lg text-neutral-500 dark:text-neutral-400">
-      {{ .Description | default "Курируемые awesome-списки из внешних репозиториев, сгруппированные по темам." }}
-    </p>
-    <p class="mt-2 text-sm text-neutral-400 dark:text-neutral-500">
-      Списки подключены как git-субмодули с выборочной загрузкой (sparse-checkout) —
-      из каждого репозитория синхронизируется только <code>README.md</code>/список.
-      Автоматически пополняются через
-      <a class="text-primary-600 dark:text-primary-400 hover:underline" href="https://github.com/dominicusin/dominicusin.github.io/actions/workflows/awesome-discover.yml">awesome-discover</a>.
-    </p>
-  </header>
-
+<!DOCTYPE html>
+<html lang="{{ site.Language.LanguageCode | default "ru" }}" data-theme="dark">
+{{ partial "neo-head.html" . }}
+{{/* Neo awesome section — standalone full-doc; data/awesome.json drives the cards */}}
+<body>
+{{ partial "neo-header.html" . }}
+<main class="neo">
+<div class="neo-wrap">
+  <div class="neo-sec-head" style="margin-top:20px">
+    <h2>{{ .Title | default "Awesome" }}</h2>
+    <span class="more">{{ $data := .Site.Data.awesome }}{{ if $data }}{{ $data.total }} списков{{ else }}0 списков{{ end }}</span>
+  </div>
+  {{ .Content }}
   {{ $data := .Site.Data.awesome }}
-      {{ with $data.generatedAt }}<p class="mt-1 text-xs text-neutral-400 dark:text-neutral-500">Каталог сгенерирован: {{ (time .) | time.Format "2006-01-02 15:04 MST" }}</p>{{ end }}
   {{ if not $data }}
     <p class="text-neutral-500">Каталог пока пуст. Запустите <code>node scripts/build-awesome.cjs</code>.</p>
   {{ else }}
@@ -64,5 +59,8 @@
       Всего курируемых списков: <strong>{{ $data.total }}</strong> в <strong>{{ len $data.groups }}</strong> группах.
     </p>
   {{ end }}
-</section>
-{{ end }}
+</div>
+</main>
+{{ partial "neo-footer.html" . }}
+</body>
+</html>

--- a/layouts/gists/list.html
+++ b/layouts/gists/list.html
@@ -1,9 +1,15 @@
-{{ define "main" }}
-  {{ .Scratch.Set "scope" "list" }}
-  <header class="mt-5">
-    <h1 class="text-4xl font-extrabold text-neutral-900 dark:text-neutral">{{ .Title }}</h1>
-    {{ with .Content }}<section class="prose dark:prose-invert max-w-prose mt-3">{{ . }}</section>{{ end }}
-  </header>
+<!DOCTYPE html>
+<html lang="{{ site.Language.LanguageCode | default "ru" }}" data-theme="dark">
+{{ partial "neo-head.html" . }}
+<body>
+{{ partial "neo-header.html" . }}
+<main class="neo">
+<div class="neo-wrap">
+  <div class="neo-sec-head" style="margin-top:20px">
+    <h2>{{ .Title }}</h2>
+    <span class="more">{{ len .RegularPages }} гистов</span>
+  </div>
+  {{ .Content }}
   <div class="repo-grid">
     {{ range .RegularPages.ByTitle }}
       <a class="repo-card" href="{{ .RelPermalink }}">
@@ -17,4 +23,8 @@
       </a>
     {{ end }}
   </div>
-{{ end }}
+</div>
+</main>
+{{ partial "neo-footer.html" . }}
+</body>
+</html>

--- a/layouts/partials/neo-header.html
+++ b/layouts/partials/neo-header.html
@@ -19,6 +19,7 @@
       <a href="{{ "ontology/" | relURL }}">Онтология</a>
       <a href="{{ "knowledge-graph/" | relURL }}">Graph</a>
       <a href="{{ "awesome/" | relURL }}">awesome</a>
+      <a href="{{ "wiki-build/" | relURL }}">Wiki</a>
       <a href="{{ "categories/" | relURL }}">Категории</a>
       <a href="{{ "tags/" | relURL }}">Теги</a>
       <a href="{{ "sitemap.xml" | relURL }}">sitemap</a>
@@ -67,6 +68,7 @@
           <a class="neo-theme-opt" href="{{ "ontology/" | relURL }}" style="margin-top:4px">🕸 Онтология</a>
           <a class="neo-theme-opt" href="{{ "knowledge-graph/" | relURL }}" style="margin-top:4px">🔗 Graph</a>
           <a class="neo-theme-opt" href="{{ "awesome/" | relURL }}" style="margin-top:4px">⭐ awesome</a>
+          <a class="neo-theme-opt" href="{{ "wiki-build/" | relURL }}" style="margin-top:4px">📖 Wiki</a>
           <a class="neo-theme-opt" href="{{ "categories/" | relURL }}" style="margin-top:4px">🗂 Категории</a>
           <a class="neo-theme-opt" href="{{ "tags/" | relURL }}" style="margin-top:4px">🏷 Теги</a>
           <a class="neo-theme-opt" href="{{ "sitemap.xml" | relURL }}" style="margin-top:4px">🗺 sitemap.xml</a>

--- a/layouts/repositories/list.html
+++ b/layouts/repositories/list.html
@@ -1,10 +1,15 @@
-{{ define "main" }}
-  {{ .Scratch.Set "scope" "list" }}
-  <header class="mt-5">
-    <h1 class="text-4xl font-extrabold text-neutral-900 dark:text-neutral">{{ .Title }}</h1>
-    {{ with .Content }}<section class="prose dark:prose-invert max-w-prose mt-3">{{ . }}</section>{{ end }}
-  </header>
-
+<!DOCTYPE html>
+<html lang="{{ site.Language.LanguageCode | default "ru" }}" data-theme="dark">
+{{ partial "neo-head.html" . }}
+<body>
+{{ partial "neo-header.html" . }}
+<main class="neo">
+<div class="neo-wrap">
+  <div class="neo-sec-head" style="margin-top:20px">
+    <h2>{{ .Title }}</h2>
+    <span class="more">{{ len .RegularPages }} репозиториев</span>
+  </div>
+  {{ .Content }}
   {{ $pages := .RegularPages }}
   <div class="repo-grid" data-count="{{ len $pages }}">
     {{ range $pages.ByTitle }}
@@ -22,4 +27,8 @@
       </a>
     {{ end }}
   </div>
-{{ end }}
+</div>
+</main>
+{{ partial "neo-footer.html" . }}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Добавлен пункт **Wiki** в основное меню (neo-header) и в мобильный дравер «Навигация».
- `repositories/`, `gists/`, `awesome/` переведены с Blowfish `define "main"` на автономные Neo full-документы (`neo-head` + `neo-header` + контент + `neo-footer`), чтобы все разделы были в одном стиле.

## Verification
- Локальный билд: `hugo --source ... --destination /tmp/...` прошёл без ошибок.
- Все target-страницы содержат ссылку `wiki-build/` в шапке.

## Manual QA
- [ ] `dominicusin.github.io/repositories/` — карточки репозиториев в Neo-стиле.
- [ ] `dominicusin.github.io/gists/` — карточки гистов в Neo-стиле.
- [ ] `dominicusin.github.io/awesome/` — карточки awesome в Neo-стиле.
- [ ] `dominicusin.github.io/wiki-build/` — пункт «Wiki» в меню.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Awesome, Gists, and Repositories pages with a consistent Neo-themed layout.
  * Added item counts to list page headers.
  * Added a Wiki link to the main navigation and settings menu.
  * Improved dark-theme presentation across repository and gist listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->