### PR TITLE
style: accentuate tag/category cloud (.neo-tagcloud + .count badge)

### DIFF
--- a/assets/css/neo.css
+++ b/assets/css/neo.css
@@ -406,6 +406,13 @@ html[data-reduce-motion="true"] *{animation:none !important; transition:none !im
 .neo-foot-col{display:flex;flex-direction:column;gap:8px}
 .neo-foot-col h5{font-family:var(--mono);font-size:12px;color:var(--accent);letter-spacing:1px;text-transform:uppercase;margin-bottom:4px}
 .neo-foot-col a{font-size:13.5px;color:var(--muted)}.neo-foot-col a:hover{color:var(--accent)}
+.neo-tagcloud{display:flex;flex-wrap:wrap;gap:10px;align-items:center;margin-top:.5rem}
+.neo-tagcloud .neo-chip{display:inline-flex;align-items:center;gap:.35rem;transition:color .2s,border-color .2s,background .2s,transform .2s}
+.neo-tagcloud .neo-chip:hover{color:var(--accent);border-color:color-mix(in srgb,var(--accent) 45%,transparent);
+  background:color-mix(in srgb,var(--accent) 10%,transparent);transform:translateY(-1px)}
+.neo-tagcloud .count{font-family:var(--mono);font-size:.72em;font-weight:700;color:var(--accent);
+  background:color-mix(in srgb,var(--accent) 16%,transparent);border:1px solid color-mix(in srgb,var(--accent) 35%,transparent);
+  padding:.05rem .4rem;border-radius:999px;line-height:1}
 .neo-tagcloud-foot{max-width:1180px;margin:0 auto;padding:0 24px 40px;display:flex;flex-wrap:wrap;gap:10px;align-items:center}
 .neo-tagcloud-foot .neo-tc{color:var(--muted);border:1px solid var(--line-2);border-radius:999px;padding:4px 12px;transition:color .2s,border-color .2s}
 .neo-tagcloud-foot .neo-tc:hover{color:var(--accent);border-color:var(--accent)}


### PR DESCRIPTION
## What
The tag/category landing pages (`/tags/`, `/categories/`) render via `layouts/_default/terms.html` (a standalone neo page that loads only neo.css). The cloud container `.neo-tagcloud` had **no rule in neo.css** (only the unrelated `.neo-tagcloud-foot` existed), so the chips weren't laid out as a flex-wrap cloud, and the per-chip post-count `.count` badge was unstyled.

Added to neo.css (token-driven, matches the rest of the accent system):
- `.neo-tagcloud` — flex-wrap container with gap
- `.neo-tagcloud .neo-chip` — accent hover (color + border + subtle bg + lift), consistent with the other accentuated lists
- `.neo-tagcloud .count` — accent pill badge (accent text + tinted bg + border) for the post count

This is the last un-accentuated "list" surface (tag/category cloud) and rounds out the consistent neo accent system across gists, repositories, awesome, homepage, about, and the taxonomy cloud.

## Verification
- Hugo build: Total in 1883 ms
- Built neo.min.css contains `neo-tagcloud{display:flex` and `neo-tagcloud .count{`
- npm test: 3/3 (Unit + A11y + Perf) passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Added a responsive tag cloud layout with wrapping tags.
  - Added hover effects that highlight tags with accent colors and a subtle lift animation.
  - Added styled count badges with bold, monospace text and tinted backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->