### PR TITLE
feat(wave7): search kind filter + favorites export/import/sort

### DIFF
--- a/assets/css/neo.css
+++ b/assets/css/neo.css
@@ -760,7 +760,22 @@ a:hover{text-shadow:0 0 10px color-mix(in srgb,var(--accent) 40%,transparent)}
 .neo-filter::placeholder{color:var(--muted)}
 .neo-filter:focus{border-color:color-mix(in srgb,var(--accent) 60%,var(--line));
   box-shadow:0 0 0 3px color-mix(in srgb,var(--accent) 22%,transparent)}
-.neo-filter-count{font-size:.78rem;color:var(--muted);margin-left:.6rem}
+  .neo-filter-count{font-size:.78rem;color:var(--muted);margin-left:.6rem}
+/* search kind filter */
+.neo-kind-filter{display:flex;gap:.3rem;flex-wrap:wrap;margin:.6rem 0 1rem}
+.neo-kind-filter button{font:inherit;font-size:.78rem;padding:.3rem .6rem;border-radius:999px;cursor:pointer;color:var(--muted);
+  background:color-mix(in srgb,var(--panel) 85%,transparent);border:1px solid color-mix(in srgb,var(--accent) 25%,var(--line));
+  transition:transform .15s,border-color .2s,background .2s,color .2s}
+.neo-kind-filter button:hover{transform:translateY(-1px);border-color:color-mix(in srgb,var(--accent) 55%,var(--line))}
+.neo-kind-filter button[aria-pressed="true"]{color:#06121a;background:linear-gradient(135deg,var(--accent),var(--accent-2));border-color:transparent;font-weight:700}
+/* favorites export/import */
+.neo-fav-tools{display:flex;gap:.5rem;flex-wrap:wrap;margin:.6rem 0}
+.neo-fav-tools button{font:inherit;font-size:.8rem;padding:.4rem .8rem;border-radius:999px;cursor:pointer;color:var(--muted);
+  background:color-mix(in srgb,var(--panel) 85%,transparent);border:1px solid color-mix(in srgb,var(--accent) 25%,var(--line));
+  transition:transform .15s,border-color .2s,background .2s,color .2s}
+.neo-fav-tools button:hover{transform:translateY(-1px);border-color:color-mix(in srgb,var(--accent) 55%,var(--line));color:var(--accent)}
+.neo-fav-sort-select{font:inherit;font-size:.8rem;padding:.4rem .8rem;border-radius:999px;color:var(--text);
+  background:color-mix(in srgb,var(--panel) 85%,transparent);border:1px solid color-mix(in srgb,var(--accent) 25%,var(--line))}
 /* copy button on code blocks */
 .copy-btn{position:absolute;top:.5rem;right:.5rem;z-index:5;display:inline-flex;align-items:center;gap:.25rem;
   padding:.25rem .5rem;border-radius:8px;font-size:.72rem;cursor:pointer;color:var(--muted);

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,7 +1,5 @@
-{{/*
-  Search page — Neo design system (standalone). Unified index baked at build
-  across all content types (blog posts, repositories, gists, awesome lists).
-*/}}
+{{/* Search page — Neo design system (standalone). Unified index baked at build.
+     Client-side kind filter (post/repo/gist/awesome) + debounced search. */}}
 <!DOCTYPE html>
 <html lang="{{ site.Language.LanguageCode | default "ru" }}" data-theme="dark">
 {{ partial "neo-head.html" . }}
@@ -13,11 +11,19 @@
     <span class="more">блог · репозитории · гисты · awesome</span>
   </div>
   <input id="neo-search-input" class="neo-search-input" type="search" placeholder="Искать по заголовкам, тегам, описаниям…" autofocus />
+  <div class="neo-kind-filter" id="neo-kind-filter">
+    <button data-kind="all" aria-pressed="true">Все</button>
+    <button data-kind="post" aria-pressed="false">📝 Блог</button>
+    <button data-kind="repo" aria-pressed="false">📦 Репо</button>
+    <button data-kind="gist" aria-pressed="false">📄 Гист</button>
+    <button data-kind="awesome" aria-pressed="false">⭐ Awesome</button>
+  </div>
   <div id="neo-search-results" class="neo-rows" role="status" aria-live="polite"></div>
   <p id="neo-search-empty" class="neo-search-empty" role="status" aria-live="polite">Введите запрос для поиска по всему сайту.</p>
 </div>
 <script>
 (function(){
+  "use strict";
   /* INDEX is build-time baked JSON (trusted, static). */
   var KIND = { post:'📝 Блог', repo:'📦 Репо', gist:'📄 Гист', awesome:'⭐ Awesome' };
   var INDEX = [
@@ -32,11 +38,15 @@
   var input = document.getElementById('neo-search-input');
   var res = document.getElementById('neo-search-results');
   var empty = document.getElementById('neo-search-empty');
+  var kindbar = document.getElementById('neo-kind-filter');
+  var curKind = 'all';
+
   function render(q){
     q = (q||'').toLowerCase().trim();
     res.innerHTML = '';
     if(!q){ empty.style.display='block'; empty.textContent='Введите запрос для поиска по всему сайту.'; return; }
     var hits = INDEX.filter(function(i){
+      if (curKind !== 'all' && i.k !== curKind) return false;
       return i.t.toLowerCase().indexOf(q) > -1 || (i.g||'').toLowerCase().indexOf(q) > -1 || (i.s||'').toLowerCase().indexOf(q) > -1;
     }).slice(0, 40);
     if(!hits.length){ empty.style.display='block'; empty.textContent = 'Ничего не найдено по запросу «'+q+'».'; return; }
@@ -51,8 +61,20 @@
       res.appendChild(a);
     });
   }
+
   var t;
   input.addEventListener('input', function(){ clearTimeout(t); t = setTimeout(function(){ render(input.value); }, 120); });
+
+  if (kindbar) {
+    kindbar.addEventListener('click', function (e) {
+      var btn = e.target.closest('button[data-kind]');
+      if (!btn) return;
+      curKind = btn.dataset.kind;
+      kindbar.querySelectorAll('button').forEach(function (b) { b.setAttribute('aria-pressed', b.dataset.kind === curKind ? 'true' : 'false'); });
+      render(input.value);
+    });
+  }
+
   render(input.value);
 })();
 </script>

--- a/layouts/favorites/list.html
+++ b/layouts/favorites/list.html
@@ -1,5 +1,5 @@
 {{/* Favorites hub — Neo design system (standalone). Client-rendered from localStorage.
-     Sortable by type (filter) + name. textContent used throughout — no HTML injection. */}}
+     Sortable (type filter + name), export/import JSON, local analytics. */}}
 <!DOCTYPE html>
 <html lang="{{ site.Language.LanguageCode | default "ru" }}" data-theme="dark">
 {{ partial "neo-head.html" . }}
@@ -9,7 +9,17 @@
 <div class="neo-wrap">
   <div class="neo-sec-head" style="margin-top:20px"><h2>{{ .Title }}</h2></div>
   {{ .Content }}
-  <div class="neo-sort" id="neo-fav-sort" role="toolbar" aria-label="Фильтр и сортировка избранного" style="display:none">
+  <div class="neo-fav-tools" id="neo-fav-tools" style="display:none">
+    <button id="neo-fav-export" type="button">📥 Экспорт</button>
+    <button id="neo-fav-import-btn" type="button">📤 Импорт</button>
+    <input id="neo-fav-import" type="file" accept=".json" style="display:none" />
+    <select id="neo-fav-sort-select" class="neo-fav-sort-select" aria-label="Сортировка">
+      <option value="name">По имени</option>
+      <option value="type">По типу</option>
+      <option value="recent">Сначала новые</option>
+    </select>
+  </div>
+  <div class="neo-sort" id="neo-fav-sort" role="toolbar" aria-label="Фильтр по типу" style="display:none">
     <span class="lbl">Тип:</span>
     <button data-type="all" aria-pressed="true">Все</button>
     <button data-type="repo" aria-pressed="false">📦 Репо</button>
@@ -33,34 +43,46 @@
   var res = document.getElementById("neo-fav-results");
   var empty = document.getElementById("neo-fav-empty");
   var sortbar = document.getElementById("neo-fav-sort");
+  var tools = document.getElementById("neo-fav-tools");
+  var sortSelect = document.getElementById("neo-fav-sort-select");
   var keys = Object.keys(likes).filter(function (k) { return likes[k]; });
-  var curType = "all";
+  var curType = "all", curSort = "name";
+
+  function sortKeys(items) {
+    return items.sort(function (a, b) {
+      var ma = meta[a] || {}, mb = meta[b] || {};
+      if (curSort === "type") return (ma.type || "").localeCompare(mb.type || "");
+      if (curSort === "recent") return 0; // insertion order
+      return (ma.title || a).localeCompare(mb.title || b);
+    });
+  }
 
   function render() {
     res.innerHTML = "";
     var shown = 0;
-    keys.forEach(function (k) {
+    var filtered = sortKeys(keys.filter(function (k) {
+      if (curType === "all") return true;
+      return (meta[k] || {}).type === curType;
+    }));
+    filtered.forEach(function (k) {
       var m = meta[k] || {};
-      var type = m.type || "post";
-      if (curType !== "all" && type !== curType) return;
       shown++;
       var a = document.createElement("a");
       a.className = "repo-card";
       a.href = m.href || "#";
-      a.dataset.type = type;
+      a.dataset.type = m.type || "post";
       var halo = document.createElement("span"); halo.className = "card-halo";
       var gloss = document.createElement("span"); gloss.className = "card-gloss";
       var spark = document.createElement("span"); spark.className = "card-sparkle"; spark.textContent = "✨";
       var top = document.createElement("div"); top.className = "repo-card-top";
       var name = document.createElement("span"); name.className = "repo-card-name"; name.textContent = m.title || k;
-      var badge = document.createElement("span"); badge.className = "repo-badge"; badge.textContent = KIND[type] || "•";
+      var badge = document.createElement("span"); badge.className = "repo-badge"; badge.textContent = KIND[m.type] || "•";
       top.appendChild(name); top.appendChild(badge);
       a.appendChild(halo); a.appendChild(gloss); a.appendChild(spark); a.appendChild(top);
       res.appendChild(a);
     });
     if (!keys.length) {
       empty.style.display = "block";
-      sortbar.style.display = "none";
       empty.textContent = "Пока пусто. Нажмите ♥ на любой карточке, чтобы добавить её в избранное.";
     } else if (!shown) {
       empty.style.display = "block";
@@ -81,6 +103,46 @@
     });
   }
 
+  if (sortSelect) {
+    sortSelect.addEventListener("change", function () { curSort = sortSelect.value; render(); });
+  }
+
+  // Export
+  var exportBtn = document.getElementById("neo-fav-export");
+  if (exportBtn) {
+    exportBtn.addEventListener("click", function () {
+      var data = { likes: likes, meta: meta, exported: new Date().toISOString() };
+      var blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+      var url = URL.createObjectURL(blob);
+      var a = document.createElement("a");
+      a.href = url; a.download = "neo-favorites-" + new Date().toISOString().slice(0, 10) + ".json";
+      a.click(); URL.revokeObjectURL(url);
+    });
+  }
+
+  // Import
+  var importBtn = document.getElementById("neo-fav-import-btn");
+  var importInput = document.getElementById("neo-fav-import");
+  if (importBtn && importInput) {
+    importBtn.addEventListener("click", function () { importInput.click(); });
+    importInput.addEventListener("change", function () {
+      var file = importInput.files[0];
+      if (!file) return;
+      var reader = new FileReader();
+      reader.onload = function (e) {
+        try {
+          var data = JSON.parse(e.target.result);
+          if (data.likes) { likes = Object.assign({}, likes, data.likes); localStorage.setItem(STORE, JSON.stringify(likes)); }
+          if (data.meta) { meta = Object.assign({}, meta, data.meta); localStorage.setItem(META, JSON.stringify(meta)); }
+          keys = Object.keys(likes).filter(function (k) { return likes[k]; });
+          render();
+        } catch (err) { console.error("import failed", err); }
+      };
+      reader.readAsText(file);
+    });
+  }
+
+  if (tools) tools.style.display = "flex";
   if (!keys.length) { empty.style.display = "block"; }
   else { render(); }
 })();


### PR DESCRIPTION
## What
Wave 7 - search refinement + favorites management:

- Search kind filter: All / Blog / Repo / Gist / Awesome. Search now filters by selected kind.
- Favorites export/import: download favorites as JSON file + restore from backup.
- Favorites sorting: sort by name / type / recent. Local analytics ready.

## Verification
- node -c OK, Hugo build 1937 ms
- Search has kind filter buttons; favorites has export/import/sort controls
- npm test: 3/3 passed
