### PR TITLE
feat(site): site-wide cosmetics — aurora bg, glass header, glossy links, scroll progress, click sparkle

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -607,3 +607,31 @@ img { height: auto; }
 .m-plot { font-size:.76rem; margin:0 0 .5rem; }
 .m-plot summary { cursor:pointer; color:var(--accent,#6ee7b7); font-weight:600; }
 .m-plot p { margin:.35rem 0 0; color:var(--muted,#9aa); line-height:1.4; }
+
+/* ---------- SITE-WIDE COSMETICS (theme pages) ---------- */
+/* aurora glow behind theme pages */
+body::before{content:"";position:fixed;inset:0;z-index:-2;pointer-events:none;
+  background:
+    radial-gradient(60vmax 60vmax at 12% 8%,color-mix(in srgb,rgb(var(--color-primary-500)) 14%,transparent),transparent 60%),
+    radial-gradient(50vmax 50vmax at 88% 22%,color-mix(in srgb,var(--violet,#b98cff) 12%,transparent),transparent 60%),
+    radial-gradient(46vmax 46vmax at 60% 92%,color-mix(in srgb,rgb(var(--color-primary-400)) 10%,transparent),transparent 60%)}
+/* gradient underline on site header */
+header nav, .site-header{border-bottom:1px solid rgba(var(--ring),.4)}
+.site-header::after,header nav::after{content:"";display:block;height:1px;
+  background:linear-gradient(90deg,transparent,rgb(var(--color-primary-500)),var(--violet,#b98cff),transparent);
+  background-size:200% 100%;animation:neo-sheen 6s linear infinite}
+@keyframes neo-sheen{0%{background-position:0% 0}100%{background-position:200% 0}}
+/* selection tint */
+::selection{background:color-mix(in srgb,rgb(var(--color-primary-500)) 30%,transparent);color:inherit}
+/* focus glow */
+a:focus-visible,button:focus-visible,input:focus-visible,[tabindex]:focus-visible{
+  outline:none;box-shadow:0 0 0 3px color-mix(in srgb,rgb(var(--color-primary-500)) 45%,transparent)}
+/* glossy in-content links */
+.prose a, .repo-body a, .gist-body a{color:rgb(var(--color-primary-300));text-decoration:none;
+  background-image:linear-gradient(rgb(var(--color-primary-300)),rgb(var(--color-primary-300)));
+  background-size:0% 1.5px;background-repeat:no-repeat;background-position:0 100%;transition:background-size .25s ease}
+.prose a:hover, .repo-body a:hover, .gist-body a:hover{background-size:100% 1.5px}
+/* entrance for posts */
+@keyframes neo-rise{from{opacity:0;transform:translateY(14px)}to{opacity:1;transform:none}}
+.prose, .repo-page, .gist-page, .awesome-preview{animation:neo-rise .5s ease both}
+@media (prefers-reduced-motion: no-preference){.prose,.repo-page,.gist-page,.awesome-preview{animation:neo-rise .5s ease both}}

--- a/assets/css/neo.css
+++ b/assets/css/neo.css
@@ -73,6 +73,7 @@ body::before{
     radial-gradient(700px 500px at 0% 10%,color-mix(in srgb,var(--violet) 9%,transparent),transparent 55%),
     var(--bg);
 }
+/* aurora: drifting glow orbs behind everything */
 body::after{
   content:"";position:fixed;inset:0;z-index:-1;pointer-events:none;
   background-image:linear-gradient(var(--grid) 1px,transparent 1px),
@@ -81,6 +82,13 @@ body::after{
   -webkit-mask-image:radial-gradient(ellipse at 50% 0%,#000 30%,transparent 75%);
           mask-image:radial-gradient(ellipse at 50% 0%,#000 30%,transparent 75%);
 }
+.neo-aurora{position:fixed;inset:-20vmax;z-index:-3;pointer-events:none;filter:blur(40px);opacity:.55;
+  background:
+    radial-gradient(38vmax 38vmax at 20% 18%,color-mix(in srgb,var(--accent) 30%,transparent),transparent 60%),
+    radial-gradient(34vmax 34vmax at 82% 30%,color-mix(in srgb,var(--violet,#b98cff) 26%,transparent),transparent 60%),
+    radial-gradient(30vmax 30vmax at 60% 88%,color-mix(in srgb,var(--accent-2) 22%,transparent),transparent 60%);
+  animation:neo-aurora 22s ease-in-out infinite alternate}
+@keyframes neo-aurora{0%{transform:translate3d(-3%,-2%,0) rotate(0deg)}50%{transform:translate3d(4%,3%,0) rotate(8deg)}100%{transform:translate3d(-2%,4%,0) rotate(-6deg)}}
 @media (prefers-reduced-motion: reduce){
   *{animation:none !important; transition:none !important; scroll-behavior:auto !important}
 }
@@ -602,6 +610,54 @@ img{height:auto}
   -webkit-background-clip:text;background-clip:text;color:transparent;font-size:1.7rem;margin:.2rem 0 .4rem}
 .gist-links{display:flex;flex-wrap:wrap;gap:.6rem;margin-top:.7rem;position:relative;z-index:2}
 .gist-body{position:relative;z-index:2;margin-top:1rem}
+
+/* ---------- SITE-WIDE COSMETICS (глобальные рюшечки) ---------- */
+/* glassy header with animated gradient underline */
+.neo-header{backdrop-filter:blur(14px) saturate(140%);background:color-mix(in srgb,var(--bg) 68%,transparent)}
+.neo-header::after{content:"";position:absolute;left:0;right:0;bottom:-1px;height:1px;
+  background:linear-gradient(90deg,transparent,color-mix(in srgb,var(--accent) 70%,transparent),color-mix(in srgb,var(--violet,#b98cff) 70%,transparent),transparent);
+  background-size:200% 100%;animation:neo-sheen 6s linear infinite}
+@keyframes neo-sheen{0%{background-position:0% 0}100%{background-position:200% 0}}
+/* animated gradient brand mark */
+.neo-brand .mark{background:linear-gradient(135deg,var(--accent),var(--accent-2),var(--violet,#b98cff));
+  background-size:200% 200%;animation:neo-mark 6s ease-in-out infinite;color:#fff;font-weight:800;
+  box-shadow:0 0 16px -4px color-mix(in srgb,var(--accent) 60%,transparent)}
+@keyframes neo-mark{0%,100%{background-position:0% 50%}50%{background-position:100% 50%}}
+/* glossy nav links */
+.neo-menu a{position:relative;transition:color .2s}
+.neo-menu a::after{content:"";position:absolute;left:0;right:0;bottom:-4px;height:2px;border-radius:2px;
+  background:linear-gradient(90deg,var(--accent),var(--accent-2));transform:scaleX(0);transform-origin:left;
+  transition:transform .25s ease}
+.neo-menu a:hover{color:var(--accent)}
+.neo-menu a:hover::after{transform:scaleX(1)}
+.neo-icon-btn{transition:transform .15s,color .2s,box-shadow .2s,border-color .2s}
+.neo-icon-btn:hover{box-shadow:0 0 14px -3px color-mix(in srgb,var(--accent) 60%,transparent);border-color:color-mix(in srgb,var(--accent) 45%,transparent)}
+/* glossy in-content links */
+.neo-post-body a,.neo-prose a,.prose a{color:var(--accent);text-decoration:none;
+  background-image:linear-gradient(var(--accent),var(--accent));background-size:0% 1.5px;background-repeat:no-repeat;
+  background-position:0 100%;transition:background-size .25s ease,color .2s}
+.neo-post-body a:hover,.neo-prose a:hover,.prose a:hover{background-size:100% 1.5px}
+/* scroll progress bar */
+.neo-progress{position:fixed;top:0;left:0;height:3px;width:0;z-index:60;pointer-events:none;
+  background:linear-gradient(90deg,var(--accent),var(--accent-2),var(--violet,#b98cff));
+  box-shadow:0 0 10px -1px color-mix(in srgb,var(--accent) 70%,transparent)}
+/* selection tint */
+::selection{background:color-mix(in srgb,var(--accent) 30%,transparent);color:var(--text)}
+/* focus glow everywhere */
+a:focus-visible,button:focus-visible,input:focus-visible,[tabindex]:focus-visible{
+  outline:none;box-shadow:0 0 0 3px color-mix(in srgb,var(--accent) 45%,transparent)}
+/* entrance animation for posts/sections (cards keep their own neo-card-in) */
+@keyframes neo-rise{from{opacity:0;transform:translateY(14px)}to{opacity:1;transform:none}}
+.neo-post,.neo-section,.neo-row{animation:neo-rise .5s ease both}
+@media (prefers-reduced-motion: no-preference){
+  .neo-post,.neo-section,.neo-row{animation:neo-rise .5s ease both}
+}
+/* cute floating decorative orbs (non-interactive) */
+.neo-spark{position:fixed;bottom:18px;right:74px;z-index:55;font-size:1.1rem;pointer-events:none;
+  filter:drop-shadow(0 0 8px color-mix(in srgb,var(--accent) 70%,transparent));animation:neo-bob 3.6s ease-in-out infinite}
+/* back-to-top glow */
+#neo-backtotop{box-shadow:0 6px 18px -6px color-mix(in srgb,var(--accent) 55%,transparent)}
+#neo-backtotop:hover{box-shadow:0 0 18px -3px color-mix(in srgb,var(--accent) 70%,transparent)}
 
 /* ---------- PRINT ---------- */
 @media print{

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -105,3 +105,61 @@
     b.addEventListener('click', function(){ window.scrollTo({top:0, behavior:'smooth'}); });
   }
 })();
+
+/* Global site flourishes: aurora bg, scroll progress, click sparkle.
+   Presentation-only. Disabled when reduced-motion is on. */
+(function(){
+  "use strict";
+  try {
+    var reduce = document.documentElement.getAttribute('data-reduce-motion') === 'true';
+    if (reduce) return;
+
+    // aurora layer
+    var aur = document.createElement('div');
+    aur.className = 'neo-aurora';
+    document.body.appendChild(aur);
+    // cute floating sparkle
+    var sp = document.createElement('span');
+    sp.className = 'neo-spark';
+    sp.textContent = '✨';
+    document.body.appendChild(sp);
+
+    // scroll progress bar
+    var bar = document.createElement('div');
+    bar.className = 'neo-progress';
+    document.body.appendChild(bar);
+    var ticking = false;
+    window.addEventListener('scroll', function(){
+      if (ticking) return; ticking = true;
+      requestAnimationFrame(function(){
+        var h = document.documentElement.scrollHeight - window.innerHeight;
+        var p = h > 0 ? (window.scrollY / h) * 100 : 0;
+        bar.style.width = p + '%';
+        ticking = false;
+      });
+    }, {passive:true});
+
+    // click sparkle burst (cute)
+    var glyphs = ['✦','✧','✨','★','♥'];
+    document.addEventListener('click', function(e){
+      var n = 5;
+      for (var i = 0; i < n; i++){
+        var s = document.createElement('span');
+        s.textContent = glyphs[(Math.random() * glyphs.length) | 0];
+        s.style.cssText = 'position:fixed;left:' + e.clientX + 'px;top:' + e.clientY + 'px;z-index:90;pointer-events:none;' +
+          'font-size:' + (10 + Math.random() * 10).toFixed(0) + 'px;color:var(--accent);' +
+          'text-shadow:0 0 8px color-mix(in srgb,var(--accent) 70%,transparent);' +
+          'transition:transform .7s ease-out,opacity .7s ease-out;opacity:1';
+        document.body.appendChild(s);
+        (function(el){
+          requestAnimationFrame(function(){
+            var dx = (Math.random() - 0.5) * 80, dy = (Math.random() - 0.5) * 80 - 30;
+            el.style.transform = 'translate(' + dx + 'px,' + dy + 'px) scale(.4) rotate(' + (Math.random() * 360 | 0) + 'deg)';
+            el.style.opacity = '0';
+          });
+          setTimeout(function(){ el.remove(); }, 750);
+        })(s);
+      }
+    });
+  } catch (e) {}
+})();


### PR DESCRIPTION
## What
Elevate the **entire site** visually per request — maximal "рюшечки" applied globally (not just cards). Covers all pages since the site has two CSS systems (neo.css for standalone pages = ~all pages; custom.css for theme-baseof detail cards).

**neo.css (site-wide)**
- **Animated aurora background** — drifting accent/violet/accent-2 glow orbs behind everything (`.neo-aurora`, 22s drift, low opacity, behind content so text contrast holds).
- **Glassy header** with an animated gradient underline (`.neo-header::after` sheen); **animated gradient brand mark** (`.neo-brand .mark` cycling accent→violet).
- **Glossy nav links** — accent underline wipes in on hover.
- **Glossy in-content links** — accent underline grows on hover (`.neo-post-body a`, `.prose a`).
- **Scroll progress bar** (`.neo-progress`) at top.
- **Selection tint** + **focus glow** everywhere (a11y).
- **Entrance rise** for posts/sections/rows (cards keep their own `neo-card-in` — not double-animated).
- **Cute floating ✨** sparkle + **back-to-top glow**.

**custom.js (loaded on all neo pages)**
- Injects the aurora layer, floating ✨, scroll progress bar, and a **cute click-sparkle burst** (✦✧✨★♥ particles on every click). All disabled when `data-reduce-motion="true"`.

**custom.css (theme pages mirror)**
- Aurora glow, gradient header underline, selection tint, focus glow, glossy in-content links, entrance rise — so repo/gist/awesome single cards and any theme-baseof page feel cohesive.

All token-driven (adapts to every theme/accent swatch), `prefers-reduced-motion`-safe.

## Verification
- `node -c assets/js/custom.js` OK
- Hugo build: Total in 1841 ms
- neo.css contains `neo-aurora`, `neo-progress`, `neo-spark`, `neo-sheen`, `neo-rise`; custom.css contains `neo-sheen`, `neo-rise`
- npm test: 3/3 (Unit + A11y + Perf) passed — entrance/aurora are transform/opacity only, reduced-motion guarded