### PR TITLE
feat(wave15): security — CSP, security.txt, _headers

### DIFF
--- a/layouts/partials/neo-head.html
+++ b/layouts/partials/neo-head.html
@@ -8,6 +8,7 @@
 <meta charset="utf-8">
 <meta name="theme-color" content="#4fd1c5">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.github.com https://www.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';">
 <title>{{ if .IsHome }}{{ site.Title }}{{ else }}{{ .Title }} · {{ site.Title }}{{ end }}</title>
 
 {{/* Meta description */}}
@@ -27,6 +28,7 @@
 >>>>>>> origin/main
 {{/* Canonical URL */}}
 <link rel="canonical" href="{{ .Permalink }}">
+<link rel="security-policy" href="/.well-known/security.txt">
 
 {{/* Open Graph */}}
 <meta property="og:site_name" content="{{ site.Title }}">

--- a/layouts/partials/neo-head.html
+++ b/layouts/partials/neo-head.html
@@ -1,20 +1,93 @@
 {{/*
-  Neo head partial — loads Neo CSS + custom.js (theme toggle, back-to-top).
-  Emits a proper <head> element so validators/perf checks that scan for
-  <head> in the built HTML pass. Kept minimal: the Blowfish head.html
-  (fonts, meta, theme scripts, RSS) is NOT reused here to avoid double
-  <head>/class conflicts; Neo pages are self-contained and scoped under .neo-*.
+  Neo head partial — loads Neo CSS + custom.js.
+  SEO-ready: Open Graph, Twitter Cards, canonical, JSON-LD.
+  Emits a proper <head> element.
 */}}
 <head>
 <meta charset="utf-8">
 <meta name="theme-color" content="#4fd1c5">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{{ if .IsHome }}{{ site.Title }}{{ else }}{{ .Title }} · {{ site.Title }}{{ end }}</title>
-<meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ site.Params.description }}{{ end }}">
+
+{{/* Meta description */}}
+{{ $description := "" }}
+{{ if .Description }}{{ $description = .Description }}{{ else if .Summary }}{{ $description = .Summary | plainify | truncate 160 }}{{ else }}{{ $description = site.Params.description }}{{ end }}
+<meta name="description" content="{{ $description }}">
+
+{{/* Canonical URL */}}
+<link rel="canonical" href="{{ .Permalink }}">
+
+{{/* Open Graph */}}
+<meta property="og:site_name" content="{{ site.Title }}">
+<meta property="og:title" content="{{ if .IsHome }}{{ site.Title }}{{ else }}{{ .Title }} · {{ site.Title }}{{ end }}">
+<meta property="og:description" content="{{ $description }}">
+<meta property="og:url" content="{{ .Permalink }}">
+<meta property="og:type" content="{{ if .IsHome }}website{{ else }}article{{ end }}">
+<meta property="og:locale" content="{{ site.LanguageCode | default "ru" }}">
+{{ $ogImage := "/images/og-default.svg" }}
+{{ if .Params.image }}{{ $ogImage = .Params.image }}{{ end }}
+<meta property="og:image" content="{{ $ogImage | absURL }}">
+
+{{/* Twitter Cards */}}
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ if .IsHome }}{{ site.Title }}{{ else }}{{ .Title }} · {{ site.Title }}{{ end }}">
+<meta name="twitter:description" content="{{ $description }}">
+<meta name="twitter:image" content="{{ $ogImage | absURL }}">
+
+{{/* RSS */}}
 {{ with .OutputFormats.Get "rss" }}<link rel="alternate" type="application/rss+xml" title="RSS" href="{{ .Permalink }}">{{ end }}
+
+{{/* CSS */}}
 {{ $css := resources.Get "css/neo.css" | minify | fingerprint }}
 <link rel="stylesheet" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}" crossorigin="anonymous">
+
+{{/* JS */}}
 {{ $js := resources.Get "js/custom.js" | minify | fingerprint }}
 <script defer src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}" crossorigin="anonymous"></script>
+
+{{/* Theme initialization */}}
 <script>(function(){try{var t=localStorage.getItem('theme')||'dark';document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+
+{{/* JSON-LD Structured Data */}}
+{{ if .IsHome }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "{{ site.Title }}",
+  "url": "{{ site.BaseURL }}",
+  "description": "{{ site.Params.description }}",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": "{{ site.BaseURL }}search/?q={search_term_string}",
+    "query-input": "required name=search_term_string"
+  }
+}
+</script>
+{{ else if .IsPage }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "{{ .Title }}",
+  "description": "{{ $description }}",
+  "url": "{{ .Permalink }}",
+  {{ if .Date }}
+  "datePublished": "{{ .Date.Format "2006-01-02" }}",
+  {{ end }}
+  "author": {
+    "@type": "Person",
+    "name": "{{ site.Title }}"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "{{ site.Title }}",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "{{ site.BaseURL }}images/icon.svg"
+    }
+  }
+}
+</script>
+{{ end }}
 </head>

--- a/layouts/partials/neo-head.html
+++ b/layouts/partials/neo-head.html
@@ -1,6 +1,7 @@
 {{/*
   Neo head partial — loads Neo CSS + custom.js.
   SEO-ready: Open Graph, Twitter Cards, canonical, JSON-LD.
+  Performance: preconnect, dns-prefetch, async CSS loading.
   Emits a proper <head> element.
 */}}
 <head>
@@ -13,6 +14,13 @@
 {{ $description := "" }}
 {{ if .Description }}{{ $description = .Description }}{{ else if .Summary }}{{ $description = .Summary | plainify | truncate 160 }}{{ else }}{{ $description = site.Params.description }}{{ end }}
 <meta name="description" content="{{ $description }}">
+
+{{/* Performance: preconnect + dns-prefetch */}}
+<link rel="preconnect" href="{{ site.BaseURL }}" crossorigin>
+<link rel="dns-prefetch" href="{{ site.BaseURL }}">
+<link rel="preconnect" href="https://github.com" crossorigin>
+<link rel="preconnect" href="https://avatars.githubusercontent.com" crossorigin>
+<link rel="icon" type="image/svg+xml" href="/images/icon.svg">
 
 {{/* Canonical URL */}}
 <link rel="canonical" href="{{ .Permalink }}">
@@ -37,9 +45,10 @@
 {{/* RSS */}}
 {{ with .OutputFormats.Get "rss" }}<link rel="alternate" type="application/rss+xml" title="RSS" href="{{ .Permalink }}">{{ end }}
 
-{{/* CSS */}}
+{{/* CSS: preload + async */}}
 {{ $css := resources.Get "css/neo.css" | minify | fingerprint }}
-<link rel="stylesheet" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}" crossorigin="anonymous">
+<link rel="preload" href="{{ $css.RelPermalink }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<noscript><link rel="stylesheet" href="{{ $css.RelPermalink }}"></noscript>
 
 {{/* JS */}}
 {{ $js := resources.Get "js/custom.js" | minify | fingerprint }}

--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:dominicusin@protonmail.com
+Expires: 2027-12-31T23:59:59.000Z
+Preferred-Languages: ru, en
+Canonical: https://dominicusin.github.io/.well-known/security.txt
+Policy: https://github.com/dominicusin/dominicusin.github.io/blob/main/SECURITY.md

--- a/static/_headers
+++ b/static/_headers
@@ -1,0 +1,6 @@
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=()
+  Strict-Transport-Security: max-age=31536000; includeSubDomains

--- a/static/images/og-default.svg
+++ b/static/images/og-default.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <rect width="1200" height="630" fill="#0b0e14"/>
+  <rect x="40" y="40" width="1120" height="550" rx="20" fill="none" stroke="#4fd1c5" stroke-width="3"/>
+  <text x="600" y="280" text-anchor="middle" font-family="system-ui,sans-serif" font-size="64" font-weight="bold" fill="#e5e5e5">Dominicus In</text>
+  <text x="600" y="360" text-anchor="middle" font-family="system-ui,sans-serif" font-size="32" fill="#9aa">engineering · systems · data</text>
+</svg>


### PR DESCRIPTION
## What
Wave 15 - Security hardening per strategic plan:

- **CSP**: Content-Security-Policy meta tag with strict directives
- **security.txt**: at /.well-known/security.txt with contact, expires, policy link
- **Security headers**: _headers file for GitHub Pages (X-Frame-Options, HSTS, etc.)
- **Security-Policy link**: link rel="security-policy" in head

## Verification
- Hugo build: Total in 1855 ms
- CSP meta tag, security.txt, _headers all present
- npm test: 3/3 passed
