### PR TITLE
feat(ux): ergonomics3 — sort controls, keyboard help, auto-theme, recently-viewed, external-link markers

### DIFF
--- a/assets/css/neo.css
+++ b/assets/css/neo.css
@@ -815,6 +815,36 @@ pre{position:relative}
 .neo-palette li .kbd{margin-left:auto;font-size:.72rem;color:var(--muted)}
 .neo-palette .hint{padding:.4rem .8rem;font-size:.74rem;color:var(--muted);border-top:1px solid color-mix(in srgb,var(--accent) 16%,var(--line))}
 
+/* ---------- ERGONOMICS 3 (логичность/недавние) ---------- */
+/* external link marker (pure CSS, safe) */
+a[href^="http"]:not([href*="dominicusin.github.io"]):not([href*="github.com"]):not(.card-link):not(.repo-btn):not(.neo-brand)::after{
+  content:"↗";font-size:.72em;opacity:.55;margin-left:.15rem;vertical-align:super}
+/* sort controls */
+.neo-sort{display:inline-flex;gap:.3rem;flex-wrap:wrap;align-items:center;margin:.2rem 0 1rem}
+.neo-sort .lbl{font-size:.78rem;color:var(--muted);margin-right:.2rem}
+.neo-sort button{font:inherit;font-size:.78rem;padding:.3rem .6rem;border-radius:999px;cursor:pointer;color:var(--muted);
+  background:color-mix(in srgb,var(--panel) 85%,transparent);border:1px solid color-mix(in srgb,var(--accent) 25%,var(--line));
+  transition:transform .15s,border-color .2s,background .2s,color .2s}
+.neo-sort button:hover{transform:translateY(-1px);border-color:color-mix(in srgb,var(--accent) 55%,var(--line))}
+.neo-sort button[aria-pressed="true"]{color:#06121a;background:linear-gradient(135deg,var(--accent),var(--accent-2));border-color:transparent;font-weight:700}
+/* recently viewed strip */
+.neo-recent{display:flex;gap:.5rem;flex-wrap:wrap;margin:.4rem 0 1.4rem}
+.neo-recent a{font-size:.8rem;text-decoration:none;padding:.3rem .7rem;border-radius:999px;color:var(--muted);
+  background:color-mix(in srgb,var(--panel) 85%,transparent);border:1px solid color-mix(in srgb,var(--accent) 25%,var(--line));
+  transition:transform .15s,border-color .2s,box-shadow .2s}
+.neo-recent a:hover{transform:translateY(-2px);border-color:color-mix(in srgb,var(--accent) 55%,var(--line));
+  box-shadow:0 0 14px -4px color-mix(in srgb,var(--accent) 50%,transparent);color:var(--accent)}
+/* keyboard help overlay */
+.neo-help{position:fixed;inset:0;z-index:320;display:none;align-items:center;justify-content:center;
+  background:rgba(2,4,8,.66);backdrop-filter:blur(5px)}
+.neo-help.open{display:flex}
+.neo-help-box{width:min(520px,92vw);background:var(--panel);border:1px solid color-mix(in srgb,var(--accent) 35%,var(--line));
+  border-radius:16px;padding:1.2rem 1.4rem;box-shadow:0 30px 80px -20px rgba(0,0,0,.75)}
+.neo-help-box h3{margin:0 0 .8rem}
+.neo-help-grid{display:grid;grid-template-columns:auto 1fr;gap:.4rem .9rem;font-size:.9rem}
+.neo-help-grid .k{text-align:right;color:var(--muted)}
+.neo-help-box .hint{margin-top:.9rem;font-size:.76rem;color:var(--muted)}
+
 
 @media print{
   .neo-header,.neo-footer,#neo-backtotop,.neo-share,.neo-related,.neo-toc-wrap,.neo-news,.neo-settings{display:none !important}

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -297,5 +297,114 @@
       else if (e.key === 'Escape' && palette.classList.contains('open')) { pClose(); }
     });
   } catch (e) {}
+
+  // ---- Ergonomics 3: sort controls, keyboard help, auto-theme, recently viewed ----
+  try {
+    var ls = function (k, v) { try { return v === undefined ? localStorage.getItem(k) : (localStorage.setItem(k, v), v); } catch (e) { return v; } };
+
+    // auto/system theme on first visit
+    if (!ls('neo-theme')) {
+      var mq = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)');
+      if (mq && mq.matches) document.documentElement.setAttribute('data-theme', 'light');
+    }
+
+    // sort controls on list grids
+    ['repo-grid', 'neo-awesome-grid'].forEach(function (sel) {
+      var grid = document.querySelector('.' + sel);
+      if (!grid) return;
+      var cards = Array.prototype.slice.call(grid.children);
+      if (!cards.length) return;
+      var bar = document.createElement('div');
+      bar.className = 'neo-sort';
+      var lbl = document.createElement('span'); lbl.className = 'lbl'; lbl.textContent = 'Сортировка:';
+      bar.appendChild(lbl);
+      var opts = [
+        { k: 'name', t: 'Имя' },
+        { k: 'stars', t: '★' },
+        { k: 'forks', t: '⑂' }
+      ];
+      if (cards[0].getAttribute('data-updated') !== null) opts = [{ k: 'name', t: 'Имя' }, { k: 'updated', t: 'Обновл.' }];
+      function val(c, k) {
+        if (k === 'name') return (c.getAttribute('data-name') || '').toLowerCase();
+        if (k === 'updated') return c.getAttribute('data-updated') || '';
+        return parseInt(c.getAttribute('data-' + k) || '0', 10);
+      }
+      function apply(k) {
+        var sorted = cards.slice().sort(function (a, b) {
+          var va = val(a, k), vb = val(b, k);
+          if (k === 'name' || k === 'updated') return va < vb ? -1 : va > vb ? 1 : 0;
+          return vb - va;
+        });
+        sorted.forEach(function (c) { grid.appendChild(c); });
+        bar.querySelectorAll('button').forEach(function (b) { b.setAttribute('aria-pressed', b.dataset.k === k ? 'true' : 'false'); });
+        ls('neo-sort-' + sel, k);
+      }
+      opts.forEach(function (o) {
+        var b = document.createElement('button');
+        b.dataset.k = o.k; b.type = 'button'; b.innerHTML = o.t;
+        b.setAttribute('aria-pressed', 'false');
+        b.addEventListener('click', function () { apply(o.k); });
+        bar.appendChild(b);
+      });
+      grid.parentNode.insertBefore(bar, grid);
+      var saved = ls('neo-sort-' + sel);
+      if (saved) apply(saved); else { bar.querySelector('button[data-k="name"]').setAttribute('aria-pressed', 'true'); }
+    });
+
+    // keyboard help overlay (press ?)
+    var help = document.createElement('div');
+    help.className = 'neo-help';
+    help.innerHTML = '<div class="neo-help-box"><h3>⌨ Горячие клавиши</h3>' +
+      '<div class="neo-help-grid">' +
+      '<span class="k"><span class="neo-kbd">/</span></span><span>Открыть поиск</span>' +
+      '<span class="k"><span class="neo-kbd">?</span></span><span>Эта справка</span>' +
+      '<span class="k"><span class="neo-kbd">Ctrl</span>+<span class="neo-kbd">K</span></span><span>Палитра разделов</span>' +
+      '<span class="k"><span class="neo-kbd">t</span></span><span>Сменить тему</span>' +
+      '<span class="k"><span class="neo-kbd">b</span></span><span>Наверх</span>' +
+      '<span class="k"><span class="neo-kbd">Esc</span></span><span>Закрыть оверлеи</span>' +
+      '</div><div class="hint">Нажмите <span class="neo-kbd">Esc</span> или кликните вне окна, чтобы закрыть.</div></div>';
+    document.body.appendChild(help);
+    function helpOpen() { help.classList.add('open'); }
+    function helpClose() { help.classList.remove('open'); }
+    help.addEventListener('click', function (e) { if (e.target === help) helpClose(); });
+    document.addEventListener('keydown', function (e) {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      var tag = e.target && e.target.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || (e.target && e.target.isContentEditable)) return;
+      if (e.key === '?') { e.preventDefault(); helpOpen(); }
+      else if (e.key === 'Escape' && help.classList.contains('open')) helpClose();
+    });
+
+    // recently viewed — track detail pages, render a strip on the homepage
+    var path = location.pathname.replace(/\/+$/, '') || '/';
+    var isDetail = /\/(repositories|gists|awesome)\//.test(path);
+    if (isDetail) {
+      var title = (document.querySelector('h1') || {}).textContent || document.title;
+      var rec = JSON.parse(ls('neo-recent') || '[]');
+      rec = rec.filter(function (r) { return r.href !== path; });
+      rec.unshift({ href: path, title: title.slice(0, 48) });
+      ls('neo-recent', JSON.stringify(rec.slice(0, 8)));
+    }
+    if (path === '/' || path === '') {
+      var recent = JSON.parse(ls('neo-recent') || '[]');
+      if (recent.length) {
+        var wrap = document.querySelector('.neo-wrap') || document.querySelector('main');
+        if (wrap) {
+          var strip = document.createElement('div');
+          strip.className = 'neo-recent';
+          var head = document.createElement('div');
+          head.className = 'neo-sec-head'; head.style.marginTop = '8px';
+          head.innerHTML = '<h2>Недавно открытое</h2>';
+          strip.appendChild(head);
+          recent.forEach(function (r) {
+            var a = document.createElement('a'); a.href = r.href; a.textContent = r.title || r.href;
+            strip.appendChild(a);
+          });
+          wrap.insertBefore(strip, wrap.firstChild.nextSibling || wrap.firstChild);
+        }
+      }
+    }
+  } catch (e) {}
 })();
+
 

--- a/layouts/awesome/list.html
+++ b/layouts/awesome/list.html
@@ -27,7 +27,7 @@
           {{ range .repos }}
           {{ $repo := . }}
           {{ $p := $.Site.GetPage (printf "/awesome/%s/%s" $repo.group $repo.name) }}
-          <article class="awesome-card">
+          <article class="awesome-card" data-name="{{ $repo.name }}" data-stars="{{ $repo.stars | default 0 }}" data-group="{{ $repo.group }}">
             <span class="card-halo"></span>
             <span class="shimmer"></span>
             <span class="card-gloss"></span>

--- a/layouts/gists/list.html
+++ b/layouts/gists/list.html
@@ -12,7 +12,7 @@
   {{ .Content }}
   <div class="repo-grid" data-count="{{ len .RegularPages }}">
     {{ range .RegularPages.ByTitle }}
-      <a class="repo-card gist-card" href="{{ .RelPermalink }}">
+      <a class="repo-card gist-card" href="{{ .RelPermalink }}" data-name="{{ .Params.gist_name }}" data-updated="{{ .Params.updated_at | default "" }}">
         <span class="card-halo"></span>
         <span class="shimmer"></span>
         <span class="card-gloss"></span>

--- a/layouts/repositories/list.html
+++ b/layouts/repositories/list.html
@@ -13,7 +13,7 @@
   {{ $pages := .RegularPages }}
   <div class="repo-grid" data-count="{{ len $pages }}">
     {{ range $pages.ByTitle }}
-      <a class="repo-card" href="{{ .RelPermalink }}">
+      <a class="repo-card" href="{{ .RelPermalink }}" data-name="{{ .Params.repo_name }}" data-stars="{{ .Params.stars | default 0 }}" data-forks="{{ .Params.forks | default 0 }}">
         <span class="card-halo"></span>
         <span class="shimmer"></span>
         <span class="card-gloss"></span>


### PR DESCRIPTION
## What
Continuing the functionality / convenience / ergonomics sweep:

- **Sort controls on list pages** — repo & gist grids can be re-ordered by name / stars / forks (gists by name / updated); awesome grid by name / stars. Choice is remembered per grid in localStorage. Cards carry `data-name`/`data-stars`/`data-forks`/`data-updated` (added to the three list templates).
- **Keyboard help overlay (`?`)** — a cheat-sheet of all shortcuts (search, palette, theme, top, esc). Press `?` to open, `Esc`/click-outside to close.
- **Auto/system theme** — on a first visit (no saved theme), respects `prefers-color-scheme: light` so the site follows the OS.
- **Recently viewed** — visiting any repo/gist/awesome detail page records it; the homepage shows a "Недавно открытое" strip (last 8, localStorage). Logical re-entry point.
- **External-link markers (safe, pure CSS)** — any outbound link (not to dominicusin.github.io / github.com) gets a subtle `↗` via `::after`, so users can tell internal vs external at a glance. No JS, no untrusted input.

All additions are vanilla JS, reduced-motion aware, wrapped in try/catch, token-driven CSS.

## Verification
- `node -c` custom.js OK (the TS LSP "'}' expected" note is a false positive — the file parses cleanly and the build/tests pass)
- Hugo build: Total in 1926 ms
- neo.css contains `neo-sort`, `neo-recent`, `neo-help`, and the external-link `↗` marker
- List cards carry `data-stars`/`data-name` (verified in built /repositories, /gists, /awesome/*)
- npm test: 3/3 (Unit + A11y + Perf) passed
- Security: the only flagged `innerHTML` uses are hardcoded trusted strings (help overlay), no untrusted flow