### PR TITLE
feat(ux): mobile nav (hamburger) + unified site-wide search

### DIFF
--- a/assets/css/neo.css
+++ b/assets/css/neo.css
@@ -845,6 +845,22 @@ a[href^="http"]:not([href*="dominicusin.github.io"]):not([href*="github.com"]):n
 .neo-help-grid .k{text-align:right;color:var(--muted)}
 .neo-help-box .hint{margin-top:.9rem;font-size:.76rem;color:var(--muted)}
 
+/* ---------- MOBILE NAV ---------- */
+.neo-burger{display:none}
+.neo-mobile-nav{display:none;flex-direction:column;gap:2px;padding:0 1rem;
+  background:color-mix(in srgb,var(--bg) 92%,transparent);backdrop-filter:blur(14px) saturate(140%);
+  max-height:0;overflow:hidden;transition:max-height .3s ease,padding .3s ease;
+  border-top:1px solid color-mix(in srgb,var(--accent) 18%,var(--line))}
+.neo-mobile-nav.open{display:flex;max-height:70vh;padding:.6rem 1rem 1rem;overflow:auto}
+.neo-mobile-nav a{padding:.7rem .4rem;border-radius:8px;color:var(--text);text-decoration:none;
+  font-size:1rem;border-bottom:1px solid color-mix(in srgb,var(--accent) 10%,var(--line))}
+.neo-mobile-nav a:hover{color:var(--accent);background:color-mix(in srgb,var(--accent) 10%,var(--panel))}
+@media(max-width:900px){
+  .neo-burger{display:inline-flex}
+  .neo-mobile-nav{display:flex}
+  .neo-burger[aria-expanded="true"]{color:var(--accent)}
+}
+
 
 @media print{
   .neo-header,.neo-footer,#neo-backtotop,.neo-share,.neo-related,.neo-toc-wrap,.neo-news,.neo-settings{display:none !important}

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -75,6 +75,23 @@
     });
   }
 
+  // Mobile nav toggle
+  var burger = document.getElementById('neo-burger');
+  var mnav = document.getElementById('neo-mobile-nav');
+  if (burger && mnav) {
+    burger.addEventListener('click', function (e) {
+      e.stopPropagation();
+      var open = mnav.classList.toggle('open');
+      burger.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+    mnav.addEventListener('click', function (e) {
+      if (e.target.tagName === 'A') { mnav.classList.remove('open'); burger.setAttribute('aria-expanded', 'false'); }
+    });
+    document.addEventListener('click', function (e) {
+      if (!mnav.contains(e.target) && e.target !== burger) { mnav.classList.remove('open'); burger.setAttribute('aria-expanded', 'false'); }
+    });
+  }
+
   // Quick light/dark toggle
   var tog = document.getElementById('neo-theme-toggle');
   if (tog){

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,5 +1,6 @@
 {{/*
-  Search page — Neo design system (standalone). Inline index baked at build.
+  Search page — Neo design system (standalone). Unified index baked at build
+  across all content types (blog posts, repositories, gists, awesome lists).
 */}}
 <!DOCTYPE html>
 <html lang="{{ site.Language.LanguageCode | default "ru" }}" data-theme="dark">
@@ -8,17 +9,24 @@
 {{ partial "neo-header.html" . }}
 <main class="neo" id="main">
 <div class="neo-wrap search-page">
-  <div class="neo-sec-head" style="margin-top:20px"><h2>Поиск по блогу</h2></div>
-  <input id="neo-search-input" class="neo-search-input" type="search" placeholder="Введите запрос…" autofocus />
+  <div class="neo-sec-head" style="margin-top:20px"><h2>Поиск по сайту</h2>
+    <span class="more">блог · репозитории · гисты · awesome</span>
+  </div>
+  <input id="neo-search-input" class="neo-search-input" type="search" placeholder="Искать по заголовкам, тегам, описаниям…" autofocus />
   <div id="neo-search-results" class="neo-rows"></div>
-  <p id="neo-search-empty" class="neo-search-empty">Введите запрос для поиска по заголовкам, тегам и описаниям.</p>
+  <p id="neo-search-empty" class="neo-search-empty">Введите запрос для поиска по всему сайту.</p>
 </div>
 <script>
 (function(){
   /* INDEX is build-time baked JSON (trusted, static). */
+  var KIND = { post:'📝 Блог', repo:'📦 Репо', gist:'📄 Гист', awesome:'⭐ Awesome' };
   var INDEX = [
-    {{ range site.RegularPages }}
-    {t:{{ .Title | jsonify }}, u:{{ .RelPermalink | jsonify }}, g:{{ with .Params.tags }}{{ delimit . " " | jsonify }}{{ else }}""{{ end }}, s:{{ .Summary | plainify | truncate 180 | jsonify }}, d:{{ .Date.Format "2006-01-02" | jsonify }}},
+    {{ $pages := where site.RegularPages "RelPermalink" "ne" "" }}
+    {{ range $pages }}
+    {{- $u := .RelPermalink -}}
+    {{- $kind := "post" -}}
+    {{- if hasPrefix $u "/repositories/" }}{{ $kind = "repo" }}{{ else if hasPrefix $u "/gists/" }}{{ $kind = "gist" }}{{ else if hasPrefix $u "/awesome/" }}{{ $kind = "awesome" }}{{ end -}}
+    {t:{{ .Title | jsonify }}, u:{{ $u | jsonify }}, k:{{ $kind | jsonify }}, g:{{ with .Params.tags }}{{ delimit . " " | jsonify }}{{ else }}{{ .Description | jsonify }}{{ end }}, s:{{ .Summary | plainify | truncate 160 | jsonify }}},
     {{ end }}
   ];
   var input = document.getElementById('neo-search-input');
@@ -27,24 +35,25 @@
   function render(q){
     q = (q||'').toLowerCase().trim();
     res.innerHTML = '';
-    if(!q){ empty.style.display='block'; empty.textContent='Введите запрос для поиска по заголовкам, тегам и описаниям.'; return; }
+    if(!q){ empty.style.display='block'; empty.textContent='Введите запрос для поиска по всему сайту.'; return; }
     var hits = INDEX.filter(function(i){
-      return i.t.toLowerCase().indexOf(q) > -1 || i.g.toLowerCase().indexOf(q) > -1 || i.s.toLowerCase().indexOf(q) > -1;
-    }).slice(0, 30);
-    if(hits.length){ empty.style.display='none'; } else {
-      empty.style.display='block'; empty.textContent = 'Ничего не найдено по запросу «'+q+'».'; return;
-    }
+      return i.t.toLowerCase().indexOf(q) > -1 || (i.g||'').toLowerCase().indexOf(q) > -1 || (i.s||'').toLowerCase().indexOf(q) > -1;
+    }).slice(0, 40);
+    if(!hits.length){ empty.style.display='block'; empty.textContent = 'Ничего не найдено по запросу «'+q+'».'; return; }
+    empty.style.display='none';
     hits.forEach(function(h){
       var a = document.createElement('a');
       a.className='neo-row'; a.href=h.u;
-      var date = document.createElement('span'); date.className='date'; date.textContent=h.d;
+      var date = document.createElement('span'); date.className='date'; date.textContent = KIND[h.k] || '•';
       var title = document.createElement('span'); title.className='title'; title.textContent=h.t;
-      var tag = document.createElement('span'); tag.className='tag'; tag.textContent = h.g ? h.g : 'тег';
-      a.appendChild(date); a.appendChild(title); a.appendChild(tag);
+      a.appendChild(date); a.appendChild(title);
+      if(h.g){ var tag = document.createElement('span'); tag.className='tag'; tag.textContent = (h.g||'').split(' ')[0]; a.appendChild(tag); }
       res.appendChild(a);
     });
   }
-  input.addEventListener('input', function(){ render(input.value); });
+  var t;
+  input.addEventListener('input', function(){ clearTimeout(t); t = setTimeout(function(){ render(input.value); }, 120); });
+  render(input.value);
 })();
 </script>
 </main>

--- a/layouts/partials/neo-header.html
+++ b/layouts/partials/neo-header.html
@@ -27,6 +27,7 @@
     </nav>
 
     <div class="neo-nav-actions">
+      <button class="neo-icon-btn neo-burger" id="neo-burger" aria-label="Меню" aria-expanded="false" aria-controls="neo-mobile-nav">☰</button>
       <button class="neo-icon-btn" id="neo-search-open" aria-label="Поиск" title="Поиск">⌕</button>
       <div class="neo-settings">
         <button class="neo-icon-btn" id="neo-settings-btn" aria-label="Настройки" title="Настройки">⚙</button>
@@ -80,4 +81,18 @@
       <button class="neo-icon-btn" id="neo-theme-toggle" aria-label="Светлая/тёмная" title="Светлая/тёмная">◐</button>
     </div>
   </div>
+  <nav class="neo-mobile-nav" id="neo-mobile-nav" aria-label="Мобильное меню">
+    <a href="{{ "blog/" | relURL }}">Блог</a>
+    <a href="{{ "repositories/" | relURL }}">Репозитории</a>
+    <a href="{{ "gists/" | relURL }}">Гисты</a>
+    <a href="{{ "ontology/" | relURL }}">Онтология</a>
+    <a href="{{ "knowledge-graph/" | relURL }}">Graph</a>
+    <a href="{{ "awesome/" | relURL }}">awesome</a>
+    <a href="{{ "wiki-build/" | relURL }}">Wiki</a>
+    <a href="{{ "categories/" | relURL }}">Категории</a>
+    <a href="{{ "tags/" | relURL }}">Теги</a>
+    <a href="{{ "sitemap.xml" | relURL }}">sitemap</a>
+    <a href="{{ "search/" | relURL }}">Поиск</a>
+    <a href="{{ "archives/" | relURL }}">Архив</a>
+  </nav>
 </header>


### PR DESCRIPTION
## What
Two concrete logic/ergonomics gaps closed:

**1. Mobile navigation was broken** — at ≤900px `.neo-menu{display:none}` with NO replacement, so the entire main nav vanished on phones. Added:
- A `☰` hamburger button (`#neo-burger`, hidden on desktop, shown ≤900px).
- A `#neo-mobile-nav` slide-down panel mirroring the full nav, with `aria-expanded`/`aria-controls`, outside-click + link-click close.
- CSS for `.neo-burger` / `.neo-mobile-nav` (animated max-height, glass bg).

**2. Search only covered blog posts** ("Поиск по блогу", `site.RegularPages` only). Rewrote `/search/` as a **unified index** across all content types, deriving the kind from the URL prefix (robust vs ambiguous section/type):
- 📝 Блог (post), 📦 Репо (repo, 128), 📄 Гист (gist, 106), ⭐ Awesome (51) — **351 entries total**.
- Each result shows a type chip; debounced (120ms) live filtering; empty/zero-state messages.
- The build-time JSON index is trusted/static (no untrusted input flows to innerHTML; `res.innerHTML=''` is only used to clear, all content via textContent).

## Verification
- `node -c` custom.js OK
- Hugo build: Total in 1883 ms
- Built `/search/` INDEX parses to 351 entries: post 66 / repo 128 / gist 106 / awesome 51
- Built header has `id="neo-burger"` + `id="neo-mobile-nav"`; neo.css has `.neo-burger`/`.neo-mobile-nav`
- npm test: 3/3 (Unit + A11y + Perf) passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a responsive mobile navigation menu with an accessible burger button.
  * Mobile menus close automatically after selecting a link or clicking outside.
  * Expanded search to include blog posts, repositories, gists, and curated lists.
  * Increased search results to 40 and improved result labels, loading behavior, and empty-state messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->