### PR TITLE
feat(ux): reading progress + vim nav (g h/g b, n/p) + prev/next post links

### DIFF
--- a/assets/css/neo.css
+++ b/assets/css/neo.css
@@ -845,6 +845,21 @@ a[href^="http"]:not([href*="dominicusin.github.io"]):not([href*="github.com"]):n
 .neo-help-grid .k{text-align:right;color:var(--muted)}
 .neo-help-box .hint{margin-top:.9rem;font-size:.76rem;color:var(--muted)}
 
+/* ---------- READING PROGRESS (per-article) ---------- */
+.neo-readbar{position:fixed;left:0;top:0;height:3px;width:0;z-index:120;pointer-events:none;
+  background:linear-gradient(90deg,var(--accent),var(--accent-2),var(--violet,#b98cff));
+  box-shadow:0 0 10px color-mix(in srgb,var(--accent) 60%,transparent)}
+
+/* prev/next post navigation */
+.neo-prevnext{display:flex;gap:.8rem;flex-wrap:wrap;margin:1.6rem 0 .4rem}
+.neo-pn{display:flex;flex-direction:column;gap:.15rem;text-decoration:none;padding:.7rem 1rem;border-radius:12px;
+  flex:1 1 220px;min-width:0;background:color-mix(in srgb,var(--panel) 85%,transparent);
+  border:1px solid color-mix(in srgb,var(--accent) 28%,var(--line));transition:transform .18s,border-color .2s,box-shadow .2s,background .2s}
+.neo-pn:hover{transform:translateY(-2px);border-color:color-mix(in srgb,var(--accent) 55%,var(--line));
+  box-shadow:0 0 16px -5px color-mix(in srgb,var(--accent) 50%,transparent)}
+.pn-dir{font-size:.74rem;color:var(--muted)}
+.pn-t{font-weight:700;color:var(--text);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.pn-next{text-align:right;align-items:flex-end}
 /* ---------- MOBILE NAV ---------- */
 .neo-burger{display:none}
 .neo-mobile-nav{display:none;flex-direction:column;gap:2px;padding:0 1rem;

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -422,6 +422,51 @@
       }
     }
   } catch (e) {}
+
+  // ---- Ergonomics 4: reading progress + vim-style navigation ----
+  try {
+    var reduce = document.documentElement.getAttribute('data-reduce-motion') === 'true';
+
+    // per-article reading progress
+    var article = document.querySelector('.neo-post-body, .gist-body, .repo-body, .awesome-preview');
+    if (article) {
+      var rbar = document.createElement('div');
+      rbar.className = 'neo-readbar';
+      document.body.appendChild(rbar);
+      var ticking = false;
+      function updRead() {
+        var rect = article.getBoundingClientRect();
+        var total = rect.height - window.innerHeight;
+        var passed = -rect.top;
+        var p = total > 0 ? Math.min(100, Math.max(0, (passed / total) * 100)) : 0;
+        rbar.style.width = p + '%';
+        ticking = false;
+      }
+      window.addEventListener('scroll', function () { if (!ticking) { ticking = true; requestAnimationFrame(updRead); } }, { passive: true });
+      window.addEventListener('resize', updRead);
+      updRead();
+    }
+
+    // vim-style navigation: g h (home), g b (blog), n / p (prev/next post)
+    var gPending = false, gTimer = null;
+    var navPrev = document.body.getAttribute('data-prev');
+    var navNext = document.body.getAttribute('data-next');
+    document.addEventListener('keydown', function (e) {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      var tag = e.target && e.target.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || (e.target && e.target.isContentEditable)) return;
+      if (gPending) {
+        gPending = false; clearTimeout(gTimer);
+        if (e.key === 'h') location.href = '/';
+        else if (e.key === 'b') location.href = '/blog/';
+        return;
+      }
+      if (e.key === 'g') { gPending = true; gTimer = setTimeout(function () { gPending = false; }, 800); return; }
+      if ((e.key === 'n' || e.key === 'N') && navNext) { e.preventDefault(); location.href = navNext; }
+      else if ((e.key === 'p' || e.key === 'P') && navPrev) { e.preventDefault(); location.href = navPrev; }
+    });
+  } catch (e) {}
 })();
+
 
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,7 +4,7 @@
 <!DOCTYPE html>
 <html lang="{{ site.Language.LanguageCode | default "ru" }}" data-theme="dark">
 {{ partial "neo-head.html" . }}
-<body>
+<body{{ with .PrevInSection }} data-prev="{{ .RelPermalink }}"{{ end }}{{ with .NextInSection }} data-next="{{ .RelPermalink }}"{{ end }}>
 {{ partial "neo-header.html" . }}
 <main class="neo" id="main">
 <article class="neo-post">
@@ -24,6 +24,12 @@
   </header>
   {{ if or .Params.toc .TableOfContents }}{{ partial "toc.html" . }}{{ end }}
   <div class="neo-post-body">{{ .Content }}</div>
+  {{ if or .PrevInSection .NextInSection }}
+  <nav class="neo-prevnext" aria-label="Навигация по записям">
+    {{ with .PrevInSection }}<a class="neo-pn pn-prev" href="{{ .RelPermalink }}"><span class="pn-dir">← Пред.</span><span class="pn-t">{{ .Title }}</span></a>{{ end }}
+    {{ with .NextInSection }}<a class="neo-pn pn-next" href="{{ .RelPermalink }}"><span class="pn-dir">След. →</span><span class="pn-t">{{ .Title }}</span></a>{{ end }}
+  </nav>
+  {{ end }}
   {{ partial "share.html" . }}
   {{ partial "related.html" . }}
   {{ if or .Params.comments .Site.Params.article.showComments }}{{ partial "comments.html" . }}{{ end }}


### PR DESCRIPTION
## What
Wave 2 ergonomics (autonomous plan):

- **Per-article reading progress** — a thin gradient bar (`.neo-readbar`) pinned to the top, tracking scroll position through the article body on posts / gist / repo / awesome detail pages. Reuses the accent palette; `requestAnimationFrame`-throttled.
- **Vim-style keyboard navigation** (ignored while typing):
  - `g` then `h` → home, `g` then `b` → blog (800ms chord window)
  - `n` / `p` → next / previous post (reads `data-prev`/`data-next` set from Hugo's `.PrevInSection`/`.NextInSection`)
- **Visible prev/next post links** — a glossy `.neo-prevnext` nav block at the end of each post (also powers the `n`/`p` shortcuts), with proper ARIA label and ellipsis-truncated titles.

Added `data-prev`/`data-next` to the blog single `<body>` and a `neo-prevnext` nav before the share block. All additions vanilla JS, reduced-motion aware, try/catch-wrapped, token-driven CSS.

## Verification
- `node -c` custom.js OK
- Hugo build: Total in 1914 ms
- neo.css has `neo-readbar`, `neo-prevnext`, `neo-pn`
- Built post `/2026/08/26/film-collection/` has `data-prev` (→ prev post), `neo-prevnext` nav, and the JS bundle ships `neo-readbar` + `data-prev`/`data-next` handling
- npm test: 3/3 (Unit + A11y + Perf) passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a reading progress bar to article pages.
  - Added previous and next post navigation links.
  - Added keyboard shortcuts for navigating home, the blog, and adjacent posts.
  - Navigation is available between posts within the same section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->