### PR TITLE
fix(security): regex-allowlist sanitize search data-href (CodeQL #290)

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -85,19 +85,16 @@
     });
   }
 
-  // Search open -> go to /search/ (data-href, if present, must be a
-  // same-origin path or http(s) URL; reject javascript:/data: schemes).
+  // Search open -> go to /search/ (data-href, if present, must be a safe
+  // local path: starts with "/" and contains no scheme/colon — so it can
+  // never be a javascript:/data: URL. Validated by regex (CodeQL sanitizer).
   var so = document.getElementById('neo-search-open');
   if (so){
     so.addEventListener('click', function(){
-      var dest = so.getAttribute('data-href') || '/search/';
-      try {
-        var u = new URL(dest, window.location.href);
-        var ok = u.origin === window.location.origin && /^https?:$/.test(u.protocol);
-        window.location.href = ok ? u.pathname + u.search + u.hash : '/search/';
-      } catch (e) {
-        window.location.href = '/search/';
-      }
+      var dest = so.getAttribute('data-href');
+      // Allow only relative local paths like "/search/" or "/x?q=1#h".
+      var safe = /^\/(?!\/)[a-zA-Z0-9/._\-]*(\?[a-zA-Z0-9=._\-&%]*)?(#[a-zA-Z0-9=._\-&%]*)?$/.test(dest);
+      window.location.href = safe ? dest : '/search/';
     });
   }
 


### PR DESCRIPTION
## What
Closes the remaining open CodeQL alert `js/xss-through-dom` (alert #290) on assets/js/custom.js:97 — a stricter follow-up to #306.

#306 added a same-origin `new URL()` guard, but CodeQL still traced `getAttribute` -> `pathname` into `location.href`. The reliable sanitizer CodeQL recognizes is a **regex allowlist on the raw attribute string**: a path that starts with `/` (but not `//`) and contains no scheme/colon can never be a `javascript:`/protocol-relative URL.

Replaced the `new URL()` flow with:
```
var safe = /^\/(?!\/)[a-zA-Z0-9/._\-]*(\?[a-zA-Z0-9=._\-&%]*)?(#[a-zA-Z0-9=._\-&%]*)?$/.test(dest);
window.location.href = safe ? dest : '/search/';
```
Verified the regex rejects `javascript:alert(1)`, `//evil.com`, `//x`, `/a:b` and accepts `/search/`, `/x?q=1#h`, `/ok`; `null` (no data-href, the real case) falls back to `/search/`.

## Verification
- node -c: OK; regex unit-checked against 9 cases
- Hugo build: Total in 1737 ms
- npm test: 3/3 (Unit + A11y + Perf) passed