### PR TITLE
fix(search): use textContent (no innerHTML) + show real tag

### DIFF
--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -37,7 +37,10 @@
     hits.forEach(function(h){
       var a = document.createElement('a');
       a.className='neo-row'; a.href=h.u;
-      a.innerHTML = '<span class="date">'+h.d+'</span><span class="title">'+h.t+'</span><span class="tag">тег</span>';
+      var date = document.createElement('span'); date.className='date'; date.textContent=h.d;
+      var title = document.createElement('span'); title.className='title'; title.textContent=h.t;
+      var tag = document.createElement('span'); tag.className='tag'; tag.textContent = h.g ? h.g : 'тег';
+      a.appendChild(date); a.appendChild(title); a.appendChild(tag);
       res.appendChild(a);
     });
   }


### PR DESCRIPTION
## What
Hardening the client-side search results render in layouts/_default/search.html:

- The hit rows were built with `a.innerHTML = '<span class="date">'+h.d+'</span><span class="title">'+h.t+'</span>...'`. The INDEX is build-time baked (trusted, static) so this isn't a live XSS, but inserting page titles/summaries via innerHTML is a risky pattern (and a CodeQL `js/xss-through-dom` candidate if the source ever becomes dynamic). Replaced with `document.createElement` + `textContent` + `appendChild` — no HTML parsing of data, so injection is impossible.
- The tag chip was hardcoded to the literal string "тег" for every hit. Now it shows the actual matched tag (`h.g`) when present, falling back to "тег".

## Verification
- Hugo build: Total in 1763 ms
- Rendered /search/ no longer contains `a.innerHTML` for hits (0 occurrences)
- npm test: 3/3 (Unit + A11y + Perf) passed