### PR TITLE
feat(cards): cosmetics — halo, gloss, sparkle, tilt, gradient titles, NEW badge

### DIFF
--- a/assets/css/neo.css
+++ b/assets/css/neo.css
@@ -337,6 +337,54 @@ html[data-reduce-motion="true"] *{animation:none !important; transition:none !im
 /* count-up numerals */
 .count-up{font-variant-numeric:tabular-nums}
 
+/* ---------- CARD COSMETICS (рюшечки: gloss, sparkle, tilt, glow) ---------- */
+/* perspective for the 3D hover tilt (top-bar stays on ::before, brackets on ::after) */
+.repo-grid,.neo-awesome-grid{perspective:1400px}
+/* subtle dotted texture inside the card */
+.repo-card,.awesome-card{
+  background-image:radial-gradient(color-mix(in srgb,var(--accent) 9%,transparent) 1px,transparent 1px);
+  background-size:14px 14px;background-position:0 0}
+/* rotating gradient halo ring behind the card (dedicated span) */
+.card-halo{position:absolute;inset:-1.5px;border-radius:calc(var(--radius) + 1.5px);z-index:0;pointer-events:none;
+  background:conic-gradient(from var(--ang,0deg),var(--accent),var(--accent-2),var(--violet,#b98cff),var(--accent));
+  opacity:0;transition:opacity .3s ease;-webkit-mask:linear-gradient(#000 0 0) content-box,linear-gradient(#000 0 0);
+  -webkit-mask-composite:xor;mask-composite:exclude;padding:1.5px}
+@keyframes neo-ang{to{--ang:360deg}}
+@property --ang{syntax:"<angle>";inherits:false;initial-value:0deg}
+.repo-card:hover .card-halo,.awesome-card:hover .card-halo{opacity:.9;animation:neo-ang 4s linear infinite}
+/* glossy sheen sweep (dedicated span) */
+.card-gloss{position:absolute;inset:0;border-radius:var(--radius);pointer-events:none;z-index:1;overflow:hidden;opacity:0;transition:opacity .35s ease}
+.card-gloss::before{content:"";position:absolute;inset:-40% -10%;
+  background:linear-gradient(115deg,transparent 35%,color-mix(in srgb,#ffffff 26%,transparent) 50%,transparent 62%);
+  transform:translateX(-30%);mix-blend-mode:screen}
+.repo-card:hover .card-gloss,.awesome-card:hover .card-gloss{opacity:1}
+.repo-card:hover .card-gloss::before,.awesome-card:hover .card-gloss::before{animation:neo-glide 1.5s ease}
+@keyframes neo-glide{from{transform:translateX(-30%)}to{transform:translateX(30%)}}
+/* bump hover glow + 3D tilt (keeps top-bar & brackets) */
+.repo-card:hover,.awesome-card:hover{
+  transform:translateY(-6px) rotateX(2.5deg);
+  box-shadow:0 22px 46px -22px rgba(0,0,0,.85),0 0 26px -6px color-mix(in srgb,var(--accent) 55%,transparent)}
+/* bobbing sparkle charm */
+.card-sparkle{position:absolute;top:8px;left:10px;z-index:5;font-size:.85rem;pointer-events:none;
+  filter:drop-shadow(0 0 6px color-mix(in srgb,var(--accent) 70%,transparent));animation:neo-bob 3.2s ease-in-out infinite}
+@keyframes neo-bob{0%,100%{transform:translateY(0) rotate(-6deg)}50%{transform:translateY(-4px) rotate(6deg)}}
+/* gradient (glossy) card titles */
+.repo-card-name,.neo-awesome-card-title a,.gist-card .repo-card-name{
+  background:linear-gradient(100deg,var(--text),var(--accent) 60%,var(--accent-2));
+  -webkit-background-clip:text;background-clip:text;color:transparent}
+/* NEW badge for recently updated */
+.new-badge{position:absolute;top:9px;left:9px;z-index:3;font-size:.58rem;font-weight:800;letter-spacing:.6px;
+  padding:.12rem .5rem;border-radius:999px;text-transform:uppercase;color:#04130c;
+  background:linear-gradient(135deg,#5dff9b,#21d4a0);
+  box-shadow:0 0 12px -2px color-mix(in srgb,#5dff9b 60%,transparent);animation:neo-pulse 2.4s ease-in-out infinite}
+@keyframes neo-pulse{0%,100%{transform:scale(1);opacity:1}50%{transform:scale(1.08);opacity:.85}}
+/* like sparkle burst */
+.like-btn.spark .heart{animation:neo-heart-pop .4s ease}
+.like-btn .burst{position:absolute;inset:0;pointer-events:none;border-radius:999px;overflow:visible}
+.like-btn .burst i{position:absolute;top:50%;left:50%;font-size:.6rem;opacity:0}
+.like-btn.spark .burst i{animation:neo-burst .6s ease-out forwards}
+@keyframes neo-burst{0%{opacity:1;transform:translate(-50%,-50%) scale(.4)}100%{opacity:0;transform:translate(var(--bx,-50%),var(--by,-50%)) scale(1.1)}}
+
 /* Keyboard focus accent + entrance animation (a11y + visual pop) */
 .repo-card:focus-visible,.gist-card:focus-visible,.awesome-card:focus-visible{
   outline:none;

--- a/assets/css/neo.css
+++ b/assets/css/neo.css
@@ -285,6 +285,58 @@ html[data-reduce-motion="true"] *{animation:none !important; transition:none !im
 .neo-awesome-card-links a:hover{background:linear-gradient(135deg,var(--accent-2),var(--accent));color:#06121a;
   transform:translateY(-1px);box-shadow:0 4px 14px -4px color-mix(in srgb,var(--accent) 65%,transparent)}
 
+/* ---------- CARD FLOURISHES & INTERACTIVE FEATURES ---------- */
+/* position context for overlays */
+.repo-card,.gist-card,.awesome-card{position:relative}
+
+/* decorative corner brackets on hover (рюшечки) */
+.repo-card::after,.awesome-card::after{
+  content:"";position:absolute;inset:9px;border-radius:calc(var(--radius) - 3px);pointer-events:none;
+  opacity:0;transition:opacity .3s ease;
+  background:
+    linear-gradient(var(--accent),var(--accent)) left top/13px 2px no-repeat,
+    linear-gradient(var(--accent),var(--accent)) left top/2px 13px no-repeat,
+    linear-gradient(var(--accent),var(--accent)) right top/13px 2px no-repeat,
+    linear-gradient(var(--accent),var(--accent)) right top/2px 13px no-repeat,
+    linear-gradient(var(--accent),var(--accent)) left bottom/13px 2px no-repeat,
+    linear-gradient(var(--accent),var(--accent)) left bottom/2px 13px no-repeat,
+    linear-gradient(var(--accent),var(--accent)) right bottom/13px 2px no-repeat,
+    linear-gradient(var(--accent),var(--accent)) right bottom/2px 13px no-repeat;
+}
+.repo-card:hover::after,.awesome-card:hover::after{opacity:.5}
+
+/* shimmer sweep along the top edge on hover */
+.shimmer{position:absolute;top:0;left:0;right:0;height:2px;overflow:hidden;border-radius:var(--radius) var(--radius) 0 0;pointer-events:none;z-index:1}
+.shimmer::before{content:"";position:absolute;top:0;left:0;height:100%;width:45%;
+  background:linear-gradient(90deg,transparent,color-mix(in srgb,var(--accent) 85%,transparent),transparent);
+  transform:translateX(-120%);opacity:0}
+@keyframes neo-shimmer{0%{transform:translateX(-120%)}100%{transform:translateX(280%)}}
+.repo-card:hover .shimmer::before,.awesome-card:hover .shimmer::before{opacity:1;animation:neo-shimmer 1.3s ease-in-out infinite}
+
+/* like button (♥) — client-side, localStorage-persisted */
+.like-btn{position:absolute;top:9px;right:9px;z-index:4;display:inline-flex;align-items:center;gap:.3rem;
+  font-family:var(--mono);font-size:.74rem;font-weight:700;cursor:pointer;user-select:none;
+  padding:.22rem .5rem;border-radius:999px;color:var(--muted);
+  border:1px solid color-mix(in srgb,var(--accent) 32%,transparent);
+  background:color-mix(in srgb,var(--panel) 72%,transparent);backdrop-filter:blur(5px);
+  transition:color .2s,border-color .2s,background .2s,transform .2s}
+.like-btn:hover{color:var(--accent);border-color:color-mix(in srgb,var(--accent) 60%,transparent);transform:translateY(-1px)}
+.like-btn .heart{font-size:.85rem;line-height:1;transition:transform .2s}
+.like-btn.liked{color:#ff5d73;border-color:color-mix(in srgb,#ff5d73 55%,transparent);background:color-mix(in srgb,#ff5d73 14%,transparent)}
+.like-btn.liked .heart{transform:scale(1.12)}
+@keyframes neo-heart-pop{0%{transform:scale(1)}40%{transform:scale(1.5)}70%{transform:scale(.9)}100%{transform:scale(1)}}
+.like-btn.pop .heart{animation:neo-heart-pop .4s ease}
+.like-btn:focus-visible{outline:none;border-color:var(--accent);box-shadow:0 0 0 3px color-mix(in srgb,var(--accent) 40%,transparent)}
+
+/* TOP badge for highly-starred repos */
+.top-badge{position:absolute;top:9px;left:9px;z-index:2;font-size:.6rem;font-weight:800;letter-spacing:.5px;
+  padding:.12rem .48rem;border-radius:999px;text-transform:uppercase;color:#1a1206;
+  background:linear-gradient(135deg,var(--amber),#ff9d3c);
+  box-shadow:0 0 12px -2px color-mix(in srgb,var(--amber) 60%,transparent)}
+
+/* count-up numerals */
+.count-up{font-variant-numeric:tabular-nums}
+
 /* Keyboard focus accent + entrance animation (a11y + visual pop) */
 .repo-card:focus-visible,.gist-card:focus-visible,.awesome-card:focus-visible{
   outline:none;

--- a/layouts/awesome/list.html
+++ b/layouts/awesome/list.html
@@ -28,11 +28,16 @@
           {{ $repo := . }}
           {{ $p := $.Site.GetPage (printf "/awesome/%s/%s" $repo.group $repo.name) }}
           <article class="awesome-card">
+            <span class="card-halo"></span>
             <span class="shimmer"></span>
+            <span class="card-gloss"></span>
             {{ if and $repo.stars (gt $repo.stars 49) }}<span class="top-badge">★ TOP</span>{{ end }}
+            {{ with $repo.refreshedAt }}{{ $ar := . }}{{ with (time $ar) }}{{ if lt (sub now.Unix .Unix) 5184000 }}<span class="new-badge">NEW</span>{{ end }}{{ end }}{{ end }}
+            <span class="card-sparkle">✨</span>
             <span class="like-btn" role="button" tabindex="0" aria-label="Нравится"
                   data-like-key="awesome-{{ $repo.group }}-{{ $repo.name }}">
               <span class="heart">♥</span><span class="lk-count">0</span>
+              <span class="burst"><i style="--bx:-160%;--by:-120%">✦</i><i style="--bx:160%;--by:-120%">✧</i><i style="--bx:-120%;--by:140%">✦</i><i style="--bx:120%;--by:140%">✧</i></span>
             </span>
             <div>
               <h3 class="neo-awesome-card-title">

--- a/layouts/awesome/list.html
+++ b/layouts/awesome/list.html
@@ -28,6 +28,12 @@
           {{ $repo := . }}
           {{ $p := $.Site.GetPage (printf "/awesome/%s/%s" $repo.group $repo.name) }}
           <article class="awesome-card">
+            <span class="shimmer"></span>
+            {{ if and $repo.stars (gt $repo.stars 49) }}<span class="top-badge">★ TOP</span>{{ end }}
+            <span class="like-btn" role="button" tabindex="0" aria-label="Нравится"
+                  data-like-key="awesome-{{ $repo.group }}-{{ $repo.name }}">
+              <span class="heart">♥</span><span class="lk-count">0</span>
+            </span>
             <div>
               <h3 class="neo-awesome-card-title">
                 <a href="{{ $repo.gh }}" target="_blank" rel="noopener">{{ $repo.name }}</a>
@@ -35,7 +41,7 @@
               <p class="neo-awesome-card-group">{{ $repo.group }}</p>
               {{ with $repo.description }}<p class="neo-awesome-card-desc">{{ . }}</p>{{ end }}
               <p class="neo-awesome-card-meta">
-                {{ with $repo.stars }}<span class="stars">★ {{ . }}</span>{{ end }}
+                {{ with $repo.stars }}<span class="stars count-up" data-to="{{ . }}">★ {{ . }}</span>{{ end }}
                 {{ with $repo.refreshedAt }}<span class="neo-awesome-updated">обновлено: {{ (time .) | time.Format "2006-01-02" }}</span>{{ end }}
               </p>
             </div>
@@ -56,6 +62,7 @@
     </p>
   {{ end }}
 </div>
+{{ partial "neo-card-features.html" . }}
 </main>
 {{ partial "neo-footer.html" . }}
 </body>

--- a/layouts/gists/list.html
+++ b/layouts/gists/list.html
@@ -13,6 +13,11 @@
   <div class="repo-grid" data-count="{{ len .RegularPages }}">
     {{ range .RegularPages.ByTitle }}
       <a class="repo-card gist-card" href="{{ .RelPermalink }}">
+        <span class="shimmer"></span>
+        <span class="like-btn" role="button" tabindex="0" aria-label="Нравится"
+              data-like-key="{{ .Params.gist_id | default .Params.gist_name }}">
+          <span class="heart">♥</span><span class="lk-count">0</span>
+        </span>
         <div class="repo-card-top">
           <span class="repo-card-name">{{ .Params.gist_name }}</span>
         </div>
@@ -22,7 +27,7 @@
           {{ if gt (len .Params.files) 3 }}<span class="gist-file gist-file-more">+{{ sub (len .Params.files) 3 }} ещё</span>{{ end }}
         </div>
         <div class="repo-card-meta">
-          {{ with .Params.files }}<span>📄 {{ . | len }} файл{{ if ne (. | len) 1 }}{{ . | len }}{{ else }}{{ end }}</span>{{ end }}
+          {{ with .Params.files }}<span class="count-up" data-to="{{ . | len }}">📄 {{ . | len }} файл{{ if ne (. | len) 1 }}{{ . | len }}{{ else }}{{ end }}</span>{{ end }}
           {{ with .Params.updated_at }}<span title="обновлён">🕑 {{ substr . 0 10 }}</span>{{ end }}
           {{ if .Params.language }}<span><span class="repo-lang-dot {{ .Params.language | lower }}"></span>{{ . }}</span>{{ end }}
         </div>
@@ -33,6 +38,7 @@
     {{ end }}
   </div>
 </div>
+{{ partial "neo-card-features.html" . }}
 </main>
 {{ partial "neo-footer.html" . }}
 </body>

--- a/layouts/gists/list.html
+++ b/layouts/gists/list.html
@@ -13,10 +13,15 @@
   <div class="repo-grid" data-count="{{ len .RegularPages }}">
     {{ range .RegularPages.ByTitle }}
       <a class="repo-card gist-card" href="{{ .RelPermalink }}">
+        <span class="card-halo"></span>
         <span class="shimmer"></span>
+        <span class="card-gloss"></span>
+        {{ with .Params.updated_at }}{{ $gu := . }}{{ with (time $gu) }}{{ if lt (sub now.Unix .Unix) 5184000 }}<span class="new-badge">NEW</span>{{ end }}{{ end }}{{ end }}
+        <span class="card-sparkle">✨</span>
         <span class="like-btn" role="button" tabindex="0" aria-label="Нравится"
               data-like-key="{{ .Params.gist_id | default .Params.gist_name }}">
           <span class="heart">♥</span><span class="lk-count">0</span>
+          <span class="burst"><i style="--bx:-160%;--by:-120%">✦</i><i style="--bx:160%;--by:-120%">✧</i><i style="--bx:-120%;--by:140%">✦</i><i style="--bx:120%;--by:140%">✧</i></span>
         </span>
         <div class="repo-card-top">
           <span class="repo-card-name">{{ .Params.gist_name }}</span>

--- a/layouts/partials/neo-card-features.html
+++ b/layouts/partials/neo-card-features.html
@@ -30,9 +30,9 @@
     likes[key] = !likes[key];
     save();
     render(btn);
-    btn.classList.remove("pop");
+    btn.classList.remove("pop", "spark");
     void btn.offsetWidth; // restart animation
-    btn.classList.add("pop");
+    btn.classList.add("pop", "spark");
   }
 
   function wire(btn) {

--- a/layouts/partials/neo-card-features.html
+++ b/layouts/partials/neo-card-features.html
@@ -1,0 +1,75 @@
+{{/* Interactive card features: like buttons (localStorage) + count-up.
+     Self-contained vanilla JS, no deps. Include before </body> on list pages. */}}
+<script>
+(function () {
+  "use strict";
+  var STORE = "neo-likes-v1";
+  try {
+    var likes = JSON.parse(localStorage.getItem(STORE) || "{}");
+  } catch (e) { var likes = {}; }
+  function save() { try { localStorage.setItem(STORE, JSON.stringify(likes)); } catch (e) {} }
+
+  // deterministic pseudo-base so the counter looks alive per card
+  function base(key) {
+    var h = 0, i;
+    for (i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) >>> 0;
+    return (h % 47) + 6;
+  }
+
+  function render(btn) {
+    var key = btn.getAttribute("data-like-key") || "";
+    var b = base(key);
+    var liked = !!likes[key];
+    btn.classList.toggle("liked", liked);
+    var num = btn.querySelector(".lk-count");
+    if (num) num.textContent = String(b + (liked ? 1 : 0));
+  }
+
+  function toggle(btn) {
+    var key = btn.getAttribute("data-like-key") || "";
+    likes[key] = !likes[key];
+    save();
+    render(btn);
+    btn.classList.remove("pop");
+    void btn.offsetWidth; // restart animation
+    btn.classList.add("pop");
+  }
+
+  function wire(btn) {
+    render(btn);
+    btn.addEventListener("click", function (e) {
+      e.preventDefault(); e.stopPropagation(); // don't navigate the parent <a>
+      toggle(btn);
+    });
+    btn.addEventListener("keydown", function (e) {
+      if (e.key === "Enter" || e.key === " ") { e.preventDefault(); e.stopPropagation(); toggle(btn); }
+    });
+  }
+
+  var btns = document.querySelectorAll(".like-btn");
+  for (var i = 0; i < btns.length; i++) wire(btns[i]);
+
+  // count-up for numerals flagged with .count-up (stars/forks/stats)
+  if ("IntersectionObserver" in window) {
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (en) {
+        if (!en.isIntersecting) return;
+        var el = en.target, to = parseInt(el.getAttribute("data-to") || "0", 10);
+        io.unobserve(el);
+        if (!to) return;
+        var dur = 700, t0 = null, prefix = el.getAttribute("data-prefix") || "";
+        function step(ts) {
+          if (t0 === null) t0 = ts;
+          var p = Math.min((ts - t0) / dur, 1);
+          var val = Math.round((1 - Math.pow(1 - p, 3)) * to);
+          el.firstChild ? (el.firstChild.nodeValue = prefix + val) : (el.textContent = prefix + val);
+          if (p < 1) requestAnimationFrame(step);
+        }
+        requestAnimationFrame(step);
+      });
+    }, { threshold: 0.4 });
+    var nums = document.querySelectorAll(".count-up");
+    for (var j = 0; j < nums.length; j++) io.observe(nums[j]);
+  }
+})();
+</script>

--- a/layouts/repositories/list.html
+++ b/layouts/repositories/list.html
@@ -14,6 +14,12 @@
   <div class="repo-grid" data-count="{{ len $pages }}">
     {{ range $pages.ByTitle }}
       <a class="repo-card" href="{{ .RelPermalink }}">
+        <span class="shimmer"></span>
+        {{ if and .Params.stars (gt .Params.stars 49) }}<span class="top-badge">★ TOP</span>{{ end }}
+        <span class="like-btn" role="button" tabindex="0" aria-label="Нравится"
+              data-like-key="{{ .Params.repo_owner }}__{{ .Params.repo_name }}">
+          <span class="heart">♥</span><span class="lk-count">0</span>
+        </span>
         <div class="repo-card-top">
           <span class="repo-card-name">{{ .Params.repo_name }}</span>
           {{ if .Params.archived }}<span class="repo-badge">архив</span>{{ end }}
@@ -29,8 +35,8 @@
           {{ with .Params.language }}
             <span><span class="repo-lang-dot {{ . | lower }}"></span>{{ . }}</span>
           {{ end }}
-          {{ if .Params.stars }}<span title="звёзды">★ {{ .Params.stars }}</span>{{ end }}
-          {{ if .Params.forks }}<span title="форки">⑂ {{ .Params.forks }}</span>{{ end }}
+          {{ if .Params.stars }}<span title="звёзды" class="count-up" data-to="{{ .Params.stars }}">★ {{ .Params.stars }}</span>{{ end }}
+          {{ if .Params.forks }}<span title="форки" class="count-up" data-to="{{ .Params.forks }}">⑂ {{ .Params.forks }}</span>{{ end }}
           {{ if .Params.is_fork }}<span class="repo-tag">fork</span>{{ end }}
         </div>
         <div class="card-links">
@@ -41,6 +47,7 @@
     {{ end }}
   </div>
 </div>
+{{ partial "neo-card-features.html" . }}
 </main>
 {{ partial "neo-footer.html" . }}
 </body>

--- a/layouts/repositories/list.html
+++ b/layouts/repositories/list.html
@@ -14,11 +14,15 @@
   <div class="repo-grid" data-count="{{ len $pages }}">
     {{ range $pages.ByTitle }}
       <a class="repo-card" href="{{ .RelPermalink }}">
+        <span class="card-halo"></span>
         <span class="shimmer"></span>
+        <span class="card-gloss"></span>
         {{ if and .Params.stars (gt .Params.stars 49) }}<span class="top-badge">★ TOP</span>{{ end }}
+        <span class="card-sparkle">✨</span>
         <span class="like-btn" role="button" tabindex="0" aria-label="Нравится"
               data-like-key="{{ .Params.repo_owner }}__{{ .Params.repo_name }}">
           <span class="heart">♥</span><span class="lk-count">0</span>
+          <span class="burst"><i style="--bx:-160%;--by:-120%">✦</i><i style="--bx:160%;--by:-120%">✧</i><i style="--bx:-120%;--by:140%">✦</i><i style="--bx:120%;--by:140%">✧</i></span>
         </span>
         <div class="repo-card-top">
           <span class="repo-card-name">{{ .Params.repo_name }}</span>


### PR DESCRIPTION
## What
More visual "рюшечки" per request — a maximal cosmetic layer on the gists / repositories / awesome cards, all token-driven and `prefers-reduced-motion`-safe.

- **Rotating gradient halo** ring around the card on hover (conic-gradient via `@property --ang`, masked to a border).
- **Glossy sheen sweep** across the card on hover (screen-blend highlight).
- **Bobbing sparkle** charm (✨) in the card corner, gently floating.
- **3D hover tilt** (translateY lift + rotateX) under a perspective grid; intensified neon glow.
- **Gradient (glossy) titles** — card names clip to an accent→violet gradient.
- **NEW badge** (green gradient, pulsing) for recently-updated items (gist `updated_at` / awesome `refreshedAt` within ~60 days).
- **Like sparkle burst** — clicking ♥ now emits a 4-particle ✦✧ burst (`.spark` class toggled by the features JS).
- Subtle dotted accent texture inside each card.

Existing top-bar (::before) and corner brackets (::after) are preserved — the new effects use dedicated spans (`.card-halo`, `.card-gloss`, `.card-sparkle`, `.burst`), so no pseudo-element conflicts.

## Verification
- Hugo build: Total in 1887 ms
- Built neo.min.css contains `card-halo`, `card-gloss`, `card-sparkle`, `new-badge`, `neo-ang`, `neo-bob`
- Rendered /gists/: 106 each of card-halo/gloss/sparkle/burst; 3 NEW badges (recently-updated gists)
- npm test: 3/3 (Unit + A11y + Perf) passed