### PR TITLE
fix(404): use textContent + createElement instead of innerHTML

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -31,7 +31,12 @@
       });
       if(best && bestScore>0.3){
         var el=document.getElementById('neo-nf-suggestion');
-        if(el) el.innerHTML = 'Возможно, вы искали: <a href="'+best.url+'">'+best.title+'</a>';
+        if(el){
+          el.textContent = 'Возможно, вы искали: ';
+          var a=document.createElement('a');
+          a.href=best.url; a.textContent=best.title || best.url;
+          el.appendChild(a);
+        }
       }
     }).catch(function(){});
   function score(a,b){


### PR DESCRIPTION
## What
Hardening layouts/404.html's "did you mean" suggestion. It fetched the static `redirect-index.json` and rendered the closest match with `el.innerHTML = '...<a href="'+best.url+'">'+best.title+'</a>'`. The data is build-time static (trusted), but injecting `best.url`/`best.title` via innerHTML — with the URL placed into an `href` through string concatenation — is a risky pattern (attribute breakout if a value ever contains a quote; and a CodeQL `js/xss-through-dom` candidate).

Replaced with `textContent` + `document.createElement('a')` + `a.href = best.url` (browser-escaped) + `a.textContent`. No HTML parsing of data.

## Verification
- Hugo build: Total in 1814 ms
- Rendered /404.html no longer uses `el.innerHTML` / `best.url+'` (0 occurrences)
- npm test: 3/3 (Unit + A11y + Perf) passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the 404 page’s suggested-link handling for safer rendering.
  * Suggested pages now display correctly without interpreting page titles or URLs as markup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->