### PR TITLE
a11y: focus-visible accent rings + staggered card entrance

### DIFF
--- a/assets/css/neo.css
+++ b/assets/css/neo.css
@@ -250,6 +250,26 @@ html[data-reduce-motion="true"] *{animation:none !important; transition:none !im
 .neo .awesome-card .group{font-size:.72rem;text-transform:uppercase;letter-spacing:.5px;color:var(--faint)}
 .neo .awesome-card .stars{color:var(--amber)}
 
+/* Keyboard focus accent + entrance animation (a11y + visual pop) */
+.repo-card:focus-visible,.gist-card:focus-visible,.awesome-card:focus-visible{
+  outline:none;
+  border-color:var(--accent);
+  box-shadow:0 0 0 3px color-mix(in srgb,var(--accent) 45%,transparent),
+             0 18px 40px -20px rgba(0,0,0,.85);
+}
+@keyframes neo-card-in{from{opacity:0;transform:translateY(10px)}to{opacity:1;transform:none}}
+@media (prefers-reduced-motion: no-preference){
+  .repo-grid > .repo-card,.repo-grid > .gist-card,
+  .group-section .awesome-card{
+    animation:neo-card-in .5s cubic-bezier(.2,.7,.3,1) both;
+  }
+  .repo-grid > .repo-card:nth-child(2n),
+  .repo-grid > .gist-card:nth-child(2n){animation-delay:.05s}
+  .repo-grid > .repo-card:nth-child(3n),
+  .repo-grid > .gist-card:nth-child(3n){animation-delay:.1s}
+  .group-section .awesome-card:nth-child(3n){animation-delay:.08s}
+}
+
 .neo-rows{display:flex;flex-direction:column;border-top:1px solid var(--line)}
 .neo-row{display:grid;grid-template-columns:150px 1fr auto;gap:24px;align-items:center;padding:18px 6px;
   border-bottom:1px solid var(--line);transition:background .2s;text-decoration:none}


### PR DESCRIPTION
## What
Enhances the list-card accentuation (PR #301) with two best-practice a11y/visual touches, all in neo.css (the stylesheet loaded on neo pages):

- `:focus-visible` accent ring on `.repo-card` / `.gist-card` / `.awesome-card` (keyboard users get a clear accent outline; respects no outline removal beyond the standard pattern).
- Subtle staggered fade-in entrance (`neo-card-in`, respects `prefers-reduced-motion: no-preference`) so the grid feels alive on load without harming motion-sensitive users.

Tokens from the neo design system (--accent etc.), so it adapts to every theme/accent swatch.

## Verification
- Hugo build: Total in 1839 ms
- Built neo.min.css contains focus-visible (3x) + neo-card-in (2x)
- npm test: 3/3 (Unit + A11y + Perf) passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added visible keyboard-focus indicators to repository, gist, and curated content cards.
  * Added subtle card entrance animations with staggered timing.
  * Animations are automatically disabled for users who prefer reduced motion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->