### PR TITLE
chore(dependabot): add dependencies label + align PR limits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       timezone: "UTC"
     open-pull-requests-limit: 10
     auto-merge: true
+    labels:
+      - "dependencies"
     ignore:
       # Ignore major version updates for GitHub Actions (manual review required)
       - dependency-name: "actions/*"
@@ -25,6 +27,8 @@ updates:
       timezone: "UTC"
     open-pull-requests-limit: 10
     auto-merge: true
+    labels:
+      - "dependencies"
     groups:
       production-dependencies:
         dependency-type: "production"
@@ -42,4 +46,4 @@ updates:
       day: "tuesday"
       time: "10:00"
       timezone: "UTC"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## What
- Add `labels: ["dependencies"]` to github-actions and npm Dependabot updates so auto-PRs land in the right triage label.
- Align bundler `open-pull-requests-limit` 5 -> 10 (consistency with other ecosystems).

## Why
Branch `fix/dependabot-yml-validated` (PR #297) carried the same `labels`, but that PR was closed; main kept the variant without the label. Restoring the improvement.

## Check
- YAML structurally valid (correct lists added).
- Only `.github/dependabot.yml` changed -- no effect on build/test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependency update pull requests are now labeled consistently as dependencies.
  * Increased the allowed number of open bundler update pull requests from 5 to 10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->