### PR TITLE
fix(links): route repo topics to GitHub; neutralize dead /tags//domini/people/ links

### DIFF
--- a/layouts/repositories/single.html
+++ b/layouts/repositories/single.html
@@ -18,7 +18,7 @@
         {{ if .Params.has_wiki }}<a class="repo-btn repo-btn--ghost" href="{{ .Params.wiki_url }}" target="_blank" rel="noopener">Wiki ↗</a>{{ end }}
       </div>
       {{ with .Params.topics }}<div class="repo-topics">
-        {{ range . }}<a class="repo-topic" href="/tags/{{ . | urlize }}/">#{{ . }}</a>{{ end }}
+        {{ range . }}<a class="repo-topic" href="https://github.com/topics/{{ . | urlize }}" target="_blank" rel="noopener">#{{ . }}</a>{{ end }}
       </div>{{ end }}
     </header>
 

--- a/layouts/repository/single.html
+++ b/layouts/repository/single.html
@@ -18,7 +18,7 @@
         {{ if .Params.has_wiki }}<a class="repo-btn repo-btn--ghost" href="{{ .Params.wiki_url }}" target="_blank" rel="noopener">Wiki ↗</a>{{ end }}
       </div>
       {{ with .Params.topics }}<div class="repo-topics">
-        {{ range . }}<a class="repo-topic" href="/tags/{{ . | urlize }}/">#{{ . }}</a>{{ end }}
+        {{ range . }}<a class="repo-topic" href="https://github.com/topics/{{ . | urlize }}" target="_blank" rel="noopener">#{{ . }}</a>{{ end }}
       </div>{{ end }}
     </header>
 

--- a/scripts/build-awesome.cjs
+++ b/scripts/build-awesome.cjs
@@ -119,9 +119,16 @@ function rewriteRelativeLinks(md, ghUrl, repoPath) {
   const base = ghUrl.replace(/\/$/, '');
   // Raw HTML anchors with relative hrefs (e.g. the-book-of-secret-knowledge
   // README has `<a href="LICENSE.md">`), which markdown-link rewriting misses.
-  md = md.replace(/<a\s+([^>]*?)href=["\']([^"\']+)["\']([^>]*)>/gi, (m, pre, href, post) => {
+  md = md.replace(/<a\s+([\s\S]*?)href=["']([^"']+)["']([\s\S]*?)>/gi, (m, pre, href, post) => {
     const d = href.trim();
-    if (/^(https?:\/\/|mailto:|tel:|#|\/)/i.test(d)) return m;
+    if (/^(https?:\/\/|mailto:|tel:|#)/i.test(d)) return m;       // absolute / anchor
+    if (d.startsWith('/')) {
+      const seg = d.replace(/^\//, '').replace(/\/$/, '');
+      if (/^tags\//i.test(seg)) return `<a ${pre}href="https://github.com/topics/${seg.split('/')[1]}"${post}>`;
+      if (!seg.includes('/') && !seg.includes('.')) return `<a ${pre}href="https://github.com/${seg}"${post}>`;
+      const rel = seg;
+      return `<a ${pre}href="${base}/blob/${branch}/${rel}"${post}>`;
+    }
     const rel = d.replace(/^\.\//, '').replace(/^\.\.\//, '');
     return `<a ${pre}href="${base}/blob/${branch}/${rel}"${post}>`;
   });
@@ -129,8 +136,16 @@ function rewriteRelativeLinks(md, ghUrl, repoPath) {
     const d = dest.trim();
     if (/^(https?:\/\/|mailto:|tel:|#)/i.test(d)) return m;      // absolute / anchor
     let rel;
-    if (d.startsWith('/')) rel = d.slice(1);                        // repo-root absolute -> repo path
-    else rel = d.replace(/^\.\//, '').replace(/^\.\.\//, '');   // ./ or ../ -> repo root
+    if (d.startsWith('/')) {
+      // Repo-root absolute link. GitHub READMEs commonly use these for the
+      // author/org profile (/domini, /people) or topic pages (/tags/x).
+      // Point user/org + topic roots at real GitHub URLs instead of a broken
+      // repo-blob path; everything else is treated as a repo-path.
+      const seg = d.replace(/^\//, '').replace(/\/$/, '');
+      if (/^tags\//i.test(seg)) return `](https://github.com/topics/${seg.split('/')[1]})`;
+      if (!seg.includes('/') && !seg.includes('.')) return `](https://github.com/${seg})`;
+      rel = seg;
+    } else rel = d.replace(/^\.\//, '').replace(/^\.\.\//, '');   // ./ or ../ -> repo root
     const frag = d.includes('#') ? '#' + d.split('#')[1] : '';
     const q = d.includes('?') ? '?' + d.split('?')[1] : '';
     return `](${base}/blob/${branch}/${rel}${q}${frag})`;

--- a/scripts/sanitize.cjs
+++ b/scripts/sanitize.cjs
@@ -26,7 +26,12 @@ function sanitizeExternal(input) {
     .replace(/<(iframe|object|embed)\b[^>]*\/?>/gi, '')
     // a11y: <img> without alt gets an empty alt (decorative/technical images
     // from ingested gists/repos should not fail the a11y spot-check)
-    .replace(/<img\b([^>]*?)\b(?!alt=)([^>]*)>/gi, '<img alt="$1$2>');
+    .replace(/<img\b([^>]*?)\b(?!alt=)([^>]*)>/gi, '<img alt="$1$2>')
+    // link-rot: GitHub READMEs link to /tags/<x>/, /domini/, /people/ etc.
+    // that do not exist on this site. Neutralize those internal markdown
+    // links (keep the visible label, drop the broken href) so generated
+    // pages don't publish dead internal links.
+    .replace(/\[([^\]]+)\]\(((\/tags\/|\/domini\/|\/people\/)[^)\s]+)\)/gi, '$1');
 }
 
 module.exports = { sanitizeExternal };


### PR DESCRIPTION
## What
Fixes 11 dead internal links found by scanning the built site's internal `href`s against real output files.

**Root causes & fixes**
1. **9 broken `/tags/<topic>/` links** — `layouts/repository/single.html` (the template actually rendering repo single pages; `layouts/repositories/single.html` is a duplicate that isn't used) rendered each GitHub repo *topic* as `#config` → `/tags/config/` (a page that doesn't exist here). Now points to the real GitHub topic page `https://github.com/topics/<topic>` (new tab, `rel=noopener`). Verified in a fresh build: repo-topic chips now emit `https://github.com/topics/...` and zero `/tags/` topic links remain.
2. **2 broken `/domini/`, `/people/` links** — from ingested awesome GitHub READMEs (author/org profile links like `[Domini](/domini/)`). Fixed durably in `scripts/build-awesome.cjs::rewriteRelativeLinks`: repo-root `/X/` links where X is a single user/org segment now map to `https://github.com/X`, and `/tags/X` → `https://github.com/topics/X`. Also fixed the raw-HTML anchor branch, which previously left leading-`/` hrefs untouched and failed on multiline `<a>` tags.
3. **Defense in depth** — added the same `/tags/`, `/domini/`, `/people/` neutralization to `scripts/sanitize.cjs` (the trust-boundary sanitizer used by `sync-github.cjs` for repo/gist content), so future repo/gist syncs don't publish dead internal links either.

## Verification
- `node -c` on both scripts: OK
- Unit test of `rewriteRelativeLinks` (6 cases, incl. multiline raw `<a href="/domini/">`): ALL PASS — maps to github.com URLs, leaves relative/absolute links intact
- Fresh Hugo build: broken internal links dropped 11 → 2 (the 2 remaining are awesome-README `/domini/`/`/people/` links, which the build-awesome fix rewrites on the next deploy sync since the README content is sourced from the sparse submodule at build time)
- npm test: 3/3 (Unit + A11y + Perf) passed

The 9 topic-chip links are fixed immediately; the 2 README-authored links are fixed at the generation layer and apply on the next deploy's `refresh-awesome`/`sync-github` step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Repository topics now link directly to GitHub topic pages and open in a new browser tab.
  - Links in generated repository content now correctly resolve to GitHub topic pages, profiles, or repository files.

- **Bug Fixes**
  - Improved handling of repository links during site generation.
  - Broken links to unavailable tags, directories, or people pages are now displayed as plain text instead of leading to dead pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->