### PR TITLE
fix(security): sanitize neo-search-open data-href (CodeQL XSS)

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -85,9 +85,21 @@
     });
   }
 
-  // Search open -> go to /search/
+  // Search open -> go to /search/ (data-href, if present, must be a
+  // same-origin path or http(s) URL; reject javascript:/data: schemes).
   var so = document.getElementById('neo-search-open');
-  if (so){ so.addEventListener('click', function(){ window.location.href = so.getAttribute('data-href') || '/search/'; }); }
+  if (so){
+    so.addEventListener('click', function(){
+      var dest = so.getAttribute('data-href') || '/search/';
+      try {
+        var u = new URL(dest, window.location.href);
+        var ok = u.origin === window.location.origin && /^https?:$/.test(u.protocol);
+        window.location.href = ok ? u.pathname + u.search + u.hash : '/search/';
+      } catch (e) {
+        window.location.href = '/search/';
+      }
+    });
+  }
 
   // Back to top
   var b = document.getElementById('neo-backtotop');


### PR DESCRIPTION
## What
Resolves the open CodeQL alert `js/xss-through-dom` (alert #289) on assets/js/custom.js:90.

The search button handler did `window.location.href = so.getAttribute('data-href') || '/search/'`. CodeQL flags the unescaped attribute-to-DOM flow because a `data-href` of `javascript:` could in theory navigate to a script URL.

In practice the `neo-search-open` button has no `data-href` attribute (confirmed in neo-header.html line 29), so it always fell back to `/search/` — but the pattern still trips the scanner and is fragile if a `data-href` is ever added.

Fix: resolve the destination through `new URL(dest, location.href)`, allow only same-origin `http(s)` schemes, and fall back to `/search/` on any invalid/foreign/malformed value. This closes the alert and hardens against `javascript:`/`data:` schemes.

## Verification
- `node -c assets/js/custom.js` → OK
- Hugo build: Total in 1792 ms
- npm test: 3/3 (Unit + A11y + Perf) passed
- The neo-search-open button has no data-href in markup → behaviour unchanged (still goes to /search/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search navigation safety by validating destination links before opening them.
  * Invalid or unsupported links now fall back to the standard search page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->