### PR TITLE
feat(wave6): palette random/share + ARIA live + print

### DIFF
--- a/assets/css/neo.css
+++ b/assets/css/neo.css
@@ -878,7 +878,11 @@ a[href^="http"]:not([href*="dominicusin.github.io"]):not([href*="github.com"]):n
 
 
 @media print{
-  .neo-header,.neo-footer,#neo-backtotop,.neo-share,.neo-related,.neo-toc-wrap,.neo-news,.neo-settings{display:none !important}
+  .neo-header,.neo-footer,#neo-backtotop,.neo-share,.neo-related,.neo-toc-wrap,.neo-news,.neo-settings,
+  .neo-cursor,.neo-orb,.neo-lightbox,.neo-palette,.neo-help,.neo-readbar,.neo-mobile-nav,
+  .neo-drawer,.neo-sort,.neo-filter,.neo-recent,.neo-sparkle,.card-halo,.card-gloss,
+  .like-btn,.neo-burger,.neo-motion-quick,.copy-btn,.neo-filter-bar{display:none !important}
   body{background:#fff;color:#000}body::before,body::after{display:none}
+  *{box-shadow:none !important}
   .neo-post{max-width:100%;padding:0}.neo-post-body{color:#000;font-size:12pt}
 }

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -278,8 +278,10 @@
       { ico: '🗺', label: 'Sitemap', href: '/sitemap.xml' },
       { ico: '⌕', label: 'Поиск', href: '/search/' },
       { ico: '🗓', label: 'Архив', href: '/archives/' },
-      { ico: '📋', label: 'Копировать ссылу страницы', action: 'copy' },
-      { ico: '🎨', label: 'Сменить тему', action: 'theme' }
+      { ico: '📋', label: 'Копировать ссылку страницы', action: 'copy' },
+      { ico: '🎨', label: 'Сменить тему', action: 'theme' },
+      { ico: '🎲', label: 'Случайная запись', action: 'random' },
+      { ico: '📤', label: 'Поделиться текущей страницей', action: 'share' }
     ];
     var ul = document.createElement('ul');
     items.forEach(function (it, i) {
@@ -338,6 +340,8 @@
         var it = fi[pActive];
         if (it && it.action === 'copy') { pClose(); navigator.clipboard && navigator.clipboard.writeText(location.href); announce('Ссылка скопирована в буфер обмена'); }
         else if (it && it.action === 'theme') { pClose(); var root = document.documentElement; var next = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light'; root.setAttribute('data-theme', next); try { localStorage.setItem('neo-theme', next); } catch (err) {} announce('Тема изменена на ' + (next === 'dark' ? 'тёмную' : 'светлую')); }
+        else if (it.action === 'random') { pClose(); if (RANDOM_POOL.length) { var pick = RANDOM_POOL[Math.floor(Math.random() * RANDOM_POOL.length)]; location.href = pick.href; } else { announce('Нет записей для случайного выбора'); } }
+        else if (it.action === 'share') { pClose(); if (navigator.share) { navigator.share({ title: document.title, url: location.href }).catch(function () {}); } else if (navigator.clipboard) { navigator.clipboard.writeText(location.href); announce('Ссылка скопирована для отправки'); } }
         else if (it) { location.href = it.href; }
       }
       else if (e.key === 'Escape') { e.preventDefault(); pClose(); }
@@ -366,6 +370,20 @@
     liveRegion.style.cssText = 'position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0)';
     liveRegion.id = 'neo-live';
     document.body.appendChild(liveRegion);
+    // random posts pool (blog posts with dates, for random navigation)
+    var RANDOM_POOL = [];
+    try { RANDOM_POOL = JSON.parse(localStorage.getItem('neo-random-pool') || '[]'); } catch (e) { RANDOM_POOL = []; }
+    if (!RANDOM_POOL.length) {
+      var links = document.querySelectorAll('a[href*="/20"]');
+      links.forEach(function (a) {
+        var href = a.getAttribute('href') || '';
+        if (/\/20\d{2}\//.test(href) && /\/20\d{2}\/\d{2}\/\d{2}\//.test(href)) {
+          RANDOM_POOL.push({ href: href, title: a.textContent.trim().slice(0, 60) });
+        }
+      });
+      try { localStorage.setItem('neo-random-pool', JSON.stringify(RANDOM_POOL.slice(0, 50))); } catch (e) {}
+    }
+
     function announce(msg) {
       var r = document.getElementById('neo-live');
       if (r) { r.textContent = ''; setTimeout(function () { r.textContent = msg; }, 50); }

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -13,8 +13,8 @@
     <span class="more">блог · репозитории · гисты · awesome</span>
   </div>
   <input id="neo-search-input" class="neo-search-input" type="search" placeholder="Искать по заголовкам, тегам, описаниям…" autofocus />
-  <div id="neo-search-results" class="neo-rows"></div>
-  <p id="neo-search-empty" class="neo-search-empty">Введите запрос для поиска по всему сайту.</p>
+  <div id="neo-search-results" class="neo-rows" role="status" aria-live="polite"></div>
+  <p id="neo-search-empty" class="neo-search-empty" role="status" aria-live="polite">Введите запрос для поиска по всему сайту.</p>
 </div>
 <script>
 (function(){


### PR DESCRIPTION
## What
Wave 6 — advanced palette actions + a11y + print:

- **Palette random post** (🎲): picks a random dated blog post from a pool built on first use (persisted in localStorage).
- **Palette share** (📤): uses native  when available, falls back to clipboard copy.
- **ARIA live regions**: search results + empty state are  for screen readers.
- **Print stylesheet**: hides all interactive/JS-injected elements (cursor, orbs, lightbox, palette, help, readbar, mobile nav, etc.) and removes shadows.

## Verification
- node -c OK, Hugo build 1815 ms
- Palette has Случайная запись + Поделиться; random pool logic present
- Search has 2 aria-live regions; print hides interactive elements
- npm test: 3/3 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added command palette actions for opening a random post and sharing the current page.
  - Sharing uses the device’s native share feature when available, with a copy-link fallback.

- **Accessibility**
  - Improved announcements for search results and empty states.

- **Print Improvements**
  - Print views now hide interactive and decorative elements and remove box shadows for cleaner output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->