### PR TITLE
style(awesome): replace dead Tailwind utilities with neo.css classes

### DIFF
--- a/assets/css/neo.css
+++ b/assets/css/neo.css
@@ -407,6 +407,30 @@ html[data-reduce-motion="true"] *{animation:none !important; transition:none !im
 .neo-giscus,.giscus-wrapper{min-height:220px}
 img{height:auto}
 
+/* ---------- AWESOME (port of the Tailwind utilities used by the template;
+   neo pages load only neo.css, so these replace the dead Tailwind classes) ---------- */
+.neo-awesome-groups{display:flex;flex-direction:column;gap:3rem}
+.neo-awesome-group{margin-bottom:1rem}
+.neo-awesome-group-head{display:flex;align-items:center;gap:.75rem;margin-bottom:1rem}
+.neo-awesome-group-head h2{font-size:1.5rem;font-weight:700;color:var(--text)}
+.neo-awesome-count{font-family:var(--mono);font-size:.78rem;padding:.15rem .6rem;border-radius:999px;
+  background:color-mix(in srgb,var(--accent) 16%,transparent);color:var(--accent);
+  border:1px solid color-mix(in srgb,var(--accent) 30%,transparent)}
+.neo-awesome-updated{font-size:.72rem;color:var(--faint)}
+.neo-awesome-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:18px}
+/* .awesome-card base + hover already defined in the LIST CARDS section */
+.neo-awesome-card-title{font-size:1.05rem;font-weight:700;color:var(--text);margin-bottom:.25rem}
+.neo-awesome-card-title a{color:var(--text)}
+.neo-awesome-card-title a:hover{color:var(--accent)}
+.neo-awesome-card-group{font-size:.72rem;text-transform:uppercase;letter-spacing:.5px;color:var(--faint);margin-bottom:.25rem}
+.neo-awesome-card-desc{font-size:.86rem;color:var(--muted);line-height:1.45;margin-bottom:.4rem}
+.neo-awesome-card-meta{font-size:.72rem;color:var(--faint)}
+.neo-awesome-card-meta .stars{color:var(--amber)}
+.neo-awesome-card-links{display:flex;flex-wrap:wrap;gap:.9rem;margin-top:.6rem;font-size:.85rem}
+.neo-awesome-card-links a{color:var(--accent-2)}
+.neo-awesome-card-links a:hover{color:var(--accent);text-decoration:underline}
+.neo-awesome-foot{margin-top:3rem;font-size:.85rem;color:var(--faint)}
+
 /* ---------- RESPONSIVE ---------- */
 @media(max-width:900px){
   .neo-hero{grid-template-columns:1fr;padding-top:56px}

--- a/layouts/awesome/list.html
+++ b/layouts/awesome/list.html
@@ -15,38 +15,34 @@
   {{ if not $data }}
     <p class="text-neutral-500">Каталог пока пуст. Запустите <code>node scripts/build-awesome.cjs</code>.</p>
   {{ else }}
-    <div class="space-y-12">
+    <div class="neo-awesome-groups">
       {{ range $data.groups }}
-      <div class="group-section">
-        <div class="flex items-center gap-3 mb-4">
-          <h2 class="text-2xl font-semibold text-neutral-800 dark:text-neutral-200">
-            {{ .name }}
-          </h2>
-          <span class="text-sm px-2 py-0.5 rounded-full bg-primary-100 text-primary-700 dark:bg-primary-900/40 dark:text-primary-300">
-            {{ len .repos }}
-          </span>
-          {{ with .refreshedAt }}<span class="text-[11px] text-neutral-400 dark:text-neutral-500">обновлено: {{ (time .) | time.Format "2006-01-02" }}</span>{{ end }}
+      <div class="neo-awesome-group">
+        <div class="neo-awesome-group-head">
+          <h2>{{ .name }}</h2>
+          <span class="neo-awesome-count">{{ len .repos }}</span>
+          {{ with .refreshedAt }}<span class="neo-awesome-updated">обновлено: {{ (time .) | time.Format "2006-01-02" }}</span>{{ end }}
         </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div class="neo-awesome-grid">
           {{ range .repos }}
           {{ $repo := . }}
           {{ $p := $.Site.GetPage (printf "/awesome/%s/%s" $repo.group $repo.name) }}
-          <article class="awesome-card flex flex-col justify-between rounded-xl border border-neutral-200 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-900/40 p-4 transition hover:border-primary-400 hover:shadow-sm">
+          <article class="awesome-card">
             <div>
-              <h3 class="text-lg font-medium text-neutral-900 dark:text-neutral mb-1">
-                <a class="hover:text-primary-600 dark:hover:text-primary-400 hover:underline" href="{{ $repo.gh }}" target="_blank" rel="noopener">{{ $repo.name }}</a>
+              <h3 class="neo-awesome-card-title">
+                <a href="{{ $repo.gh }}" target="_blank" rel="noopener">{{ $repo.name }}</a>
               </h3>
-              <p class="group text-xs uppercase tracking-wide text-neutral-400 dark:text-neutral-500 mb-1">{{ $repo.group }}</p>
-              {{ with $repo.description }}<p class="text-sm text-neutral-600 dark:text-neutral-300 mb-1 line-clamp-2">{{ . }}</p>{{ end }}
-              <p class="text-[11px] text-neutral-400 dark:text-neutral-500">
-                {{ with $repo.stars }}<span class="stars text-amber-500 dark:text-amber-400">★ {{ . }}</span>{{ end }}
-                {{ with $repo.refreshedAt }}<span class="ms-2">обновлено: {{ (time .) | time.Format "2006-01-02" }}</span>{{ end }}
+              <p class="neo-awesome-card-group">{{ $repo.group }}</p>
+              {{ with $repo.description }}<p class="neo-awesome-card-desc">{{ . }}</p>{{ end }}
+              <p class="neo-awesome-card-meta">
+                {{ with $repo.stars }}<span class="stars">★ {{ . }}</span>{{ end }}
+                {{ with $repo.refreshedAt }}<span class="neo-awesome-updated">обновлено: {{ (time .) | time.Format "2006-01-02" }}</span>{{ end }}
               </p>
             </div>
-            <div class="mt-3 flex flex-wrap gap-3 text-sm">
-              <a class="text-primary-600 dark:text-primary-400 hover:underline" href="{{ $repo.gh }}" target="_blank" rel="noopener">★ Репозиторий</a>
-              <a class="text-neutral-500 dark:text-neutral-400 hover:underline" href="{{ $repo.gh }}/blob/main/{{ $repo.readme }}" target="_blank" rel="noopener">README ↗</a>
-              {{ with $p }}<a class="text-emerald-600 dark:text-emerald-400 hover:underline" href="{{ .RelPermalink }}">Превью →</a>{{ end }}
+            <div class="neo-awesome-card-links">
+              <a href="{{ $repo.gh }}" target="_blank" rel="noopener">★ Репозиторий</a>
+              <a href="{{ $repo.gh }}/blob/main/{{ $repo.readme }}" target="_blank" rel="noopener">README ↗</a>
+              {{ with $p }}<a href="{{ .RelPermalink }}">Превью →</a>{{ end }}
             </div>
           </article>
           {{ end }}
@@ -55,7 +51,7 @@
       {{ end }}
     </div>
 
-    <p class="mt-12 text-sm text-neutral-400 dark:text-neutral-500">
+    <p class="neo-awesome-foot">
       Всего курируемых списков: <strong>{{ $data.total }}</strong> в <strong>{{ len $data.groups }}</strong> группах.
     </p>
   {{ end }}


### PR DESCRIPTION
## What
The awesome listing template emitted a pile of Tailwind utility classes (flex, grid grid-cols-*, gap-3, p-4, rounded-xl, border, text-lg, bg-neutral-*, text-primary-*, etc.). Neo pages load only neo.css — Tailwind is not compiled into that stylesheet — so all those utilities were dead: the cards only looked right because of the `.awesome-card` hook added earlier. Layout grid, card padding, and text sizing silently did nothing.

Ported the needed layout into neo.css under `.neo-awesome-*` and rewrote the template to use semantic classes:
- `.neo-awesome-groups` / `.neo-awesome-group` / `.neo-awesome-group-head` (flex header)
- `.neo-awesome-count` (accent pill badge, token-driven)
- `.neo-awesome-grid` (responsive auto-fill grid)
- `.neo-awesome-card-title` / `-group` / `-desc` / `-meta` / `-links` (typography + link colors)
- `.neo-awesome-foot`

The `.awesome-card` base/accent/hover (gradient top-bar + glow) already lives in the LIST CARDS section and is preserved.

## Verification
- Hugo build: Total in 1821 ms
- Rendered /awesome/ uses neo-awesome-grid (8), awesome-card (52), neo-awesome-card-title (13)
- Dead Tailwind classes (bg-neutral-900, grid-cols-1) in output: 0
- npm test: 3/3 (Unit + A11y + Perf) passed