### PR TITLE
feat(ux): ergonomics — instant filter, copy buttons, keyboard shortcuts, TOC scrollspy, heading copy

### DIFF
--- a/assets/css/neo.css
+++ b/assets/css/neo.css
@@ -752,7 +752,39 @@ html{scrollbar-color:var(--accent) color-mix(in srgb,var(--bg) 80%,transparent);
 /* sparkle trail on hover for links */
 a:hover{text-shadow:0 0 10px color-mix(in srgb,var(--accent) 40%,transparent)}
 
-/* ---------- PRINT ---------- */
+/* ---------- ERGONOMICS (функционал/удобство) ---------- */
+/* instant list filter */
+.neo-filter{width:100%;max-width:420px;margin:0 0 1.1rem;padding:.55rem .9rem;border-radius:999px;
+  background:color-mix(in srgb,var(--panel) 80%,transparent);border:1px solid color-mix(in srgb,var(--accent) 30%,var(--line));
+  color:var(--text);font-size:.9rem;outline:none;transition:border-color .2s,box-shadow .2s}
+.neo-filter::placeholder{color:var(--muted)}
+.neo-filter:focus{border-color:color-mix(in srgb,var(--accent) 60%,var(--line));
+  box-shadow:0 0 0 3px color-mix(in srgb,var(--accent) 22%,transparent)}
+.neo-filter-count{font-size:.78rem;color:var(--muted);margin-left:.6rem}
+/* copy button on code blocks */
+.copy-btn{position:absolute;top:.5rem;right:.5rem;z-index:5;display:inline-flex;align-items:center;gap:.25rem;
+  padding:.25rem .5rem;border-radius:8px;font-size:.72rem;cursor:pointer;color:var(--muted);
+  background:color-mix(in srgb,var(--panel) 85%,transparent);border:1px solid color-mix(in srgb,var(--accent) 28%,var(--line));
+  transition:color .2s,border-color .2s,background .2s,transform .15s}
+.copy-btn:hover{color:var(--accent);border-color:color-mix(in srgb,var(--accent) 55%,var(--line));transform:translateY(-1px)}
+.copy-btn.copied{color:#5dff9b;border-color:color-mix(in srgb,#5dff9b 50%,var(--line))}
+pre{position:relative}
+/* heading copy-link */
+.neo-post-body h2,.neo-post-body h3,.neo-prose h2,.neo-prose h3{position:relative;scroll-margin-top:80px}
+.head-anchor{opacity:0;margin-left:.4rem;font-size:.7em;color:var(--muted);text-decoration:none;
+  transition:opacity .2s,color .2s;vertical-align:middle}
+.neo-post-body h2:hover .head-anchor,.neo-post-body h3:hover .head-anchor,
+.neo-prose h2:hover .head-anchor,.neo-prose h3:hover .head-anchor{opacity:1;color:var(--accent)}
+.head-anchor:hover{color:var(--accent)}
+/* TOC scrollspy active */
+.neo-toc a.active{color:var(--accent);font-weight:700}
+.neo-toc a.active::before{content:"▸ ";color:var(--accent)}
+/* kbd hint */
+.neo-kbd{display:inline-block;padding:.05rem .35rem;border-radius:5px;font-size:.72rem;line-height:1.3;
+  background:color-mix(in srgb,var(--panel) 90%,transparent);border:1px solid color-mix(in srgb,var(--accent) 25%,var(--line));
+  color:var(--muted);box-shadow:0 1px 0 color-mix(in srgb,var(--accent) 18%,transparent)}
+
+
 @media print{
   .neo-header,.neo-footer,#neo-backtotop,.neo-share,.neo-related,.neo-toc-wrap,.neo-news,.neo-settings{display:none !important}
   body{background:#fff;color:#000}body::before,body::after{display:none}

--- a/layouts/partials/neo-card-features.html
+++ b/layouts/partials/neo-card-features.html
@@ -73,3 +73,108 @@
   }
 })();
 </script>
+
+{{/* Ergonomics: instant filter, copy buttons, keyboard shortcuts, TOC scrollspy, heading copy. */}}
+<script>
+(function () {
+  "use strict";
+  try {
+    // ---- instant client-side filter on list pages ----
+    var grids = [".repo-grid", ".neo-awesome-grid"];
+    grids.forEach(function (sel) {
+      var grid = document.querySelector(sel);
+      if (!grid) return;
+      var wrap = grid.parentElement;
+      if (!wrap || wrap.querySelector(".neo-filter")) return;
+      var input = document.createElement("input");
+      input.type = "search"; input.className = "neo-filter";
+      input.placeholder = "Фильтровать…"; input.setAttribute("aria-label", "Фильтровать список");
+      var count = document.createElement("span");
+      count.className = "neo-filter-count";
+      var cards = Array.prototype.slice.call(grid.children);
+      function update() {
+        var q = input.value.trim().toLowerCase(), shown = 0;
+        cards.forEach(function (c) {
+          var txt = (c.textContent || "").toLowerCase();
+          var ok = !q || txt.indexOf(q) !== -1;
+          c.style.display = ok ? "" : "none";
+          if (ok) shown++;
+        });
+        count.textContent = q ? (shown + " / " + cards.length) : "";
+      }
+      input.addEventListener("input", update);
+      wrap.insertBefore(count, grid);
+      wrap.insertBefore(input, grid);
+    });
+
+    // ---- copy-to-clipboard on code blocks ----
+    if (navigator.clipboard) {
+      document.querySelectorAll("pre > code, pre").forEach(function (block) {
+        var pre = block.tagName === "PRE" ? block : block.parentElement;
+        if (!pre || pre.parentElement.querySelector(".copy-btn")) return;
+        var btn = document.createElement("button");
+        btn.className = "copy-btn"; btn.type = "button"; btn.textContent = "Копировать";
+        btn.setAttribute("aria-label", "Копировать код");
+        btn.addEventListener("click", function () {
+          var code = pre.querySelector("code") ? pre.querySelector("code").innerText : pre.innerText;
+          navigator.clipboard.writeText(code).then(function () {
+            btn.textContent = "Скопировано ✓"; btn.classList.add("copied");
+            setTimeout(function () { btn.textContent = "Копировать"; btn.classList.remove("copied"); }, 1500);
+          });
+        });
+        pre.style.position = "relative";
+        pre.appendChild(btn);
+      });
+    }
+
+    // ---- heading copy-links ----
+    document.querySelectorAll(".neo-post-body h2, .neo-post-body h3, .neo-prose h2, .neo-prose h3").forEach(function (h) {
+      if (!h.id) return;
+      var a = document.createElement("a");
+      a.className = "head-anchor"; a.href = "#" + h.id; a.textContent = "🔗";
+      a.setAttribute("aria-label", "Скопировать ссылку"); a.title = "Скопировать ссылку";
+      a.addEventListener("click", function (e) {
+        e.preventDefault();
+        try { navigator.clipboard.writeText(location.href.split("#")[0] + "#" + h.id);
+          a.textContent = "✓"; setTimeout(function(){ a.textContent = "🔗"; }, 1200); } catch (err) {}
+      });
+      h.appendChild(a);
+    });
+
+    // ---- TOC scrollspy ----
+    var tocLinks = document.querySelectorAll(".neo-toc a[href^='#']");
+    if (tocLinks.length && "IntersectionObserver" in window) {
+      var map = {};
+      tocLinks.forEach(function (l) { var id = l.getAttribute("href").slice(1); if (id) map[id] = l; });
+      var obs = new IntersectionObserver(function (entries) {
+        entries.forEach(function (en) {
+          if (en.isIntersecting) {
+            tocLinks.forEach(function (l) { l.classList.remove("active"); });
+            var link = map[en.target.id]; if (link) link.classList.add("active");
+          }
+        });
+      }, { rootMargin: "-80px 0px -70% 0px" });
+      Object.keys(map).forEach(function (id) {
+        var t = document.getElementById(id); if (t) obs.observe(t);
+      });
+    }
+
+    // ---- keyboard shortcuts ----
+    var reduce = document.documentElement.getAttribute("data-reduce-motion") === "true";
+    document.addEventListener("keydown", function (e) {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      var t = e.target, tag = t && t.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || (t && t.isContentEditable)) return;
+      if (e.key === "/") { var s = document.getElementById("neo-search-open"); if (s) { e.preventDefault(); s.click(); } }
+      else if (e.key === "Escape") { var d = document.getElementById("neo-drawer"); if (d) d.classList.remove("open"); }
+      else if (e.key === "t" || e.key === "T") {
+        var root = document.documentElement;
+        var cur = root.getAttribute("data-theme");
+        root.setAttribute("data-theme", cur === "light" ? "dark" : "light");
+        try { localStorage.setItem("neo-theme", root.getAttribute("data-theme")); } catch (err) {}
+      }
+      else if (e.key === "b" || e.key === "B") { window.scrollTo({ top: 0, behavior: reduce ? "auto" : "smooth" }); }
+    });
+  } catch (e) {}
+})();
+</script>


### PR DESCRIPTION
## What
Shift from pure cosmetics to **functionality / convenience / ergonomics** per request. Added genuinely useful, verifiable UX features (all vanilla JS, no deps, reduced-motion aware):

- **Instant client-side filter** on the gists / repositories / awesome list pages — a search box that live-filters cards by text and shows a `shown / total` count. (Injected into the grid wrapper by the shared features partial, so no template churn.)
- **Copy-to-clipboard** on every code block (`pre`) — a "Копировать" button using the Clipboard API, with a "Скопировано ✓" confirmation.
- **Keyboard shortcuts** (ignored while typing in inputs): `/` focus search, `Esc` close settings drawer, `t` toggle theme (persisted), `b` back-to-top.
- **TOC scrollspy** — active section highlight as you scroll long posts (IntersectionObserver), with a `▸` marker.
- **Heading copy-links** — hover a post `h2/h3` to get a 🔗 that copies the deep link to that section.

All ergonomic helpers are wrapped in try/catch and respect `data-reduce-motion`. Token-driven styling (`.neo-filter`, `.copy-btn`, `.head-anchor`, `.neo-toc a.active`, `.neo-kbd`).

## Verification
- Hugo build: Total in 1929 ms
- neo.css contains `neo-filter`, `copy-btn`, `head-anchor`, `neo-toc a.active` rules
- The features partial (now carrying filter+overlay+copy+shortcut+TOC JS) is included on /gists/, /repositories/, /awesome/
- npm test: 3/3 (Unit + A11y + Perf) passed — inline handlers are on trusted DOM nodes we create; no untrusted input flows to innerHTML